### PR TITLE
Refaktorierung von CreatePlan und SeekApproval

### DIFF
--- a/arbeitszeit/use_cases/create_production_plan.py
+++ b/arbeitszeit/use_cases/create_production_plan.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from injector import inject
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.entities import Plan, ProductionCosts
+from arbeitszeit.entities import ProductionCosts
 from arbeitszeit.repositories import CompanyRepository, PlanRepository
 
 
@@ -19,6 +19,11 @@ class PlanProposal:
     is_public_service: bool
 
 
+@dataclass
+class CreatePlanResponse:
+    plan_id: UUID
+
+
 @inject
 @dataclass
 class CreatePlan:
@@ -26,8 +31,10 @@ class CreatePlan:
     datetime_service: DatetimeService
     company_repository: CompanyRepository
 
-    def __call__(self, planner: UUID, plan_proposal: PlanProposal) -> Plan:
-        return self.plan_repository.create_plan(
+    def __call__(
+        self, planner: UUID, plan_proposal: PlanProposal
+    ) -> CreatePlanResponse:
+        plan = self.plan_repository.create_plan(
             planner=self.company_repository.get_by_id(planner),
             costs=plan_proposal.costs,
             product_name=plan_proposal.product_name,
@@ -38,3 +45,4 @@ class CreatePlan:
             is_public_service=plan_proposal.is_public_service,
             creation_timestamp=self.datetime_service.now(),
         )
+        return CreatePlanResponse(plan_id=plan.id)

--- a/arbeitszeit/use_cases/seek_approval.py
+++ b/arbeitszeit/use_cases/seek_approval.py
@@ -8,13 +8,21 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.repositories import PlanRepository
 
 
+@dataclass
+class SeekApprovalResponse:
+    is_approved: bool
+    reason: str
+
+
 @inject
 @dataclass
 class SeekApproval:
     datetime_service: DatetimeService
     plan_repository: PlanRepository
 
-    def __call__(self, new_plan_id: UUID, original_plan_id: Optional[UUID]) -> bool:
+    def __call__(
+        self, new_plan_id: UUID, original_plan_id: Optional[UUID]
+    ) -> SeekApprovalResponse:
         """
         Company seeks plan approval. Either for a new plan or for a plan reneweal.
         Sets approved either to True or False, sets approval_date and approval_reason.
@@ -36,4 +44,8 @@ class SeekApproval:
                 self.plan_repository.renew_plan(original_plan)
         else:
             new_plan.deny(approval_date)
-        return is_approval
+        assert new_plan.approval_reason
+        return SeekApprovalResponse(
+            is_approved=is_approval,
+            reason=new_plan.approval_reason,
+        )

--- a/project/company/routes.py
+++ b/project/company/routes.py
@@ -202,16 +202,16 @@ def create_plan(
             else False,
         )
         new_plan = create_plan_from_proposal(current_user.id, proposal)
-        is_approved = seek_approval(new_plan.id, original_plan_uuid)
+        approval_response = seek_approval(new_plan.plan_id, original_plan_uuid)
         database.commit_changes()
 
-        if is_approved:
+        if approval_response.is_approved:
             flash(
                 "Plan erfolgreich erstellt und genehmigt. Die Aktivierung des Plans und Gewährung der Kredite erfolgt um 10 Uhr morgens."
             )
             return redirect("/company/my_plans")
         else:
-            flash(f"Plan nicht genehmigt. Grund:\n{new_plan.approval_reason}")
+            flash(f"Plan nicht genehmigt. Grund:\n{approval_response.reason}")
             return redirect(
                 url_for("main_company.create_plan", original_plan_id=original_plan_id)
             )

--- a/tests/test_seek_approval.py
+++ b/tests/test_seek_approval.py
@@ -13,8 +13,8 @@ def test_that_any_plan_will_be_approved(
 ):
     new_plan = plan_generator.create_plan()
     original_plan = plan_generator.create_plan()
-    seek_approval(new_plan.id, original_plan.id)
-    assert new_plan.approved
+    approval_response = seek_approval(new_plan.id, original_plan.id)
+    assert approval_response.is_approved
 
 
 @injection_test
@@ -24,8 +24,8 @@ def test_that_any_plan_will_be_approved_and_original_plan_renewed(
 ):
     new_plan = plan_generator.create_plan()
     original_plan = plan_generator.create_plan()
-    seek_approval(new_plan.id, original_plan.id)
-    assert new_plan.approved
+    approval_response = seek_approval(new_plan.id, original_plan.id)
+    assert approval_response.is_approved
     assert original_plan.renewed
 
 
@@ -36,8 +36,8 @@ def test_that_true_is_returned(
 ):
     new_plan = plan_generator.create_plan()
     original_plan = plan_generator.create_plan()
-    is_approval = seek_approval(new_plan.id, original_plan.id)
-    assert is_approval is True
+    approval_response = seek_approval(new_plan.id, original_plan.id)
+    assert approval_response.is_approved is True
 
 
 @injection_test


### PR DESCRIPTION
Es wird ein response model fuer die beiden gennannten use cases eingefuehrt. Dieser PR ist nicht zuletzt vorbereitung darauf, dass wir die neuen ApprovedPlan und ProposedPlan entities Problemlos einfuehren koennen.