### PR TITLE
Emacsconfig fuer Templateeinrueckung mit 2 Leerzeichen

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,3 @@
-((html-mode . ((sgml-basic-offset . 4)))
- (js-mode . ((tab-width . 4)
-	     (js-indent-level . 4))))
+((html-mode . ((sgml-basic-offset . 2)))
+ (js-mode . ((tab-width . 2)
+	     (js-indent-level . 2))))


### PR DESCRIPTION
Der PR aendert nur eine emacs config Datei, sollte also nur Emacsnutzer*innen betreffen.