### PR TITLE
Fix duplicate unit naming

### DIFF
--- a/arbeitszeit_web/query_products.py
+++ b/arbeitszeit_web/query_products.py
@@ -1,5 +1,4 @@
 from dataclasses import asdict, dataclass
-from decimal import Decimal
 from typing import Any, Dict, List, Optional, Protocol
 
 from arbeitszeit.use_cases.query_products import (
@@ -50,7 +49,7 @@ class ResultTableRow:
     product_name: str
     seller_name: str
     product_description: str
-    price_per_unit: Decimal
+    price_per_unit: str
     is_public_service: str
     contact_email: str
 
@@ -86,7 +85,7 @@ class QueryProductsPresenter:
                         product_name=result.product_name,
                         seller_name=result.seller_name,
                         product_description=result.product_description,
-                        price_per_unit=result.price_per_unit,
+                        price_per_unit=f"{result.price_per_unit} Std.",
                         is_public_service="Ja" if result.is_public_service else "Nein",
                         contact_email=f"mailto:{result.seller_email}",
                     )

--- a/project/templates/macros.html
+++ b/project/templates/macros.html
@@ -131,7 +131,7 @@
                 <td>{{ column.product_name }}</td>
                 <td>{{ column.seller_name }}</td>
                 <td>{{ column.product_description }}</td>
-                <td>{{ column.price_per_unit }} Std.</td>
+                <td>{{ column.price_per_unit }}</td>
                 <td>{{ column.is_public_service }}</td>
                 <td>
                     <a href="{{ column.contact_email }}">


### PR DESCRIPTION
Hier noch ein Mini-PR. Dieser PR löst einen Darstellungsfehler (Duplikat der Einheit "Std."), welcher in den Produktsuchen (`company` und `member`) auftaucht - Screenshot:

![image](https://user-images.githubusercontent.com/3404313/134727864-9a958d62-0cc5-4ee1-851d-2f43d063e6a1.png)
