### PR TITLE
Formatting fixes and typing issues resolved

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
-from typing import Callable, Union
 from enum import Enum
+from typing import Callable, Union
 
 
 @dataclass
@@ -27,7 +27,7 @@ class Member:
     def id(self):
         return self._id
 
-    def __eq__(self, other: Member) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Member):
             return self.id == other.id
 
@@ -53,7 +53,7 @@ class Company:
     def id(self):
         return self._id
 
-    def __eq__(self, other: Company) -> bool:
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, Company):
             return self.id == other.id
 

--- a/arbeitszeit/purchase_factory.py
+++ b/arbeitszeit/purchase_factory.py
@@ -1,15 +1,8 @@
 from datetime import datetime
 from decimal import Decimal
 from typing import Union
-from enum import Enum
 
-from arbeitszeit.entities import Company, Member, ProductOffer, Purchase
-
-
-class PurposesOfPurchases(Enum):
-    means_of_prod = "means_of_prod"
-    raw_materials = "raw_materials"
-    consumption = "consumption"
+from .entities import Company, Member, ProductOffer, Purchase, PurposesOfPurchases
 
 
 class PurchaseFactory:

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import List
 
-from arbeitszeit.entities import Company, Member, Plan, Purchase, Account, Transaction
+from arbeitszeit.entities import Account, Company, Member, Plan, Purchase, Transaction
 
 
 class CompanyWorkerRepository(ABC):

--- a/arbeitszeit/transaction_factory.py
+++ b/arbeitszeit/transaction_factory.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+
 from arbeitszeit.entities import Account, Transaction
 
 

--- a/arbeitszeit/use_cases.py
+++ b/arbeitszeit/use_cases.py
@@ -1,36 +1,30 @@
-from dataclasses import dataclass
-from typing import Union, List, Optional
-from decimal import Decimal
-from enum import Enum
 import datetime
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import List, Optional, Union
 
 from injector import inject
 
+from arbeitszeit import errors
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.entities import (
+    Account,
     Company,
     Member,
     Plan,
-    ProductOffer,
-    Account,
-    SocialAccounting,
     PlanRenewal,
+    ProductOffer,
+    SocialAccounting,
 )
-from arbeitszeit import errors
-
 from arbeitszeit.purchase_factory import PurchaseFactory
-from arbeitszeit.transaction_factory import TransactionFactory
 from arbeitszeit.repositories import (
     CompanyWorkerRepository,
-    TransactionRepository,
     PurchaseRepository,
+    TransactionRepository,
 )
+from arbeitszeit.transaction_factory import TransactionFactory
 
-
-class PurposesOfPurchases(Enum):
-    means_of_prod = "means_of_prod"
-    raw_materials = "raw_materials"
-    consumption = "consumption"
+from .entities import PurposesOfPurchases
 
 
 @inject
@@ -155,7 +149,7 @@ def seek_approval(
     approval_date = datetime_service.now()
     if is_approval:
         plan.approve(approval_date)
-        if plan_renewal and (plan_renewal.modifications == False):
+        if plan_renewal and (not plan_renewal.modifications):
             plan_renewal.original_plan.set_as_renewed()
     else:
         plan.deny("Some reason", approval_date)
@@ -169,7 +163,7 @@ def grant_credit(
     transaction_factory: TransactionFactory,
 ) -> None:
     """Social Accounting grants credit after plan has been approved."""
-    assert plan.approved == True, "Plan has not been approved!"
+    assert plan.approved, "Plan has not been approved!"
     social_accounting_account = social_accounting.account
 
     prd = plan.costs_p + plan.costs_r + plan.costs_a

--- a/project/database/repositories.py
+++ b/project/database/repositories.py
@@ -1,22 +1,22 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional, TypeVar, Union
-from datetime import datetime
 
 from injector import inject
 
 from arbeitszeit import entities, repositories
 from project.extensions import db
 from project.models import (
+    Account,
     Company,
     Kaeufe,
     Member,
     Offer,
     Plan,
     SocialAccounting,
-    Account,
     Transaction,
 )
 

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -80,6 +80,6 @@ class AccountGenerator:
             id=self.id_generator.get_id(),
             account_owner_id=self.id_generator.get_id(),
             account_type=account_type,
-            balance=0,
+            balance=Decimal(0),
             change_credit=lambda amount: None,
         )

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from arbeitszeit.use_cases import adjust_balance
 from tests.data_generators import AccountGenerator
 from tests.dependency_injection import injection_test
@@ -8,5 +10,5 @@ def test_account_balance_changes(
     account_generator: AccountGenerator,
 ):
     account = account_generator.create_account()
-    adjust_balance(account, -5)
-    assert account.balance == -5
+    adjust_balance(account, Decimal(-5))
+    assert account.balance == Decimal(-5)

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,9 +1,10 @@
 import pytest
 
+from arbeitszeit.entities import PurposesOfPurchases
 from arbeitszeit.use_cases import PurchaseProduct
-from tests.data_generators import MemberGenerator, OfferGenerator, CompanyGenerator
+from tests.data_generators import CompanyGenerator, MemberGenerator, OfferGenerator
 from tests.dependency_injection import injection_test
-from tests.repositories import TransactionRepository, PurchaseRepository
+from tests.repositories import PurchaseRepository, TransactionRepository
 
 
 @injection_test
@@ -18,7 +19,12 @@ def test_purchase_amount_can_not_exceed_supply(
     buyer = member_generator.create_member()
     with pytest.raises(AssertionError):
         purchase_product(
-            purchase_repository, transaction_repository, offer, 2, "consumption", buyer
+            purchase_repository,
+            transaction_repository,
+            offer,
+            2,
+            PurposesOfPurchases.consumption,
+            buyer,
         )
 
 
@@ -33,7 +39,12 @@ def test_product_offer_decreased_after_purchase(
     offer = offer_generator.create_offer(amount=5)
     buyer = member_generator.create_member()
     purchase_product(
-        purchase_repository, transaction_repository, offer, 2, "consumption", buyer
+        purchase_repository,
+        transaction_repository,
+        offer,
+        2,
+        PurposesOfPurchases.consumption,
+        buyer,
     )
     assert offer.amount_available == 3
 
@@ -49,9 +60,14 @@ def test_product_offer_deactivated_if_amount_zero(
     offer = offer_generator.create_offer(amount=3)
     buyer = member_generator.create_member()
     purchase_product(
-        purchase_repository, transaction_repository, offer, 3, "consumption", buyer
+        purchase_repository,
+        transaction_repository,
+        offer,
+        3,
+        PurposesOfPurchases.consumption,
+        buyer,
     )
-    assert offer.active == False
+    assert not offer.active
 
 
 @injection_test
@@ -66,7 +82,7 @@ def test_balance_of_buyer_reduced(
     # member, consumption
     offer1 = offer_generator.create_offer(amount=3)
     buyer1 = member_generator.create_member()
-    purpose1 = "consumption"
+    purpose1 = PurposesOfPurchases.consumption
     purchase_product(
         purchase_repository, transaction_repository, offer1, 3, purpose1, buyer1
     )
@@ -75,7 +91,7 @@ def test_balance_of_buyer_reduced(
     # company, means of production
     offer2 = offer_generator.create_offer(amount=3)
     buyer2 = company_generator.create_company()
-    purpose2 = "means_of_prod"
+    purpose2 = PurposesOfPurchases.means_of_prod
     purchase_product(
         purchase_repository, transaction_repository, offer2, 3, purpose2, buyer2
     )
@@ -84,7 +100,7 @@ def test_balance_of_buyer_reduced(
     # company, raw materials
     offer3 = offer_generator.create_offer(amount=3)
     buyer3 = company_generator.create_company()
-    purpose3 = "raw_materials"
+    purpose3 = PurposesOfPurchases.raw_materials
     purchase_product(
         purchase_repository, transaction_repository, offer3, 3, purpose3, buyer3
     )
@@ -102,7 +118,12 @@ def test_balance_of_seller_increased(
     offer = offer_generator.create_offer(amount=3)
     buyer = member_generator.create_member()
     purchase_product(
-        purchase_repository, transaction_repository, offer, 3, "consumption", buyer
+        purchase_repository,
+        transaction_repository,
+        offer,
+        3,
+        PurposesOfPurchases.consumption,
+        buyer,
     )
     assert offer.provider.product_account.balance == 3
 
@@ -119,7 +140,7 @@ def test_correct_transaction_added_to_repo(
     # member, consumption
     offer1 = offer_generator.create_offer(amount=3)
     buyer1 = member_generator.create_member()
-    purpose1 = "consumption"
+    purpose1 = PurposesOfPurchases.consumption
     purchase_product(
         purchase_repository, transaction_repository, offer1, 3, purpose1, buyer1
     )
@@ -130,7 +151,7 @@ def test_correct_transaction_added_to_repo(
     # company, means of production
     offer2 = offer_generator.create_offer(amount=3)
     buyer2 = company_generator.create_company()
-    purpose2 = "means_of_prod"
+    purpose2 = PurposesOfPurchases.means_of_prod
     purchase_product(
         purchase_repository, transaction_repository, offer2, 3, purpose2, buyer2
     )
@@ -139,7 +160,7 @@ def test_correct_transaction_added_to_repo(
     # company, raw materials
     offer3 = offer_generator.create_offer(amount=3)
     buyer3 = company_generator.create_company()
-    purpose3 = "raw materials"
+    purpose3 = PurposesOfPurchases.raw_materials
     purchase_product(
         purchase_repository, transaction_repository, offer3, 3, purpose3, buyer3
     )


### PR DESCRIPTION
Nichts grosses. Ich habe eine kleinere Codedopplung ausgeraeumt. `PurposesOfPurchases` ist jetzt zentrail in `arbeitszeit.entities` definiert.
Ausserdem hab ich das Codeformatierungsskript laufen lassen.