### PR TITLE
Refaktorierung von Repositories

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
 from decimal import Decimal
-from typing import Iterator, List, Optional, Union
+from typing import Iterable, Iterator, List, Optional, Union
 from uuid import UUID
 
 from arbeitszeit.entities import (
@@ -26,11 +26,11 @@ class CompanyWorkerRepository(ABC):
         pass
 
     @abstractmethod
-    def get_company_workers(self, company: Company) -> List[Member]:
+    def get_company_workers(self, company: Company) -> Iterable[Member]:
         pass
 
     @abstractmethod
-    def get_member_workplaces(self, member: UUID) -> List[Company]:
+    def get_member_workplaces(self, member: UUID) -> Iterable[Company]:
         pass
 
 
@@ -252,7 +252,7 @@ class MemberRepository(ABC):
         pass
 
     @abstractmethod
-    def get_by_id(self, id: UUID) -> Member:
+    def get_by_id(self, id: UUID) -> Optional[Member]:
         pass
 
 
@@ -283,7 +283,7 @@ class CompanyRepository(ABC):
         pass
 
     @abstractmethod
-    def get_by_id(self, id: UUID) -> Company:
+    def get_by_id(self, id: UUID) -> Optional[Company]:
         pass
 
     @abstractmethod

--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -66,7 +66,6 @@ __all__ = [
     "PayMeansOfProduction",
     "PayMeansOfProductionRequest",
     "PlanFilter",
-    "PlanProposal",
     "PlanQueryResponse",
     "PlanSummaryResponse",
     "PlanSummarySuccess",

--- a/arbeitszeit/use_cases/get_member_profile_info.py
+++ b/arbeitszeit/use_cases/get_member_profile_info.py
@@ -36,6 +36,7 @@ class GetMemberProfileInfo:
 
     def __call__(self, member: UUID) -> GetMemberProfileInfoResponse:
         _member = self.member_repository.get_by_id(member)
+        assert _member is not None
         workplaces = [
             Workplace(
                 workplace_name=workplace.name,

--- a/arbeitszeit/use_cases/pay_consumer_product/__init__.py
+++ b/arbeitszeit/use_cases/pay_consumer_product/__init__.py
@@ -80,8 +80,10 @@ class PayConsumerProduct:
     def _create_product_transaction(
         self, plan: Plan, request: PayConsumerProductRequest
     ) -> ConsumerProductTransaction:
+        buyer = self.member_repository.get_by_id(request.get_buyer_id())
+        assert buyer is not None
         return self.transaction_factory.create_consumer_product_transaction(
-            buyer=self.member_repository.get_by_id(request.get_buyer_id()),
+            buyer=buyer,
             plan=plan,
             amount=request.get_amount(),
         )

--- a/arbeitszeit/use_cases/pay_means_of_production.py
+++ b/arbeitszeit/use_cases/pay_means_of_production.py
@@ -55,6 +55,7 @@ class PayMeansOfProduction:
         except PayMeansOfProductionResponse.RejectionReason as reason:
             return PayMeansOfProductionResponse(rejection_reason=reason)
         buyer = self.company_repository.get_by_id(request.buyer)
+        assert buyer is not None
         payment = self.payment_factory.get_payment(plan, buyer, request.amount, purpose)
         payment.record_purchase()
         payment.create_transaction()

--- a/project/error.py
+++ b/project/error.py
@@ -6,13 +6,5 @@ class ProductOfferNotFound(ObjectNotFound):
     pass
 
 
-class MemberNotFound(ObjectNotFound):
-    pass
-
-
-class CompanyNotFound(ObjectNotFound):
-    pass
-
-
 class PlanNotFound(ObjectNotFound):
     pass

--- a/project/member/routes.py
+++ b/project/member/routes.py
@@ -51,7 +51,8 @@ def my_purchases(
     if not user_is_member():
         return redirect(url_for("auth.zurueck"))
 
-    member = member_repository.get_member_by_id(current_user.id)
+    member = member_repository.get_by_id(current_user.id)
+    assert member is not None
     purchases = list(query_purchases(member))
     return render_template("member/my_purchases.html", purchases=purchases)
 

--- a/tests/flask_integration/test_company_repository.py
+++ b/tests/flask_integration/test_company_repository.py
@@ -1,10 +1,7 @@
 from uuid import uuid4
 
-import pytest
-
 from arbeitszeit.entities import AccountTypes
 from project.database.repositories import AccountRepository, CompanyRepository
-from project.error import CompanyNotFound
 from tests.data_generators import CompanyGenerator
 
 from .dependency_injection import injection_test
@@ -28,8 +25,7 @@ def test_company_repository_can_convert_to_and_from_orm_without_changing_the_obj
 def test_cannot_retrieve_company_from_arbitrary_uuid(
     company_repository: CompanyRepository,
 ):
-    with pytest.raises(CompanyNotFound):
-        company_repository.get_by_id(uuid4())
+    assert company_repository.get_by_id(uuid4()) is None
 
 
 @injection_test

--- a/tests/flask_integration/test_member_repository.py
+++ b/tests/flask_integration/test_member_repository.py
@@ -1,10 +1,7 @@
 from uuid import uuid4
 
-import pytest
-
 from arbeitszeit.entities import AccountTypes
 from project.database.repositories import AccountRepository, MemberRepository
-from project.error import MemberNotFound
 from tests.data_generators import MemberGenerator
 
 from .dependency_injection import injection_test
@@ -27,20 +24,12 @@ def test_that_users_can_be_converted_from_and_to_orm_objects(
 
 
 @injection_test
-def test_that_members_cannot_be_retrieved_when_db_is_empty(
-    member_repository: MemberRepository,
-):
-    with pytest.raises(MemberNotFound):
-        member_repository.get_member_by_id(uuid4())
-
-
-@injection_test
 def test_that_member_can_be_retrieved_by_its_id(
     repository: MemberRepository,
     member_generator: MemberGenerator,
 ):
     expected_member = member_generator.create_member()
-    assert repository.get_member_by_id(expected_member.id) == expected_member
+    assert repository.get_by_id(expected_member.id) == expected_member
 
 
 @injection_test
@@ -68,3 +57,11 @@ def test_count_one_registered_member_when_one_was_created(
 ) -> None:
     generator.create_member()
     assert repository.count_registered_members() == 1
+
+
+@injection_test
+def test_get_by_id_returns_none_when_member_does_not_exist(
+    repository: MemberRepository,
+) -> None:
+    member = repository.get_by_id(uuid4())
+    assert member is None


### PR DESCRIPTION
Hi,

mit dieser Aenderung, werden zwei "Kleinigkeiten" veraendert, von denen ich denke, dass sie den Code expressiver und leichter verstaendlich machen:

Die `get_by_id`-Methoden von `MemberRepository` und `CompanyRepository` geben nun `Optional[Member]` bzw. `Optional[Company]` zurueck. Es sollen keine Exceptions mehr geworfen werden, wenn ein bestimmtes "Objekt" nicht in der Datenbank gefunden wird, sondern statt dess `None` zurueck gegeben.

Zu dem geben die Methoden `get_company_workers` und `get_member_workplaces` nun ein `Iterable` statt einer `List` zurueck. Dies macht die Implemtierung in den einzelnen Repositories flexibler.