### PR TITLE
Managementkommando fuer Planaktivierung

### DIFF
--- a/cron_job_heroku.sh
+++ b/cron_job_heroku.sh
@@ -1,2 +1,2 @@
 export ARBEITSZEIT_APP_CONFIGURATION="$PWD/production-settings.py"
-python cron_job_plan_activation.py
+flask activate-plans

--- a/project/__init__.py
+++ b/project/__init__.py
@@ -8,6 +8,7 @@ from project.extensions import login_manager
 
 def create_app(config=None, db=None, migrate=None):
     app = Flask(__name__, instance_relative_config=False)
+
     if config:
         app.config.update(**config)
     else:
@@ -24,14 +25,8 @@ def create_app(config=None, db=None, migrate=None):
     login_manager.login_view = "auth.start"
 
     # Init Flask-Talisman
-    if app.config['ENV'] == 'production':
-        csp = {
-            'default-src': [
-                '\'self\'',
-                '\'unsafe-inline\'',
-                '*.fontawesome.com'
-            ]
-        }
+    if app.config["ENV"] == "production":
+        csp = {"default-src": ["'self'", "'unsafe-inline'", "*.fontawesome.com"]}
         Talisman(app, content_security_policy=csp)
 
     # init flask extensions
@@ -40,6 +35,10 @@ def create_app(config=None, db=None, migrate=None):
     migrate.init_app(app, db)
 
     with app.app_context():
+        from project.commands import activate_database_plans
+
+        app.cli.command("activate-plans")(activate_database_plans)
+
         from .models import Company, Member
 
         @login_manager.user_loader

--- a/project/commands.py
+++ b/project/commands.py
@@ -1,10 +1,9 @@
 from arbeitszeit.use_cases import (
-    SynchronizedPlanActivation,
     CalculatePlanExpirationAndCheckIfExpired,
+    SynchronizedPlanActivation,
 )
-from project.database.repositories import PlanRepository
 from project.database import with_injection
-from project import create_app
+from project.database.repositories import PlanRepository
 
 
 @with_injection
@@ -25,8 +24,3 @@ def activate_database_plans(
     all_active_plans = plan_repository.all_active_plans()
     for plan in all_active_plans:
         calculate_expiration(plan)
-
-
-app = create_app()
-with app.app_context():
-    activate_database_plans()


### PR DESCRIPTION
Hi,

ich habe die automatisierte Planaktivierung durch den cron job auf heroku etwas verfeinert. Satt eines python scripts, dass einfach in der Wurzel des Repositories liegt, gibt es jetzt ein Managementkommando `flask activate-plans`. Ich habe das bash script, welches vom cron job auf heroku ausgefuehrt wird, so angepasst, dass es jetzt das neue Kommando benutzt.