### PR TITLE
Implement proper response model for QueryProducts

### DIFF
--- a/arbeitszeit/use_cases/query_products.py
+++ b/arbeitszeit/use_cases/query_products.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import enum
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable, Optional
+from typing import List, Optional
 from uuid import UUID
 
 from injector import inject
@@ -17,6 +19,11 @@ class ProductFilter(enum.Enum):
 
 @dataclass
 class ProductQueryResponse:
+    results: List[QueriedProduct]
+
+
+@dataclass
+class QueriedProduct:
     offer_id: UUID
     seller_name: str
     seller_email: str
@@ -34,17 +41,20 @@ class QueryProducts:
 
     def __call__(
         self, query: Optional[str], filter_by: ProductFilter
-    ) -> Iterable[ProductQueryResponse]:
+    ) -> ProductQueryResponse:
         if query is None:
             found_offers = self.offer_repository.all_active_offers()
         elif filter_by == ProductFilter.by_name:
             found_offers = self.offer_repository.query_offers_by_name(query)
         else:
             found_offers = self.offer_repository.query_offers_by_description(query)
-        return (self._offer_to_response_model(offer) for offer in found_offers)
-
-    def _offer_to_response_model(self, offer: ProductOffer) -> ProductQueryResponse:
+        results = [self._offer_to_response_model(offer) for offer in found_offers]
         return ProductQueryResponse(
+            results=results,
+        )
+
+    def _offer_to_response_model(self, offer: ProductOffer) -> QueriedProduct:
+        return QueriedProduct(
             offer_id=offer.id,
             seller_name=offer.plan.planner.name,
             seller_email=offer.plan.planner.email,

--- a/project/company/routes.py
+++ b/project/company/routes.py
@@ -106,7 +106,7 @@ def suchen(query_products: use_cases.QueryProducts):
             product_filter = use_cases.ProductFilter.by_name
         elif search_field == "Beschreibung":
             product_filter = use_cases.ProductFilter.by_description
-    results = list(query_products(query, product_filter))
+    results = query_products(query, product_filter).results
 
     if not results:
         flash("Keine Ergebnisse!")

--- a/project/member/routes.py
+++ b/project/member/routes.py
@@ -58,7 +58,7 @@ def suchen(
             product_filter = use_cases.ProductFilter.by_name
         elif search_field == "Beschreibung":
             product_filter = use_cases.ProductFilter.by_description
-    results = list(query_products(query, product_filter))
+    results = query_products(query, product_filter).results
 
     if not results:
         flash("Keine Ergebnisse!")

--- a/tests/use_cases/test_query_product.py
+++ b/tests/use_cases/test_query_product.py
@@ -1,5 +1,3 @@
-from typing import Iterable
-
 from arbeitszeit.entities import ProductOffer
 from arbeitszeit.use_cases import ProductFilter, ProductQueryResponse, QueryProducts
 from tests.data_generators import OfferGenerator
@@ -8,20 +6,18 @@ from .dependency_injection import injection_test
 from .repositories import OfferRepository
 
 
-def offer_in_results(
-    offer: ProductOffer, results: Iterable[ProductQueryResponse]
-) -> bool:
-    return offer.id in [result.offer_id for result in results]
+def offer_in_results(offer: ProductOffer, response: ProductQueryResponse) -> bool:
+    return offer.id in [result.offer_id for result in response.results]
 
 
 @injection_test
 def test_that_no_offer_is_returned_when_searching_an_empty_repository(
     query_products: QueryProducts,
 ):
-    results = list(query_products(None, ProductFilter.by_name))
-    assert not results
-    results = list(query_products(None, ProductFilter.by_description))
-    assert not results
+    response = query_products(None, ProductFilter.by_name)
+    assert not response.results
+    response = query_products(None, ProductFilter.by_description)
+    assert not response.results
 
 
 @injection_test
@@ -31,8 +27,8 @@ def test_that_offers_where_name_is_exact_match_are_returned(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
-    results = list(query_products("My Product", ProductFilter.by_name))
-    assert offer_in_results(expected_offer, results)
+    response = query_products("My Product", ProductFilter.by_name)
+    assert offer_in_results(expected_offer, response)
 
 
 @injection_test
@@ -42,8 +38,8 @@ def test_query_substring_of_name_returns_correct_result(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(name="My Product")
-    results = list(query_products("Product", ProductFilter.by_name))
-    assert offer_in_results(expected_offer, results)
+    response = query_products("Product", ProductFilter.by_name)
+    assert offer_in_results(expected_offer, response)
 
 
 @injection_test
@@ -54,8 +50,8 @@ def test_that_offers_where_description_is_exact_match_are_returned(
 ):
     description = "my description"
     expected_offer = offer_generator.create_offer(description=description)
-    results = list(query_products(description, ProductFilter.by_description))
-    assert offer_in_results(expected_offer, results)
+    response = query_products(description, ProductFilter.by_description)
+    assert offer_in_results(expected_offer, response)
 
 
 @injection_test
@@ -65,5 +61,5 @@ def test_query_substrin_of_description_returns_correct_result(
     offer_generator: OfferGenerator,
 ):
     expected_offer = offer_generator.create_offer(description="my description")
-    results = list(query_products("description", ProductFilter.by_description))
-    assert offer_in_results(expected_offer, results)
+    response = query_products("description", ProductFilter.by_description)
+    assert offer_in_results(expected_offer, response)


### PR DESCRIPTION
Reines Refactoring:

Es wurde eine echtest Responsemodel fuer den QueryProducts use case eingefuehrt um der angestrebten clean architecture besser zu entsprechen.