### PR TITLE
make_offline_purchases_for_members_possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 my_database_key.py
 *.pyc
 *.png
+.vscode/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/arbeitszeit/errors.py
+++ b/arbeitszeit/errors.py
@@ -38,3 +38,9 @@ class PlanDoesNotExist(Exception):
     def __init__(self, plan: Plan) -> None:
         self.plan = plan
         super().__init__()
+
+
+class PlanIsExpired(Exception):
+    def __init__(self, plan: Plan) -> None:
+        self.plan = plan
+        super().__init__()

--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -25,6 +25,7 @@ from arbeitszeit.transaction_factory import TransactionFactory
 
 # do not delete
 from .grant_credit import GrantCredit
+from .pay_consumer_product import PayConsumerProduct
 from .pay_means_of_production import PayMeansOfProduction
 from .query_products import ProductFilter, QueryProducts
 from .send_work_certificates_to_worker import SendWorkCertificatesToWorker

--- a/arbeitszeit/use_cases/pay_consumer_product.py
+++ b/arbeitszeit/use_cases/pay_consumer_product.py
@@ -1,0 +1,68 @@
+from dataclasses import dataclass
+
+from injector import inject
+
+from arbeitszeit import errors
+from arbeitszeit.entities import Company, Member, Plan
+from arbeitszeit.repositories import TransactionRepository
+from arbeitszeit.transaction_factory import TransactionFactory
+
+
+@inject
+@dataclass
+class PayConsumerProduct:
+    transaction_repository: TransactionRepository
+    transaction_factory: TransactionFactory
+
+    def __call__(
+        self,
+        sender: Member,
+        receiver: Company,
+        plan: Plan,
+        pieces: int,
+    ) -> None:
+        pass
+
+        """
+        This function enables the payment of consumer products which were *not* bought 
+        on the app's marketplace. Apart from sender and receiver it has to be specified 
+        the seller's plan and the amount of pieces to be paid.
+
+        This function
+            - adjusts the balances of the buying member and the selling company
+            - adds the transaction to the repository
+        """
+        if not receiver:
+            raise errors.CompanyDoesNotExist(
+                company=receiver,
+            )
+        if not plan:
+            raise errors.PlanDoesNotExist(
+                plan=plan,
+            )
+        if plan.planner != receiver:
+            raise errors.CompanyIsNotPlanner(
+                company=receiver,
+                planner=plan.planner,
+            )
+        if plan.expired:
+            raise errors.PlanIsExpired(
+                plan=plan,
+            )
+
+        # create transaction
+        price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
+        account_from = sender.account
+
+        transaction = self.transaction_factory.create_transaction(
+            account_from=account_from,
+            account_to=plan.planner.product_account,
+            amount=price_total,
+            purpose=f"Plan-Id: {plan.id}",
+        )
+
+        # add transaction to database
+        self.transaction_repository.add(transaction)
+
+        # adjust balances
+        transaction.adjust_balances()

--- a/project/member/templates/member/my_account.html
+++ b/project/member/templates/member/my_account.html
@@ -4,7 +4,7 @@
 
 
 <h1 class="title">
-    Meine Konten
+    Mein Konto
 </h1>
 <div class="box has-background-info-light has-text-info-dark">
     <div class="icon"><i class="fas fa-info-circle"></i></div>

--- a/project/member/templates/member/my_purchases.html
+++ b/project/member/templates/member/my_purchases.html
@@ -2,15 +2,24 @@
 
 {% block content2 %}
 
-<h1 class="title">
-  Meine vergangenen Käufe:
-</h1>
+<div class="content">
+  <h1 class="title">
+    Meine vergangenen Käufe (In-App):
+  </h1>
+  <div class="box has-background-info-light has-text-info-dark has-text-centered">
+    <div class="icon"><i class="fas fa-info-circle"></i></div>
+    <p>
+      Hier siehst du deine vergangenen In-App-Käufe.<br>
+      Käufe von Produkten, die du nicht über den App-Marketplace erworben hast, werden hier nicht angezeigt.
+    </p>
+  </div>
+</div>
 
 <div class="table-container">
   <table class="table is-fullwidth">
     <thead>
       <tr>
-        <th>Kauf-Id</th>
+        <th>Datum</th>
         <th>Name</th>
         <th>Beschreibung</th>
         <th>Einzelpreis</th>
@@ -22,7 +31,7 @@
       {% if purchases is defined and purchases|length %}
       {% for purchase in purchases %}
       <tr>
-        <td>{{ purchase.id }}</td>
+        <td>{{ purchase.kauf_date.strftime("%x") }}</td>
         <td>{{ purchase.offer.name }}</td>
         <td>{{ purchase.offer.description }}</td>
         <td>{{ purchase.kaufpreis }}</td>

--- a/project/member/templates/member/pay_consumer_product.html
+++ b/project/member/templates/member/pay_consumer_product.html
@@ -1,0 +1,64 @@
+{% extends "base_member.html" %}
+
+{% block content2 %}
+<div class="columns has-text-left">
+    <div class="column is-two-third">
+
+
+        <div class="content">
+            <h1 class="title">
+                Bezahlung Produkt
+            </h1>
+            <div class="box has-background-info-light has-text-info-dark has-text-centered">
+                <div class="icon"><i class="fas fa-info-circle"></i></div>
+                <p>
+                    Hier kannst du Produkte bezahlen, die du außerhalb der App erworben hast. <br>
+                    (Käufe aus dem Marketplace musst du hier <b>nicht</b> bezahlen, da diese automatisch bezahlt
+                    werden.)
+                </p>
+            </div>
+        </div>
+
+        <div class="content">
+            <form method="post">
+                <div class="field has-addons">
+                    <div class="control">
+                        <input class="input" type="text" placeholder="Betriebs-ID" , name="company_id" required>
+                    </div>
+                    <div class="control">
+                        <input class="input" type="text" placeholder="Plan-ID" , name="plan_id" required>
+                    </div>
+                    <div class="control">
+                        <input class="input" type="number" placeholder="Menge" , name="amount" required>
+                    </div>
+                    <div class="control">
+                        <button class="button is-primary" name="transfer_type" value="transfer_to_company"
+                            type="submit">Überweisen</button>
+                    </div>
+                </div>
+                <p class="help">Der verkaufende Betrieb muss dir seine Betriebs-ID und die zum Produkt gehörige Plan-ID
+                    nennen.</p>
+
+            </form>
+        </div>
+
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <div class="block"></div>
+        {% for message in messages %}
+        <div class="notification is-danger">
+            {{ message }}
+        </div>
+        {% endfor %}
+        {% endif %}
+        {% endwith %}
+
+
+
+
+
+    </div>
+</div>
+
+
+{% endblock %}

--- a/project/templates/base_member.html
+++ b/project/templates/base_member.html
@@ -22,10 +22,13 @@
 
           {% if current_user.is_authenticated %}
           <a href="{{ url_for('main_member.suchen') }}" class="navbar-item">
-            Angebote suchen
+            Marketplace
           </a>
           <a href="{{ url_for('main_member.my_purchases') }}" class="navbar-item">
             Meine Käufe
+          </a>
+          <a href="{{ url_for('main_member.pay_consumer_product') }}" class="navbar-item">
+            Bezahlen Produkt
           </a>
           <a href="{{ url_for('main_member.my_account') }}" class="navbar-item">
             Mein Konto

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -128,14 +128,16 @@ class PlanGenerator:
     datetime_service: DatetimeService
 
     def create_plan(
-        self, plan_creation_date=None, timeframe=14, approved=False
+        self, plan_creation_date=None, planner=None, timeframe=None, approved=False
     ) -> Plan:
         return Plan(
             id=self.id_generator.get_id(),
             plan_creation_date=self.datetime_service.now()
             if plan_creation_date is None
             else plan_creation_date,
-            planner=self.company_generator.create_company(),
+            planner=self.company_generator.create_company()
+            if planner is None
+            else planner,
             costs_p=Decimal(10),
             costs_r=Decimal(20),
             costs_a=Decimal(30),
@@ -143,7 +145,7 @@ class PlanGenerator:
             prd_unit="500 Gramm",
             prd_amount=100,
             description="Beschreibung für Produkt A.",
-            timeframe=int(timeframe),
+            timeframe=int(14) if timeframe is None else int(timeframe),
             approved=approved,
             approval_date=None,
             approval_reason=None,

--- a/tests/test_pay_consumer_product.py
+++ b/tests/test_pay_consumer_product.py
@@ -1,0 +1,110 @@
+import pytest
+
+from arbeitszeit import errors
+from arbeitszeit.use_cases import PayConsumerProduct
+
+from .data_generators import CompanyGenerator, MemberGenerator, PlanGenerator
+from .datetime_service import TestDatetimeService
+from .dependency_injection import injection_test
+from .repositories import TransactionRepository
+
+
+@injection_test
+def test_error_is_raised_if_company_does_not_exist(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    plan_generator: PlanGenerator,
+):
+    sender = member_generator.create_member()
+    receiver = None
+    plan = plan_generator.create_plan()
+    pieces = 3
+    with pytest.raises(errors.CompanyDoesNotExist):
+        pay_consumer_product(sender, receiver, plan, pieces)
+
+
+@injection_test
+def test_error_is_raised_if_plan_does_not_exist(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+):
+    sender = member_generator.create_member()
+    receiver = company_generator.create_company()
+    plan = None
+    pieces = 3
+    with pytest.raises(errors.PlanDoesNotExist):
+        pay_consumer_product(sender, receiver, plan, pieces)
+
+
+@injection_test
+def test_error_is_raised_if_company_is_not_planner(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+    plan_generator: PlanGenerator,
+):
+    sender = member_generator.create_member()
+    receiver = company_generator.create_company()
+    planner = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=planner)
+    pieces = 3
+    with pytest.raises(errors.CompanyIsNotPlanner):
+        pay_consumer_product(sender, receiver, plan, pieces)
+
+
+@injection_test
+def test_error_is_raised_if_plan_is_expired(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+    plan_generator: PlanGenerator,
+    datetime_service: TestDatetimeService,
+):
+    sender = member_generator.create_member()
+    receiver = company_generator.create_company()
+    plan = plan_generator.create_plan(
+        plan_creation_date=datetime_service.now_minus_two_days, timeframe=1
+    )
+    pieces = 3
+    plan.expired = True
+    with pytest.raises(errors.PlanIsExpired):
+        pay_consumer_product(sender, receiver, plan, pieces)
+
+
+@injection_test
+def test_that_correct_transaction_is_added(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+    plan_generator: PlanGenerator,
+    transaction_repository: TransactionRepository,
+):
+    sender = member_generator.create_member()
+    receiver = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=receiver)
+    pieces = 3
+    pay_consumer_product(sender, receiver, plan, pieces)
+    assert len(transaction_repository.transactions) == 1
+    transaction_added = transaction_repository.transactions[0]
+    expected_amount = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
+    assert transaction_added.account_from == sender.account
+    assert transaction_added.account_to == receiver.product_account
+    assert transaction_added.amount == expected_amount
+
+
+@injection_test
+def test_balances_are_adjusted_correctly(
+    pay_consumer_product: PayConsumerProduct,
+    member_generator: MemberGenerator,
+    company_generator: CompanyGenerator,
+    plan_generator: PlanGenerator,
+):
+    sender = member_generator.create_member()
+    receiver = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=receiver)
+    pieces = 3
+    pay_consumer_product(sender, receiver, plan, pieces)
+    costs = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
+    assert sender.account.balance == -costs
+    assert receiver.product_account.balance == costs


### PR DESCRIPTION
Arbeiter/Member müssen die Möglichkeit haben, Produkte zu bezahlen, die nicht auf dem App-eigenen Marketplace angeboten werden. Dieses Feature  wird in diesem Pull Request mit dem use case "pay_consumer_product" implementiert. Auch das entsprechende front-end und tests werden implementiert. 

Dieses feature erfüllt eine sehr ähnliche Funktion wie das use case "pay_means_of_production" auf der Betriebsseite. 