### PR TITLE
Entkupplung der Marketplace ansicht von DB models

### DIFF
--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -20,7 +20,7 @@ from .get_plan_summary import GetPlanSummary
 from .get_transaction_infos import GetTransactionInfos
 from .pay_consumer_product import PayConsumerProduct
 from .pay_means_of_production import PayMeansOfProduction
-from .query_products import ProductFilter, QueryProducts
+from .query_products import ProductFilter, ProductQueryResponse, QueryProducts
 from .query_purchases import QueryPurchases
 from .register_company import RegisterCompany
 from .register_member import RegisterMember
@@ -39,6 +39,7 @@ __all__ = [
     "PayMeansOfProduction",
     "PlanProposal",
     "ProductFilter",
+    "ProductQueryResponse",
     "PurchaseProduct",
     "QueryProducts",
     "QueryPurchases",

--- a/project/templates/macros.html
+++ b/project/templates/macros.html
@@ -130,18 +130,18 @@
     <tbody>
       {% for offer in results %}
       <tr>
-        <td>{{ offer.plan.id }}</td>
-        <td>{{ offer.name }}</td>
-        <td>{{ offer.plan.planner.name }}</td>
+        <td>{{ offer.plan_id }}</td>
+        <td>{{ offer.product_name }}</td>
+        <td>{{ offer.seller_name }}</td>
         <td>
-          <a href="mailto:{{ offer.plan.planner.email }}">
+          <a href="mailto:{{ offer.seller_email }}">
             <u><span class="icon"><i class="far fa-envelope"></i></span></u>
           </a>
         </td>
         <td>{{ offer.description }}</td>
-        <td>{{ offer.price_per_unit()|round(2) }} Std.
+        <td>{{ offer.price_per_unit|round(2) }} Std.
         </td>
-        <td>{{ offer.plan.is_public_service }}</td>
+        <td>{{ offer.is_public_service }}</td>
         <td>{{ offer.amount_available }}</td>
         <td>
           <a href="{{ url_for('%s.buy' % (request.blueprint), id=offer.id) }}">

--- a/tests/test_query_product.py
+++ b/tests/test_query_product.py
@@ -1,7 +1,16 @@
-from arbeitszeit.use_cases import ProductFilter, QueryProducts
+from typing import Iterable
+
+from arbeitszeit.entities import ProductOffer
+from arbeitszeit.use_cases import ProductFilter, ProductQueryResponse, QueryProducts
 from tests.data_generators import OfferGenerator
 from tests.dependency_injection import injection_test
 from tests.repositories import OfferRepository
+
+
+def offer_in_results(
+    offer: ProductOffer, results: Iterable[ProductQueryResponse]
+) -> bool:
+    return offer.id in [result.offer_id for result in results]
 
 
 @injection_test
@@ -22,7 +31,7 @@ def test_that_offers_where_name_is_exact_match_are_returned(
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
     results = list(query_products("My Product", ProductFilter.by_name))
-    assert expected_offer in results
+    assert offer_in_results(expected_offer, results)
 
 
 @injection_test
@@ -33,7 +42,7 @@ def test_query_substring_of_name_returns_correct_result(
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
     results = list(query_products("Product", ProductFilter.by_name))
-    assert expected_offer in results
+    assert offer_in_results(expected_offer, results)
 
 
 @injection_test
@@ -45,7 +54,7 @@ def test_that_offers_where_description_is_exact_match_are_returned(
     description = "my description"
     expected_offer = offer_generator.create_offer(description=description)
     results = list(query_products(description, ProductFilter.by_description))
-    assert expected_offer in results
+    assert offer_in_results(expected_offer, results)
 
 
 @injection_test
@@ -56,4 +65,4 @@ def test_query_substrin_of_description_returns_correct_result(
 ):
     expected_offer = offer_generator.create_offer(description="my description")
     results = list(query_products("description", ProductFilter.by_description))
-    assert expected_offer in results
+    assert offer_in_results(expected_offer, results)


### PR DESCRIPTION
Es wurde eine neue Klasse namens QueryProductsResponse eingefuehrt. Diese Klasse haelt die Suchergebnisse, die beim QueryProducts use case gefunden werden. Ziel ist es, die Marktplatzansicht vom Datenmodel zu trennen. Veraenderung an den Entities und am Datenmodell sollen nicht dazu fuehren, dass eine View nicht mehr geht.