### PR TITLE
DRAFT PlanDraft hat nicht gleichen Planner wie zu Beginn angegeben

### DIFF
--- a/arbeitszeit/entities.py
+++ b/arbeitszeit/entities.py
@@ -40,34 +40,15 @@ class Member:
         return [self.account]
 
 
+@dataclass
 class Company:
-    def __init__(
-        self,
-        id: UUID,
-        email: str,
-        name: str,
-        means_account: Account,
-        raw_material_account: Account,
-        work_account: Account,
-        product_account: Account,
-    ) -> None:
-        self._id = id
-        self.email = email
-        self.name = name
-        self.means_account = means_account
-        self.raw_material_account = raw_material_account
-        self.work_account = work_account
-        self.product_account = product_account
-
-    @property
-    def id(self) -> UUID:
-        return self._id
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, Company):
-            return self.id == other.id
-
-        return False
+    id: UUID
+    email: str
+    name: str
+    means_account: Account
+    raw_material_account: Account
+    work_account: Account
+    product_account: Account
 
     def accounts(self) -> List[Account]:
         return [

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -222,7 +222,6 @@ class PlanGenerator:
             planner = self.company_generator.create_company()
         if timeframe is None:
             timeframe = 14
-        planner = self.company_generator.create_company()
         draft = self.draft_repository.create_plan_draft(
             planner=planner.id,
             product_name=product_name,

--- a/tests/use_cases/test_create_plan_draft.py
+++ b/tests/use_cases/test_create_plan_draft.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 
 from arbeitszeit.entities import ProductionCosts
 from arbeitszeit.use_cases import CreatePlanDraft, CreatePlanDraftRequest
-from tests.data_generators import CompanyGenerator
+from tests.data_generators import CompanyGenerator, PlanGenerator
 
 from .dependency_injection import injection_test
 from .repositories import PlanDraftRepository
@@ -33,3 +33,13 @@ def test_that_create_plan_creates_a_plan_draft(
     assert not len(plan_draft_repository)
     create_plan_draft(request)
     assert len(plan_draft_repository) == 1
+
+
+@injection_test
+def test_that_drafted_plan_has_same_planner_as_specified_on_creation(
+    plan_generator: PlanGenerator,
+    company_generator: CompanyGenerator,
+) -> None:
+    planner = company_generator.create_company()
+    draft = plan_generator.draft_plan(planner=planner)
+    assert draft.planner.id == planner.id

--- a/tests/use_cases/test_seek_approval.py
+++ b/tests/use_cases/test_seek_approval.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from arbeitszeit.repositories import PlanDraftRepository, PlanRepository
 from arbeitszeit.use_cases import SeekApproval
-from tests.data_generators import PlanGenerator, CompanyGenerator
+from tests.data_generators import CompanyGenerator, PlanGenerator
 from tests.datetime_service import FakeDatetimeService
 
 from .dependency_injection import injection_test
@@ -77,5 +77,5 @@ def test_that_approved_plan_has_same_planner_as_draft(
     company_generator: CompanyGenerator,
 ):
     planner = company_generator.create_company()
-    plan_draft = plan_generator.draft_plan(planner)
+    plan_draft = plan_generator.draft_plan(planner=planner)
     assert plan_draft.planner.id == planner.id


### PR DESCRIPTION
@seppeljordan könntest du dir mal dieses Problem in der Test-Suite anschauen? Ich komme nicht drauf, wieso sich der DraftPlan nicht den gleichen Planner hat wie zu Beginn in draft_plan angegeben. Irgendwo muss da ein Bug sein, denke ich.