### PR TITLE
Löschen von eigenen Angeboten scheitert

### DIFF
--- a/arbeitszeit/use_cases/delete_offer.py
+++ b/arbeitszeit/use_cases/delete_offer.py
@@ -25,7 +25,7 @@ class DeleteOffer:
 
     def __call__(self, deletion: DeleteOfferRequest) -> DeleteOfferResponse:
         planner = self.offer_repository.get_by_id(deletion.offer_id).plan.planner
-        if planner.id is not deletion.requesting_company_id:
+        if not planner.id == deletion.requesting_company_id:
             return DeleteOfferResponse(offer_id=deletion.offer_id, is_success=False)
         self.offer_repository.delete_offer(deletion.offer_id)
         return DeleteOfferResponse(offer_id=deletion.offer_id, is_success=True)

--- a/project/company/routes.py
+++ b/project/company/routes.py
@@ -406,7 +406,7 @@ def delete_offer(
 
     if request.method == "POST":
         deletion_request = DeleteOfferRequest(
-            requesting_company_id=current_user.id,
+            requesting_company_id=UUID(current_user.id),
             offer_id=offer_id,
         )
         response = delete_offer(deletion_request)


### PR DESCRIPTION
Fixes #173

Der Bug scheint zwei Gründe zu haben: 
1) Im route ist current_user.id kein UUID-Objekt sondern ein String. --> Umwandlung in UUID noch in route.
2) Der "is not"-Vergleich der Ids funktioniert nicht wie erwartet. --> Ersetzung durch den "=="-Operator

Der Bug wurde nicht durch die Tests entdeckt, weil wir noch keine View-Tests für diesen Use Case haben. 

Der neue Code wurde in der App getestet.