### PR TITLE
Refaktorierung von create_product und DatetimeService

### DIFF
--- a/arbeitszeit/datetime_service.py
+++ b/arbeitszeit/datetime_service.py
@@ -1,6 +1,8 @@
+from abc import ABC, abstractmethod
 from datetime import datetime
 
 
-class DatetimeService:
+class DatetimeService(ABC):
+    @abstractmethod
     def now(self) -> datetime:
-        return datetime.now()
+        pass

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from decimal import Decimal
 from typing import Iterator, List, Union
+from uuid import UUID
 
 from arbeitszeit.entities import (
     Account,
@@ -54,6 +55,10 @@ class PlanRepository(ABC):
     ) -> Plan:
         pass
 
+    @abstractmethod
+    def get_plan_by_id(self, id: UUID) -> Plan:
+        pass
+
 
 class TransactionRepository(ABC):
     @abstractmethod
@@ -103,6 +108,17 @@ class OfferRepository(ABC):
 
     @abstractmethod
     def all_active_offers(self) -> Iterator[ProductOffer]:
+        pass
+
+    @abstractmethod
+    def create_offer(
+        self,
+        plan: Plan,
+        creation_datetime: datetime,
+        name: str,
+        description: str,
+        amount_available: int,
+    ) -> ProductOffer:
         pass
 
 

--- a/arbeitszeit/use_cases/create_offer.py
+++ b/arbeitszeit/use_cases/create_offer.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from injector import inject
+
+from arbeitszeit.datetime_service import DatetimeService
+from arbeitszeit.entities import ProductOffer
+from arbeitszeit.repositories import OfferRepository, PlanRepository
+
+
+@dataclass
+class Offer:
+    name: str
+    description: str
+    plan_id: UUID
+    amount_available: int
+
+
+@inject
+@dataclass
+class CreateOffer:
+    offer_repository: OfferRepository
+    plan_repository: PlanRepository
+    datetime_service: DatetimeService
+
+    def __call__(self, offer: Offer) -> ProductOffer:
+        plan = self.plan_repository.get_plan_by_id(offer.plan_id)
+        return self.offer_repository.create_offer(
+            plan,
+            self.datetime_service.now(),
+            offer.name,
+            offer.description,
+            offer.amount_available,
+        )

--- a/arbeitszeit/use_cases/seek_approval.py
+++ b/arbeitszeit/use_cases/seek_approval.py
@@ -12,6 +12,7 @@ from arbeitszeit.use_cases import GrantCredit
 @dataclass
 class SeekApproval:
     grant_credit: GrantCredit
+    datetime_service: DatetimeService
 
     def __call__(self, new_plan: Plan, original_plan: Optional[Plan]) -> bool:
         """
@@ -22,7 +23,7 @@ class SeekApproval:
         """
         # This is just a place holder
         is_approval = True
-        approval_date = DatetimeService().now()
+        approval_date = self.datetime_service.now()
         if is_approval:
             new_plan.approve(approval_date)
             self.grant_credit(new_plan)

--- a/project/company/templates/company/create_offer_in_app.html
+++ b/project/company/templates/company/create_offer_in_app.html
@@ -20,8 +20,8 @@
         </p>
         <br>
         <ul>
-            <li>Name: {{ offer.plan.prd_name }}</li>
-            <li>Beschreibung: {{ offer.plan.description }}</li>
+            <li>Name: {{ offer.name }}</li>
+            <li>Beschreibung: {{ offer.description }}</li>
         </ul>
         <br>
         <p>

--- a/project/database/__init__.py
+++ b/project/database/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime
 from functools import wraps
 
 from flask_sqlalchemy import SQLAlchemy
@@ -14,6 +15,7 @@ from injector import (
 
 from arbeitszeit import entities
 from arbeitszeit import repositories as interfaces
+from arbeitszeit.datetime_service import DatetimeService
 from project.extensions import db
 from project.models import Account, Company, Member, SocialAccounting
 
@@ -94,9 +96,22 @@ def configure_injector(binder: Binder) -> None:
         to=ClassProvider(AccountOwnerRepository),
     )
     binder.bind(
+        interfaces.OfferRepository,  # type: ignore
+        to=ClassProvider(ProductOfferRepository),
+    )
+    binder.bind(
+        DatetimeService,  # type: ignore
+        to=ClassProvider(RealtimeDatetimeService),
+    )
+    binder.bind(
         SQLAlchemy,
         to=InstanceProvider(db),
     )
+
+
+class RealtimeDatetimeService(DatetimeService):
+    def now(self):
+        return datetime.now()
 
 
 @inject

--- a/project/member/routes.py
+++ b/project/member/routes.py
@@ -111,7 +111,7 @@ def pay_consumer_product(
 
     if request.method == "POST":
         sender = member_repository.get_member_by_id(current_user.id)
-        plan = plan_repository.get_by_id(request.form["plan_id"])
+        plan = plan_repository.get_plan_by_id(request.form["plan_id"])
         receiver = company_repository.get_by_id(request.form["company_id"])
         pieces = int(request.form["amount"])
         try:

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -1,11 +1,23 @@
 from datetime import datetime, timedelta
 
+from injector import singleton
+
 from arbeitszeit.datetime_service import DatetimeService
 
 
-class TestDatetimeService(DatetimeService):
+@singleton
+class FakeDatetimeService(DatetimeService):
+    def __init__(self):
+        self.frozen_time = None
+
+    def freeze_time(self, timestamp: datetime):
+        self.frozen_time = timestamp
+
+    def now(self) -> datetime:
+        return self.frozen_time if self.frozen_time else datetime.now()
+
     def now_minus_one_day(self) -> datetime:
-        return datetime.now() - timedelta(days=1)
+        return self.now() - timedelta(days=1)
 
     def now_minus_two_days(self) -> datetime:
-        return datetime.now() - timedelta(days=2)
+        return self.now() - timedelta(days=2)

--- a/tests/flask_integration/dependency_injection.py
+++ b/tests/flask_integration/dependency_injection.py
@@ -1,0 +1,33 @@
+from flask_sqlalchemy import SQLAlchemy
+from injector import Injector, Module, inject, provider, singleton
+
+import project.models
+from project import create_app
+from project.database import configure_injector
+
+
+class SqliteModule(Module):
+    @provider
+    @singleton
+    def provide_sqlalchemy(self) -> SQLAlchemy:
+        db = SQLAlchemy(model_class=project.models.db.Model)
+        config = {
+            "SQLALCHEMY_DATABASE_URI": "sqlite://",
+            "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        }
+        app = create_app(config=config, db=db)
+        with app.app_context():
+            db.create_all()
+        app.app_context().push()
+        return db
+
+
+def injection_test(original_test):
+    injector = Injector([configure_injector, SqliteModule()])
+
+    def wrapper(*args, **kwargs):
+        return injector.call_with_injection(
+            inject(original_test), args=args, kwargs=kwargs
+        )
+
+    return wrapper

--- a/tests/flask_integration/test_member_repository.py
+++ b/tests/flask_integration/test_member_repository.py
@@ -5,7 +5,8 @@ import pytest
 from arbeitszeit.entities import AccountTypes
 from project.database.repositories import AccountRepository, MemberRepository
 from project.error import MemberNotFound
-from tests.dependency_injection import injection_test
+
+from .dependency_injection import injection_test
 
 
 @injection_test

--- a/tests/flask_integration/test_offer_repository.py
+++ b/tests/flask_integration/test_offer_repository.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+
+from project.database.repositories import ProductOfferRepository
+from tests.data_generators import PlanGenerator
+
+from .dependency_injection import injection_test
+
+
+@injection_test
+def tests_offers_can_be_created(
+    offer_repository: ProductOfferRepository, plan_generator: PlanGenerator
+):
+    plan = plan_generator.create_plan()
+    assert not len(offer_repository)
+    offer_repository.create_offer(
+        plan=plan,
+        creation_datetime=datetime.now(),
+        name="testname",
+        description="testdescription",
+        amount_available=1,
+    )
+    assert len(offer_repository)

--- a/tests/test_calculate_plan_expiration_and_check_if_expired.py
+++ b/tests/test_calculate_plan_expiration_and_check_if_expired.py
@@ -1,14 +1,15 @@
 import datetime
 
-from arbeitszeit.use_cases import calculate_plan_expiration_and_check_if_expired
+from arbeitszeit.use_cases import CalculatePlanExpirationAndCheckIfExpired
 from tests.data_generators import PlanGenerator
-from tests.datetime_service import TestDatetimeService
+from tests.datetime_service import FakeDatetimeService
 from tests.dependency_injection import injection_test
 
 
 @injection_test
 def test_that_expiration_info_is_saved_as_instance_attributes(
     plan_generator: PlanGenerator,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan()
     calculate_plan_expiration_and_check_if_expired(plan)
@@ -20,9 +21,11 @@ def test_that_expiration_info_is_saved_as_instance_attributes(
 @injection_test
 def test_that_relative_expiration_time_is_correctly_calculated(
     plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now(), timeframe=1
+        plan_creation_date=datetime_service.now(), timeframe=1
     )
     calculate_plan_expiration_and_check_if_expired(plan)
     assert plan.expiration_relative == (0, 23, 59)
@@ -31,12 +34,14 @@ def test_that_relative_expiration_time_is_correctly_calculated(
 @injection_test
 def test_that_expiration_date_is_correctly_calculated(
     plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now(), timeframe=1
+        plan_creation_date=datetime_service.now(), timeframe=1
     )
     expected_expiration_date = (
-        TestDatetimeService().now() + datetime.timedelta(days=1)
+        datetime_service.now() + datetime.timedelta(days=1)
     ).strftime("%x")
     calculate_plan_expiration_and_check_if_expired(plan)
     calculated_expiration_date = (
@@ -48,9 +53,11 @@ def test_that_expiration_date_is_correctly_calculated(
 @injection_test
 def test_that_plan_is_not_set_to_expired_if_still_in_timeframe(
     plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_two_days(), timeframe=3
+        plan_creation_date=datetime_service.now_minus_two_days(), timeframe=3
     )
     calculate_plan_expiration_and_check_if_expired(plan)
     assert not plan.expired
@@ -59,9 +66,11 @@ def test_that_plan_is_not_set_to_expired_if_still_in_timeframe(
 @injection_test
 def test_that_plan_is_set_to_expired_if_timeframe_is_expired(
     plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_two_days(), timeframe=1
+        plan_creation_date=datetime_service.now_minus_two_days(), timeframe=1
     )
     calculate_plan_expiration_and_check_if_expired(plan)
     assert plan.expired
@@ -70,12 +79,14 @@ def test_that_plan_is_set_to_expired_if_timeframe_is_expired(
 @injection_test
 def test_that_plan_is_only_set_to_expired_if_timeframe_is_expired(
     plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
+    calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan1 = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_two_days(), timeframe=1
+        plan_creation_date=datetime_service.now_minus_two_days(), timeframe=1
     )
     plan2 = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_two_days(), timeframe=3
+        plan_creation_date=datetime_service.now_minus_two_days(), timeframe=3
     )
     calculate_plan_expiration_and_check_if_expired(plan1)
     calculate_plan_expiration_and_check_if_expired(plan2)

--- a/tests/test_grant_credit.py
+++ b/tests/test_grant_credit.py
@@ -1,9 +1,7 @@
 import pytest
 
-from arbeitszeit.entities import AccountTypes
 from arbeitszeit.use_cases import GrantCredit
 from tests.dependency_injection import injection_test
-from tests.repositories import TransactionRepository
 
 from .data_generators import PlanGenerator
 
@@ -16,81 +14,3 @@ def test_that_assertion_error_is_raised_if_plan_has_not_been_approved(
     plan = plan_generator.create_plan(approved=False)
     with pytest.raises(AssertionError):
         grant_credit(plan)
-
-
-@injection_test
-def test_account_balances_adjusted(
-    grant_credit: GrantCredit,
-    plan_generator: PlanGenerator,
-):
-    plan = plan_generator.create_plan(approved=True)
-    grant_credit(plan)
-    assert plan.planner.means_account.balance == plan.production_costs.means_cost
-    assert (
-        plan.planner.raw_material_account.balance == plan.production_costs.resource_cost
-    )
-    assert plan.planner.work_account.balance == plan.production_costs.labour_cost
-    assert plan.planner.product_account.balance == -(plan.production_costs.total_cost())
-
-
-@injection_test
-def test_that_all_transactions_have_accounting_as_sender(
-    grant_credit: GrantCredit,
-    plan_generator: PlanGenerator,
-    transaction_repository: TransactionRepository,
-):
-    plan = plan_generator.create_plan(approved=True)
-    grant_credit(plan)
-    for transaction in transaction_repository.transactions:
-        assert transaction.account_from.account_type == AccountTypes.accounting
-
-
-@injection_test
-def test_that_transactions_with_all_four_account_types_as_receivers_are_added_to_repo(
-    grant_credit: GrantCredit,
-    plan_generator: PlanGenerator,
-    transaction_repository: TransactionRepository,
-):
-    plan = plan_generator.create_plan(approved=True)
-    grant_credit(plan)
-    added_account_types = [
-        transaction.account_to.account_type
-        for transaction in transaction_repository.transactions
-    ]
-    for account_type in (
-        AccountTypes.p,
-        AccountTypes.r,
-        AccountTypes.a,
-        AccountTypes.prd,
-    ):
-        assert account_type in added_account_types
-
-
-@injection_test
-def test_that_added_transactions_have_correct_amounts(
-    grant_credit: GrantCredit,
-    plan_generator: PlanGenerator,
-    transaction_repository: TransactionRepository,
-):
-    plan = plan_generator.create_plan(approved=True)
-    expected_amount_p, expected_amount_r, expected_amount_a, expected_amount_prd = (
-        plan.production_costs.means_cost,
-        plan.production_costs.resource_cost,
-        plan.production_costs.labour_cost,
-        -plan.production_costs.total_cost(),
-    )
-    grant_credit(plan)
-    for trans in transaction_repository.transactions:
-        if trans.account_to.account_type == AccountTypes.p:
-            added_amount_p = trans.amount
-        elif trans.account_to.account_type == AccountTypes.r:
-            added_amount_r = trans.amount
-        elif trans.account_to.account_type == AccountTypes.a:
-            added_amount_a = trans.amount
-        elif trans.account_to.account_type == AccountTypes.prd:
-            added_amount_prd = trans.amount
-
-    assert expected_amount_p == added_amount_p
-    assert expected_amount_r == added_amount_r
-    assert expected_amount_a == added_amount_a
-    assert expected_amount_prd == added_amount_prd

--- a/tests/test_pay_consumer_product.py
+++ b/tests/test_pay_consumer_product.py
@@ -4,7 +4,7 @@ from arbeitszeit import errors
 from arbeitszeit.use_cases import PayConsumerProduct
 
 from .data_generators import CompanyGenerator, MemberGenerator, PlanGenerator
-from .datetime_service import TestDatetimeService
+from .datetime_service import FakeDatetimeService
 from .dependency_injection import injection_test
 from .repositories import TransactionRepository
 
@@ -31,7 +31,7 @@ def test_error_is_raised_if_plan_is_expired(
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
     plan_generator: PlanGenerator,
-    datetime_service: TestDatetimeService,
+    datetime_service: FakeDatetimeService,
 ):
     sender = member_generator.create_member()
     receiver = company_generator.create_company()

--- a/tests/test_purchase.py
+++ b/tests/test_purchase.py
@@ -1,8 +1,15 @@
+from decimal import Decimal
+
 import pytest
 
 from arbeitszeit.entities import AccountTypes, PurposesOfPurchases
 from arbeitszeit.use_cases import PurchaseProduct
-from tests.data_generators import CompanyGenerator, MemberGenerator, OfferGenerator
+from tests.data_generators import (
+    CompanyGenerator,
+    MemberGenerator,
+    OfferGenerator,
+    PlanGenerator,
+)
 from tests.dependency_injection import injection_test
 from tests.repositories import TransactionRepository
 
@@ -64,9 +71,11 @@ def test_balance_of_buyer_reduced(
     offer_generator: OfferGenerator,
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
+    plan_generator: PlanGenerator,
 ):
     # member, consumption
-    offer1 = offer_generator.create_offer(amount=3)
+    plan = plan_generator.create_plan(total_cost=Decimal(3), amount=3)
+    offer1 = offer_generator.create_offer(amount=3, plan=plan)
     buyer1 = member_generator.create_member()
     purpose1 = PurposesOfPurchases.consumption
     purchase_product(offer1, 3, purpose1, buyer1)
@@ -92,8 +101,10 @@ def test_balance_of_seller_increased(
     purchase_product: PurchaseProduct,
     offer_generator: OfferGenerator,
     member_generator: MemberGenerator,
+    plan_generator: PlanGenerator,
 ):
-    offer = offer_generator.create_offer(amount=3)
+    plan = plan_generator.create_plan(total_cost=Decimal(3), amount=3)
+    offer = offer_generator.create_offer(amount=3, plan=plan)
     buyer = member_generator.create_member()
     purchase_product(
         offer,

--- a/tests/test_query_product.py
+++ b/tests/test_query_product.py
@@ -21,7 +21,6 @@ def test_that_offers_where_name_is_exact_match_are_returned(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
-    repository.add_offer(expected_offer)
     results = list(query_products("My Product", ProductFilter.by_name))
     assert expected_offer in results
 
@@ -33,7 +32,6 @@ def test_query_substring_of_name_returns_correct_result(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
-    repository.add_offer(expected_offer)
     results = list(query_products("Product", ProductFilter.by_name))
     assert expected_offer in results
 
@@ -46,7 +44,6 @@ def test_that_offers_where_description_is_exact_match_are_returned(
 ):
     description = "my description"
     expected_offer = offer_generator.create_offer(description=description)
-    repository.add_offer(expected_offer)
     results = list(query_products(description, ProductFilter.by_description))
     assert expected_offer in results
 
@@ -58,6 +55,5 @@ def test_query_substrin_of_description_returns_correct_result(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(description="my description")
-    repository.add_offer(expected_offer)
     results = list(query_products("description", ProductFilter.by_description))
     assert expected_offer in results

--- a/tests/test_query_purchases.py
+++ b/tests/test_query_purchases.py
@@ -1,6 +1,6 @@
 from arbeitszeit.use_cases import QueryPurchases
 from tests.data_generators import CompanyGenerator, MemberGenerator, PurchaseGenerator
-from tests.datetime_service import TestDatetimeService
+from tests.datetime_service import FakeDatetimeService
 from tests.dependency_injection import injection_test
 from tests.repositories import PurchaseRepository
 
@@ -49,13 +49,14 @@ def test_that_purchases_are_returned_in_correct_order_when_member_queries(
     member_generator: MemberGenerator,
     purchase_generator: PurchaseGenerator,
     repository: PurchaseRepository,
+    datetime_service: FakeDatetimeService,
 ):
     member = member_generator.create_member()
     expected_recent_purchase = purchase_generator.create_purchase(
-        buyer=member, purchase_date=TestDatetimeService().now_minus_one_day()
+        buyer=member, purchase_date=datetime_service.now_minus_one_day()
     )
     expected_older_purchase = purchase_generator.create_purchase(
-        buyer=member, purchase_date=TestDatetimeService().now_minus_two_days()
+        buyer=member, purchase_date=datetime_service.now_minus_two_days()
     )
     repository.add(expected_older_purchase)  # adding older purchase first
     repository.add(expected_recent_purchase)
@@ -69,13 +70,14 @@ def test_that_purchases_are_returned_in_correct_order_when_company_queries(
     purchase_generator: PurchaseGenerator,
     company_generator: CompanyGenerator,
     repository: PurchaseRepository,
+    datetime_service: FakeDatetimeService,
 ):
     company = company_generator.create_company()
     expected_recent_purchase = purchase_generator.create_purchase(
-        buyer=company, purchase_date=TestDatetimeService().now_minus_one_day()
+        buyer=company, purchase_date=datetime_service.now_minus_one_day()
     )
     expected_older_purchase = purchase_generator.create_purchase(
-        buyer=company, purchase_date=TestDatetimeService().now_minus_two_days()
+        buyer=company, purchase_date=datetime_service.now_minus_two_days()
     )
     repository.add(expected_older_purchase)  # adding older purchase first
     repository.add(expected_recent_purchase)

--- a/tests/test_seek_approval.py
+++ b/tests/test_seek_approval.py
@@ -1,7 +1,11 @@
+from datetime import datetime
+
+from arbeitszeit.entities import AccountTypes
 from arbeitszeit.use_cases import SeekApproval
 from tests.data_generators import PlanGenerator
-from tests.datetime_service import TestDatetimeService
+from tests.datetime_service import FakeDatetimeService
 from tests.dependency_injection import injection_test
+from tests.repositories import TransactionRepository
 
 
 @injection_test
@@ -10,9 +14,7 @@ def test_that_any_plan_will_be_approved(
     seek_approval: SeekApproval,
 ):
     new_plan = plan_generator.create_plan()
-    original_plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_one_day()
-    )
+    original_plan = plan_generator.create_plan()
     seek_approval(new_plan, original_plan)
     assert new_plan.approved
 
@@ -23,9 +25,7 @@ def test_that_any_plan_will_be_approved_and_original_plan_renewed(
     seek_approval: SeekApproval,
 ):
     new_plan = plan_generator.create_plan()
-    original_plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_one_day()
-    )
+    original_plan = plan_generator.create_plan()
     seek_approval(new_plan, original_plan)
     assert new_plan.approved
     assert original_plan.renewed
@@ -37,9 +37,7 @@ def test_that_true_is_returned(
     seek_approval: SeekApproval,
 ):
     new_plan = plan_generator.create_plan()
-    original_plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_one_day()
-    )
+    original_plan = plan_generator.create_plan()
     is_approval = seek_approval(new_plan, original_plan)
     assert is_approval is True
 
@@ -48,13 +46,89 @@ def test_that_true_is_returned(
 def test_that_approval_date_has_correct_day_of_month(
     plan_generator: PlanGenerator,
     seek_approval: SeekApproval,
+    datetime_service: FakeDatetimeService,
 ):
+    datetime_service.freeze_time(datetime(year=2021, month=5, day=3))
     new_plan = plan_generator.create_plan()
-    original_plan = plan_generator.create_plan(
-        plan_creation_date=TestDatetimeService().now_minus_one_day()
-    )
+    original_plan = plan_generator.create_plan()
     seek_approval(new_plan, original_plan)
-    expected_day_of_month = TestDatetimeService().now().strftime("%d")
     assert new_plan.approval_date
-    day_of_month = new_plan.approval_date.strftime("%d")
-    assert expected_day_of_month == day_of_month
+    assert 3 == new_plan.approval_date.day
+
+
+@injection_test
+def test_account_balances_adjusted(
+    seek_approval: SeekApproval,
+    plan_generator: PlanGenerator,
+):
+    plan = plan_generator.create_plan()
+    seek_approval(plan, None)
+    assert plan.planner.means_account.balance == plan.production_costs.means_cost
+    assert (
+        plan.planner.raw_material_account.balance == plan.production_costs.resource_cost
+    )
+    assert plan.planner.work_account.balance == plan.production_costs.labour_cost
+    assert plan.planner.product_account.balance == -(plan.production_costs.total_cost())
+
+
+@injection_test
+def test_that_all_transactions_have_accounting_as_sender(
+    seek_approval: SeekApproval,
+    plan_generator: PlanGenerator,
+    transaction_repository: TransactionRepository,
+):
+    plan = plan_generator.create_plan()
+    seek_approval(plan, None)
+    for transaction in transaction_repository.transactions:
+        assert transaction.account_from.account_type == AccountTypes.accounting
+
+
+@injection_test
+def test_that_transactions_with_all_four_account_types_as_receivers_are_added_to_repo(
+    seek_approval: SeekApproval,
+    plan_generator: PlanGenerator,
+    transaction_repository: TransactionRepository,
+):
+    plan = plan_generator.create_plan()
+    seek_approval(plan, None)
+    added_account_types = [
+        transaction.account_to.account_type
+        for transaction in transaction_repository.transactions
+    ]
+    for account_type in (
+        AccountTypes.p,
+        AccountTypes.r,
+        AccountTypes.a,
+        AccountTypes.prd,
+    ):
+        assert account_type in added_account_types
+
+
+@injection_test
+def test_that_added_transactions_have_correct_amounts(
+    seek_approval: SeekApproval,
+    plan_generator: PlanGenerator,
+    transaction_repository: TransactionRepository,
+):
+    plan = plan_generator.create_plan()
+    expected_amount_p, expected_amount_r, expected_amount_a, expected_amount_prd = (
+        plan.production_costs.means_cost,
+        plan.production_costs.resource_cost,
+        plan.production_costs.labour_cost,
+        -plan.production_costs.total_cost(),
+    )
+    seek_approval(plan, None)
+    for trans in transaction_repository.transactions:
+        if trans.account_to.account_type == AccountTypes.p:
+            added_amount_p = trans.amount
+        elif trans.account_to.account_type == AccountTypes.r:
+            added_amount_r = trans.amount
+        elif trans.account_to.account_type == AccountTypes.a:
+            added_amount_a = trans.amount
+        elif trans.account_to.account_type == AccountTypes.prd:
+            added_amount_prd = trans.amount
+
+    assert expected_amount_p == added_amount_p
+    assert expected_amount_r == added_amount_r
+    assert expected_amount_a == added_amount_a
+    assert expected_amount_prd == added_amount_prd


### PR DESCRIPTION
Vorab erstmal:

Es tut mir Leid, dass der PR so riesengross geworden ist. Es kam einfach eins zum Anderen :(

# Was wurde getan

* DatetimeService wurde zu einer abstrakten Klasse gemacht
* /company/create_offer wurde refaktoriert und zu einem "use case" gemacht
* Ein separater @injection_test decorator fuer Tests an der Datenbank wurde erstellt
* Die helper-Klassen aus tests/data_generators.py wurden kompatibel gemacht mit den Integrationstests
* Die mesten unit tests aus tests/test_grant_credit.py wurden nach tests/seek_approval.py umgezogen

# Aber warum?

## DatetimeService wurde zu einer abstrakten Klasse gemacht

Der DatetimeService wurde abstrakt gemacht, um zu verhindern, dass der Service an der dependency injection Logik vorbei benutzt wird. Eine konsistente Nutzung von DI macht die Implementierung von "freeze time" trivial (was auch mit dieser Aenderung getan wurde). Ich denke, dass das mittelfristig von grossem Nutzen beim Testen sein wird.

## /company/create_offer wurde refaktoriert und zu einem "use case" gemacht

Ich denke, dass diese Aenderung nicht besonders kontrovers ist. Die Vorteile gerade beim Thema Testbarkeit sollten auf der Hand liegen.

## Ein separater @injection_test decorator fuer Tests an der Datenbank wurde erstellt

Die Nutzung eines separaten Dekorators an der Stelle erlaubt uns, die Testlogik fuer Tests mit der Datenbank besser zu kontrollieren. Anpassungen bei der DI-Logik koennen so ohne Ruecksicht auf die anderen Tests, die keine DB brauchen, getaetigt werden.

## Die helper-Klassen aus tests/data_generators.py wurden kompatibel gemacht mit den Integrationstests

Dadurch koennen wir den Code den wir bereits geschrieben haben auch fuer die DB-Tests verwenden.

## Die mesten unit tests aus tests/test_grant_credit.py wurden nach tests/seek_approval.py umgezogen

Dies ist vermutlich die kontroverseste Aenderung. `GrantCredit` benoetigt einen Plan, der genehmigt wurde.  Es gibt aber momentan "keine" Moeglichkeit, einen Plan zu genehmigen, ohne auch den Kredit zu gewaehren. Das hat dazu gefuehrt, dass wir Testdaten an der "kanonischen" Logik vorbei generiert haben. Ich denke, dass das mittelfristig zu groesseren Problemen fuehren wuerde.