### PR TITLE
Vereinfache CalculatePlanExpiration... use case

### DIFF
--- a/arbeitszeit/use_cases/calculate_plan_expiration.py
+++ b/arbeitszeit/use_cases/calculate_plan_expiration.py
@@ -14,7 +14,11 @@ class CalculatePlanExpirationAndCheckIfExpired:
     datetime_service: DatetimeService
     plan_repository: PlanRepository
 
-    def __call__(self, plan: Plan) -> None:
+    def __call__(self) -> None:
+        for plan in self.plan_repository.all_active_plans():
+            self._calculate_plan_expiration(plan)
+
+    def _calculate_plan_expiration(self, plan: Plan) -> None:
         assert plan.is_active, "Plan is not active!"
         assert plan.activation_date, "Plan has no activation date!"
         activation_day = datetime.date(

--- a/project/commands.py
+++ b/project/commands.py
@@ -15,12 +15,6 @@ def activate_database_plans(
     """
     run once per day on the production server at time stored in DatetimeService().time_of_synchronized_plan_activation.
     """
-    all_active_plans = plan_repository.all_active_plans()
-    for plan in all_active_plans:
-        calculate_expiration(plan)
-
+    calculate_expiration()
     synchronized_plan_activation()
-
-    all_active_plans = plan_repository.all_active_plans()
-    for plan in all_active_plans:
-        calculate_expiration(plan)
+    calculate_expiration()

--- a/tests/test_calculate_plan_expiration_and_check_if_expired.py
+++ b/tests/test_calculate_plan_expiration_and_check_if_expired.py
@@ -1,7 +1,5 @@
 import datetime
 
-import pytest
-
 from arbeitszeit.use_cases import CalculatePlanExpirationAndCheckIfExpired
 from tests.data_generators import PlanGenerator
 from tests.datetime_service import FakeDatetimeService
@@ -9,13 +7,13 @@ from tests.dependency_injection import injection_test
 
 
 @injection_test
-def test_that_assertion_error_is_raised_when_plan_is_inactive(
+def test_that_a_plan_that_is_not_active_can_not_expire(
     plan_generator: PlanGenerator,
     calculate_plan_expiration_and_check_if_expired: CalculatePlanExpirationAndCheckIfExpired,
 ):
     plan = plan_generator.create_plan()
-    with pytest.raises(AssertionError, match="Plan is not active!"):
-        calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
+    assert not plan.expired
 
 
 @injection_test
@@ -30,7 +28,7 @@ def test_that_expiration_time_is_set_if_plan_is_active(
 
     assert not plan.expiration_date
     assert not plan.expiration_relative
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
     assert plan.expiration_relative
     assert plan.expiration_date
 
@@ -52,7 +50,7 @@ def test_that_expiration_date_is_correctly_calculated_after_fixed_activation_tim
     plan = plan_generator.create_plan(
         timeframe=1, activation_date=datetime_service.now_minus_one_day()
     )
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
 
     # expected to expire today
     expected_expiration_date = datetime.datetime(
@@ -81,7 +79,7 @@ def test_that_expiration_date_is_correctly_calculated_before_fixed_activation_ti
     plan = plan_generator.create_plan(
         timeframe=1, activation_date=datetime_service.now_minus_one_day()
     )
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
 
     # expected to expire today
     expected_expiration_date = datetime.datetime(
@@ -108,7 +106,7 @@ def test_that_expiration_relative_is_correctly_calculated(
     plan = plan_generator.create_plan(
         timeframe=1, activation_date=datetime_service.now_minus_one_day()
     )
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
 
     expected_expiration_relative = 0
     assert plan.expiration_relative == expected_expiration_relative
@@ -129,7 +127,7 @@ def test_that_plan_is_not_set_to_expired_if_still_in_timeframe(
     plan = plan_generator.create_plan(
         timeframe=1, activation_date=datetime_service.now_minus_one_day()
     )
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
     assert not plan.expired
 
 
@@ -148,5 +146,5 @@ def test_that_plan_is_set_to_expired_if_timeframe_is_expired(
     plan = plan_generator.create_plan(
         timeframe=1, activation_date=datetime_service.now_minus_one_day()
     )
-    calculate_plan_expiration_and_check_if_expired(plan)
+    calculate_plan_expiration_and_check_if_expired()
     assert plan.expired


### PR DESCRIPTION
Ich habe mir mal erlaubt, den use case zur Planaktivierung zu vereinfachen. Es ist ja eigentlich so, dass der use case zum Berechnen des Ablaufdatums ist folgendermassen formuliert werden kann:

Pruefe alle aktiven Plaene und berechne das Ablaufdatum. Wenn ein Plan abgelaufen ist, markiere ihn entsprechend.

Ein Test musste entsprechend angepasst werden.