### PR TITLE
Remove obsolete method for my_plans routs

### DIFF
--- a/project/company/routes.py
+++ b/project/company/routes.py
@@ -197,7 +197,7 @@ def create_plan(
     return render_template("company/create_plan.html", original_plan=original_plan)
 
 
-@main_company.route("/company/my_plans", methods=["GET", "POST"])
+@main_company.route("/company/my_plans", methods=["GET"])
 @login_required
 @with_injection
 def my_plans(


### PR DESCRIPTION
Ich glaube bei der `my_plans` route brauchen wir keine post requests zuzulassen