### PR TITLE
fixing bugs after latest PR merges

### DIFF
--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -24,7 +24,6 @@ from arbeitszeit.repositories import (
 from arbeitszeit.transaction_factory import TransactionFactory
 
 # do not delete, these imports make imports of use cases module more convenient.
-from .adjust_balance import adjust_balance
 from .grant_credit import GrantCredit
 from .pay_consumer_product import PayConsumerProduct
 from .pay_means_of_production import PayMeansOfProduction
@@ -162,4 +161,3 @@ def check_plans_for_expiration(plans: List[Plan]) -> List[Plan]:
             plan.set_as_expired()
 
     return plans
-

--- a/arbeitszeit/use_cases/pay_means_of_production.py
+++ b/arbeitszeit/use_cases/pay_means_of_production.py
@@ -57,7 +57,7 @@ class PayMeansOfProduction:
         price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
         if purpose == PurposesOfPurchases.means_of_prod:
             account_from = sender.means_account
-        elif purpose == PurposesOfPurchases.means_of_prod:
+        elif purpose == PurposesOfPurchases.raw_materials:
             account_from = sender.raw_material_account
 
         transaction = self.transaction_factory.create_transaction(

--- a/tests/test_pay_means_of_production.py
+++ b/tests/test_pay_means_of_production.py
@@ -1,5 +1,5 @@
 import pytest
-from arbeitszeit.use_cases import pay_means_of_production
+from arbeitszeit.use_cases import PayMeansOfProduction
 from arbeitszeit.entities import AccountTypes, PurposesOfPurchases
 
 from tests.repositories import TransactionRepository
@@ -10,7 +10,7 @@ from arbeitszeit import errors
 
 @injection_test
 def test_assertion_error_is_raised_if_purpose_is_other_than_means_or_raw_materials(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -20,14 +20,12 @@ def test_assertion_error_is_raised_if_purpose_is_other_than_means_or_raw_materia
     purpose = PurposesOfPurchases.consumption
     pieces = 5
     with pytest.raises(AssertionError):
-        pay_means_of_production(
-            transaction_repository, sender, receiver, plan, pieces, purpose
-        )
+        pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
 
 @injection_test
 def test_error_is_raised_if_money_is_sent_to_nonexisting_company(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -37,14 +35,12 @@ def test_error_is_raised_if_money_is_sent_to_nonexisting_company(
     purpose = PurposesOfPurchases.means_of_prod
     pieces = 5
     with pytest.raises(errors.CompanyDoesNotExist):
-        pay_means_of_production(
-            transaction_repository, sender, receiver, plan, pieces, purpose
-        )
+        pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
 
 @injection_test
 def test_error_is_raised_if_specified_plan_does_not_exist(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
 ):
     sender = company_generator.create_company()
@@ -53,14 +49,12 @@ def test_error_is_raised_if_specified_plan_does_not_exist(
     purpose = PurposesOfPurchases.means_of_prod
     pieces = 5
     with pytest.raises(errors.PlanDoesNotExist):
-        pay_means_of_production(
-            transaction_repository, sender, receiver, plan, pieces, purpose
-        )
+        pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
 
 @injection_test
 def test_error_is_raised_if_receiver_is_not_equal_to_planner(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -70,14 +64,12 @@ def test_error_is_raised_if_receiver_is_not_equal_to_planner(
     purpose = PurposesOfPurchases.means_of_prod
     pieces = 5
     with pytest.raises(errors.CompanyIsNotPlanner):
-        pay_means_of_production(
-            transaction_repository, sender, receiver, plan, pieces, purpose
-        )
+        pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
 
 @injection_test
 def test_balance_of_buyer_of_means_of_prod_reduced(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -87,9 +79,7 @@ def test_balance_of_buyer_of_means_of_prod_reduced(
     purpose = PurposesOfPurchases.means_of_prod
     pieces = 5
 
-    pay_means_of_production(
-        transaction_repository, sender, receiver, plan, pieces, purpose
-    )
+    pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
     price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
     assert sender.means_account.balance == -price_total
@@ -97,7 +87,7 @@ def test_balance_of_buyer_of_means_of_prod_reduced(
 
 @injection_test
 def test_balance_of_buyer_of_raw_materials_reduced(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -107,9 +97,7 @@ def test_balance_of_buyer_of_raw_materials_reduced(
     purpose = PurposesOfPurchases.raw_materials
     pieces = 5
 
-    pay_means_of_production(
-        transaction_repository, sender, receiver, plan, pieces, purpose
-    )
+    pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
     price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
     assert sender.raw_material_account.balance == -price_total
@@ -117,7 +105,7 @@ def test_balance_of_buyer_of_raw_materials_reduced(
 
 @injection_test
 def test_balance_of_seller_increased(
-    transaction_repository: TransactionRepository,
+    pay_means_of_production: PayMeansOfProduction,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
 ):
@@ -127,9 +115,7 @@ def test_balance_of_seller_increased(
     purpose = PurposesOfPurchases.raw_materials
     pieces = 5
 
-    pay_means_of_production(
-        transaction_repository, sender, receiver, plan, pieces, purpose
-    )
+    pay_means_of_production(sender, receiver, plan, pieces, purpose)
 
     price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
     assert receiver.product_account.balance == price_total
@@ -137,6 +123,7 @@ def test_balance_of_seller_increased(
 
 @injection_test
 def test_correct_transaction_added_if_means_of_production_were_paid(
+    pay_means_of_production: PayMeansOfProduction,
     transaction_repository: TransactionRepository,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
@@ -146,9 +133,7 @@ def test_correct_transaction_added_if_means_of_production_were_paid(
     plan = plan_generator.create_plan(planner=receiver)
     purpose = PurposesOfPurchases.means_of_prod
     pieces = 5
-    pay_means_of_production(
-        transaction_repository, sender, receiver, plan, pieces, purpose
-    )
+    pay_means_of_production(sender, receiver, plan, pieces, purpose)
     price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
     assert len(transaction_repository.transactions) == 1
     assert transaction_repository.transactions[0].account_from == sender.means_account
@@ -161,6 +146,7 @@ def test_correct_transaction_added_if_means_of_production_were_paid(
 
 @injection_test
 def test_correct_transaction_added_if_raw_materials_were_paid(
+    pay_means_of_production: PayMeansOfProduction,
     transaction_repository: TransactionRepository,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
@@ -170,9 +156,7 @@ def test_correct_transaction_added_if_raw_materials_were_paid(
     plan = plan_generator.create_plan(planner=receiver)
     purpose = PurposesOfPurchases.raw_materials
     pieces = 5
-    pay_means_of_production(
-        transaction_repository, sender, receiver, plan, pieces, purpose
-    )
+    pay_means_of_production(sender, receiver, plan, pieces, purpose)
     price_total = pieces * (plan.costs_p + plan.costs_r + plan.costs_a)
     assert len(transaction_repository.transactions) == 1
     assert (


### PR DESCRIPTION
Habe den test "test_pay_means_of_production.py" nach dem Mergen der letzten PRs noch angepasst.
Außerdem habe ich einen bug im use case "pay means of production" entdeckt.