### PR TITLE
implementing flask migrate

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: sh releaseapp_heroku.sh
 web: sh startapp_heroku.sh

--- a/README.rst
+++ b/README.rst
@@ -20,3 +20,11 @@ need to do is to open the "index" view of the application. That is
 usually ``http://localhost:5000/``. The reason for that is that
 currently there is some database initialization being run when the
 view is rendered for the first time.
+
+Database Migration
+==================
+
+We use Flask-Migrate for database migration. Run ``flask db migrate`` to 
+autodetect changes to the models. Run ``flask db upgrade`` 
+to upgrade the database. See https://flask-migrate.readthedocs.io/en/latest/ 
+for more info about Flask-Migrate.

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,0 +1,50 @@
+# A generic, single database configuration.
+
+[alembic]
+# template used to generate migration files
+# file_template = %%(rev)s_%%(slug)s
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic,flask_migrate
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[logger_flask_migrate]
+level = INFO
+handlers =
+qualname = flask_migrate
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,91 @@
+from __future__ import with_statement
+
+import logging
+from logging.config import fileConfig
+
+from flask import current_app
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+fileConfig(config.config_file_name)
+logger = logging.getLogger('alembic.env')
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option(
+    'sqlalchemy.url',
+    str(current_app.extensions['migrate'].db.get_engine().url).replace(
+        '%', '%%'))
+target_metadata = current_app.extensions['migrate'].db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline():
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url, target_metadata=target_metadata, literal_binds=True
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online():
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+
+    # this callback is used to prevent an auto-migration from being generated
+    # when there are no changes to the schema
+    # reference: http://alembic.zzzcomputing.com/en/latest/cookbook.html
+    def process_revision_directives(context, revision, directives):
+        if getattr(config.cmd_opts, 'autogenerate', False):
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                logger.info('No changes in schema detected.')
+
+    connectable = current_app.extensions['migrate'].db.get_engine()
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            process_revision_directives=process_revision_directives,
+            **current_app.extensions['migrate'].configure_args
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade():
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade():
+    ${downgrades if downgrades else "pass"}

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -1,7 +1,7 @@
 from flask import Flask, session
 from flask_table import Col, Table  # Do not delete
 
-from project.extensions import db, login_manager
+from project.extensions import db, login_manager, migrate
 
 
 def create_app():
@@ -15,6 +15,7 @@ def create_app():
     # init flask extensions
     db.init_app(app)
     login_manager.init_app(app)
+    migrate.init_app(app, db)
 
     with app.app_context():
         from .models import Company, Member

--- a/project/extensions.py
+++ b/project/extensions.py
@@ -1,5 +1,7 @@
 from flask_login import LoginManager
 from flask_sqlalchemy import SQLAlchemy
+from flask_migrate import Migrate
 
 db = SQLAlchemy()
 login_manager = LoginManager()
+migrate = Migrate()

--- a/releaseapp_heroku.sh
+++ b/releaseapp_heroku.sh
@@ -1,0 +1,2 @@
+export ARBEITSZEIT_APP_CONFIGURATION="$PWD/production-settings.py"
+flask db upgrade

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+alembic==1.6.5
 Babel==2.9.0
 backcall==0.2.0
 bcrypt==3.2.0
@@ -14,17 +15,17 @@ Flask-Babel==2.0.0
 Flask-BabelEx==0.9.4
 Flask-Login==0.5.0
 Flask-Mail==0.9.1
+Flask-Migrate==3.0.1
 Flask-SQLAlchemy==2.4.4
 Flask-Table==0.5.0
-Flask-User==1.0.2.2
 Flask-WTF==0.14.3
-graphviz==0.16
 gunicorn==20.0.4
 idna==3.1
 injector==0.18.4
 itsdangerous==1.1.0
 jedi==0.18.0
 Jinja2==2.11.2
+Mako==1.1.4
 parso==0.8.1
 passlib==1.7.4
 pexpect==4.8.0
@@ -38,6 +39,7 @@ Pygments==2.7.3
 pytest==6.2.4
 python-dateutil==2.8.1
 python-dotenv==0.15.0
+python-editor==1.0.4
 pytz==2020.5
 pyzmq==20.0.0
 six==1.15.0


### PR DESCRIPTION
Hi, 
ich habe die Datenbank-Migration in diesem PR mit Flask-Migrate implementiert. Das scheint mir die beste Lösung für Flask zu sein. Falls dir eine bessere Lösung einfällt oder du mit der Implementierung unzufrieden bist, lass dich nicht aufhalten. 

Die meisten der neu hinzugefügten Skripte wurden von Flask-Migrate automatisch erstellt, als ich "flask db init" ausgeführt habe und können bei Bedarf modifiziert werden. 

Für das Deployment auf Heroku habe ich ein neues bash-Skript hinzugefügt (releaseapp_heroku.sh). Wenn der Code auf Heroku gepusht wird, wird automatisch "flask db upgrade" ausgeführt, um die Datenbank zu ändern. 