### PR TITLE
Refactor company registration into separate use case

### DIFF
--- a/arbeitszeit/errors.py
+++ b/arbeitszeit/errors.py
@@ -48,3 +48,7 @@ class PlanIsExpired(Exception):
 
 class MemberAlreadyExists(Exception):
     pass
+
+
+class CompanyAlreadyExists(Exception):
+    pass

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -81,3 +81,22 @@ class MemberRepository(ABC):
     @abstractmethod
     def has_member_with_email(self, email: str) -> bool:
         pass
+
+
+class CompanyRepository(ABC):
+    @abstractmethod
+    def create_company(
+        self,
+        email: str,
+        name: str,
+        password: str,
+        means_account: Account,
+        labour_account: Account,
+        resource_account: Account,
+        products_account: Account,
+    ) -> Company:
+        pass
+
+    @abstractmethod
+    def has_company_with_email(self, email: str) -> bool:
+        pass

--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -26,6 +26,7 @@ from .pay_consumer_product import PayConsumerProduct
 from .pay_means_of_production import PayMeansOfProduction
 from .query_products import ProductFilter, QueryProducts
 from .query_purchases import QueryPurchases
+from .register_company import RegisterCompany
 from .register_member import RegisterMember
 from .seek_approval import SeekApproval
 from .send_work_certificates_to_worker import SendWorkCertificatesToWorker
@@ -38,11 +39,11 @@ __all__ = [
     "PurchaseProduct",
     "QueryProducts",
     "QueryPurchases",
+    "RegisterCompany",
     "RegisterMember",
     "SeekApproval",
     "SendWorkCertificatesToWorker",
     "add_worker_to_company",
-    "check_plans_for_expiration",
     "deactivate_offer",
 ]
 

--- a/arbeitszeit/use_cases/register_company.py
+++ b/arbeitszeit/use_cases/register_company.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+
+from injector import inject
+
+from arbeitszeit.entities import AccountTypes, Company
+from arbeitszeit.errors import CompanyAlreadyExists
+from arbeitszeit.repositories import AccountRepository, CompanyRepository
+
+
+@inject
+@dataclass
+class RegisterCompany:
+    company_repository: CompanyRepository
+    account_repository: AccountRepository
+
+    def __call__(self, email: str, name: str, password: str) -> Company:
+        if self.company_repository.has_company_with_email(email):
+            raise CompanyAlreadyExists()
+        means_account = self.account_repository.create_account(AccountTypes.p)
+        resources_account = self.account_repository.create_account(AccountTypes.r)
+        labour_account = self.account_repository.create_account(AccountTypes.a)
+        products_account = self.account_repository.create_account(AccountTypes.prd)
+        return self.company_repository.create_company(
+            email,
+            name,
+            password,
+            means_account,
+            labour_account,
+            resources_account,
+            products_account,
+        )

--- a/project/database/__init__.py
+++ b/project/database/__init__.py
@@ -32,8 +32,6 @@ __all__ = [
     "PurchaseRepository",
     "TransactionRepository",
     "add_new_account_for_social_accounting",
-    "add_new_accounts_for_company",
-    "add_new_company",
     "commit_changes",
     "create_social_accounting_in_db",
     "get_company_by_mail",
@@ -58,7 +56,6 @@ def configure_injector(binder: Binder) -> None:
         interfaces.PurchaseRepository,  # type: ignore
         to=ClassProvider(PurchaseRepository),
     )
-
     binder.bind(
         entities.SocialAccounting,
         to=CallableProvider(get_social_accounting),
@@ -71,7 +68,10 @@ def configure_injector(binder: Binder) -> None:
         interfaces.MemberRepository,  # type: ignore
         to=ClassProvider(MemberRepository),
     )
-
+    binder.bind(
+        interfaces.CompanyRepository,  # type: ignore
+        to=ClassProvider(CompanyRepository),
+    )
     binder.bind(
         interfaces.PurchaseRepository,  # type: ignore
         to=ClassProvider(PurchaseRepository),
@@ -123,26 +123,6 @@ def get_company_by_mail(email) -> Company:
     """returns first company in Company, filtered by mail."""
     company = Company.query.filter_by(email=email).first()
     return company
-
-
-def add_new_company(email, name, password) -> Company:
-    """
-    adds a new company to Company.
-    """
-    new_company = Company(email=email, name=name, password=password)
-    db.session.add(new_company)
-    db.session.commit()
-    return new_company
-
-
-def add_new_accounts_for_company(company_id):
-    for type in ["p", "r", "a", "prd"]:
-        new_account = Account(
-            account_owner_company=company_id,
-            account_type=type,
-        )
-        db.session.add(new_account)
-        db.session.commit()
 
 
 # create one social accounting with id=1

--- a/project/database/repositories.py
+++ b/project/database/repositories.py
@@ -103,7 +103,7 @@ class MemberRepository(repositories.MemberRepository):
 
 @inject
 @dataclass
-class CompanyRepository:
+class CompanyRepository(repositories.CompanyRepository):
     account_repository: AccountRepository
     member_repository: MemberRepository
 
@@ -111,27 +111,45 @@ class CompanyRepository:
         return Company.query.get(company.id)
 
     def object_from_orm(self, company_orm: Company) -> entities.Company:
-        means_account_orm = company_orm.accounts.filter_by(account_type="p").first()
-        raw_material_account_orm = company_orm.accounts.filter_by(
-            account_type="r"
-        ).first()
-        work_account_orm = company_orm.accounts.filter_by(account_type="a").first()
-        product_account_orm = company_orm.accounts.filter_by(account_type="prd").first()
         return entities.Company(
             id=company_orm.id,
-            means_account=self.account_repository.object_from_orm(means_account_orm),
-            raw_material_account=self.account_repository.object_from_orm(
-                raw_material_account_orm
+            means_account=self.account_repository.object_from_orm(
+                self._get_means_account(company_orm)
             ),
-            work_account=self.account_repository.object_from_orm(work_account_orm),
+            raw_material_account=self.account_repository.object_from_orm(
+                self._get_resources_account(company_orm)
+            ),
+            work_account=self.account_repository.object_from_orm(
+                self._get_labour_account(company_orm)
+            ),
             product_account=self.account_repository.object_from_orm(
-                product_account_orm
+                self._get_products_account(company_orm)
             ),
             workers=[
                 self.member_repository.object_from_orm(worker_orm)
                 for worker_orm in company_orm.workers
             ],
         )
+
+    def _get_means_account(self, company: Company) -> Account:
+        account = company.accounts.filter_by(account_type="p").first()
+        assert account
+        return account
+
+    def _get_resources_account(self, company: Company) -> Account:
+        account = company.accounts.filter_by(account_type="r").first()
+        assert account
+        return account
+
+    def _get_labour_account(self, company: Company) -> Account:
+        account = company.accounts.filter_by(account_type="a").first()
+        assert account
+        return account
+
+    def _get_products_account(self, company: Company) -> Account:
+        account = company.accounts.filter_by(account_type="prd").first()
+        assert account
+        return account
 
     def get_by_id(self, id: int) -> entities.Company:
         company_orm = Company.query.filter_by(id=id).first()
@@ -140,11 +158,43 @@ class CompanyRepository:
         else:
             return self.object_from_orm(company_orm)
 
+    def create_company(
+        self,
+        email: str,
+        name: str,
+        password: str,
+        means_account: entities.Account,
+        labour_account: entities.Account,
+        resource_account: entities.Account,
+        products_account: entities.Account,
+    ) -> entities.Company:
+        company = Company(
+            email=email,
+            name=name,
+            password=generate_password_hash(password, method="sha256"),
+        )
+        db.session.add(company)
+        db.session.commit()
+        for account in [
+            means_account,
+            labour_account,
+            resource_account,
+            products_account,
+        ]:
+            account_orm = self.account_repository.object_to_orm(account)
+            account_orm.account_owner_company = company.id
+        db.session.commit()
+        return self.object_from_orm(company)
+
+    def has_company_with_email(self, email: str) -> bool:
+        return Company.query.filter_by(email=email).first() is not None
+
 
 @inject
 @dataclass
 class AccountRepository(repositories.AccountRepository):
     def object_from_orm(self, account_orm: Account) -> entities.Account:
+        assert account_orm
         return entities.Account(
             id=account_orm.id,
             account_type=account_orm.account_type,

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -48,6 +48,12 @@ class RepositoryModule(Module):
     ) -> interfaces.MemberRepository:
         return repo
 
+    @provider
+    def provide_company_repository(
+        self, repo: repositories.CompanyRepository
+    ) -> interfaces.CompanyRepository:
+        return repo
+
 
 def injection_test(original_test):
     injector = Injector(RepositoryModule())

--- a/tests/repositories.py
+++ b/tests/repositories.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import Iterator, List, Union
+from typing import Dict, Iterator, List, Union
 
 from injector import inject, singleton
 
@@ -131,3 +131,39 @@ class MemberRepository(interfaces.MemberRepository):
             if member.email == email:
                 return True
         return False
+
+
+@singleton
+class CompanyRepository(interfaces.CompanyRepository):
+    @inject
+    def __init__(self) -> None:
+        self.previous_id = 0
+        self.companies: Dict[str, Company] = {}
+
+    def create_company(
+        self,
+        email: str,
+        name: str,
+        password: str,
+        means_account: Account,
+        labour_account: Account,
+        resources_account: Account,
+        products_account: Account,
+    ) -> Company:
+        new_company = Company(
+            id=self._get_id(),
+            means_account=means_account,
+            raw_material_account=resources_account,
+            work_account=labour_account,
+            product_account=products_account,
+            workers=[],
+        )
+        self.companies[email] = new_company
+        return new_company
+
+    def has_company_with_email(self, email: str) -> bool:
+        return email in self.companies
+
+    def _get_id(self) -> int:
+        self.previous_id += 1
+        return self.previous_id

--- a/tests/test_company_registration.py
+++ b/tests/test_company_registration.py
@@ -1,0 +1,31 @@
+import pytest
+
+from arbeitszeit.errors import CompanyAlreadyExists
+from arbeitszeit.use_cases import RegisterCompany
+from tests.dependency_injection import injection_test
+from tests.repositories import AccountRepository
+
+
+@injection_test
+def test_that_registering_a_company_does_create_a_company_account(
+    register_company: RegisterCompany, account_repository: AccountRepository
+) -> None:
+    new_company = register_company("a_company@company.org", "ACompany", "testpassword")
+    company_accounts = [
+        new_company.means_account,
+        new_company.raw_material_account,
+        new_company.work_account,
+        new_company.product_account,
+    ]
+    for account in company_accounts:
+        assert account in account_repository
+
+
+@injection_test
+def test_that_cannot_register_user_with_same_email_twice(
+    register_company: RegisterCompany,
+):
+    email = "betrieb@cp.org"
+    register_company(email, "Betrieb1", "testpassword")
+    with pytest.raises(CompanyAlreadyExists):
+        register_company(email, "Betrieb2", "other_password")


### PR DESCRIPTION
Die Nutzer*innenregistrierung fuer "Company"-Mitglieder wurde refaktoriert und getestet.

Ich habe haendisch folgende Szenarien im Webinterface getestet:

* Company registrieren
* Produktionsplan erstellen
* Gewaehrung des Kredits auf die entsprechenden Konten nach Planerstellung
* Kontouebersicht
* Produktionsplanuebersicht