### PR TITLE
implement request_cooperation for web

### DIFF
--- a/arbeitszeit_web/request_cooperation.py
+++ b/arbeitszeit_web/request_cooperation.py
@@ -1,0 +1,103 @@
+from dataclasses import dataclass
+from typing import List, Protocol, Union
+from uuid import UUID
+
+from arbeitszeit.use_cases import RequestCooperationRequest, RequestCooperationResponse
+
+from .session import Session
+
+
+@dataclass
+class RequestCooperationViewModel:
+    notifications: List[str]
+    is_error: bool
+
+
+class RequestCooperationPresenter:
+    def present(
+        self, use_case_response: RequestCooperationResponse
+    ) -> RequestCooperationViewModel:
+        notifications = []
+        if not use_case_response.is_rejected:
+            notifications.append("Anfrage wurde gestellt.")
+            is_error = False
+        else:
+            is_error = True
+            if (
+                use_case_response.rejection_reason
+                == RequestCooperationResponse.RejectionReason.plan_not_found
+            ):
+                notifications.append("Plan nicht gefunden.")
+            elif (
+                use_case_response.rejection_reason
+                == RequestCooperationResponse.RejectionReason.cooperation_not_found
+            ):
+                notifications.append("Kooperation nicht gefunden.")
+            elif (
+                use_case_response.rejection_reason
+                == RequestCooperationResponse.RejectionReason.plan_inactive
+            ):
+                notifications.append("Plan nicht aktiv.")
+            elif use_case_response.rejection_reason in (
+                RequestCooperationResponse.RejectionReason.plan_has_cooperation,
+                RequestCooperationResponse.RejectionReason.plan_already_part_of_cooperation,
+                RequestCooperationResponse.RejectionReason.plan_is_already_requesting_cooperation,
+            ):
+                notifications.append(
+                    "Plan kooperiert bereits oder hat Kooperation angefragt."
+                )
+            elif (
+                use_case_response.rejection_reason
+                == RequestCooperationResponse.RejectionReason.plan_is_public_service
+            ):
+                notifications.append("Öffentliche Pläne können nicht kooperieren.")
+            elif (
+                use_case_response.rejection_reason
+                == RequestCooperationResponse.RejectionReason.requester_is_not_planner
+            ):
+                notifications.append(
+                    "Nur der Ersteller des Plans kann Kooperation anfragen."
+                )
+        return RequestCooperationViewModel(
+            notifications=notifications, is_error=is_error
+        )
+
+
+class RequestCooperationForm(Protocol):
+    def get_plan_id_string(self) -> str:
+        ...
+
+    def get_cooperation_id_string(self) -> str:
+        ...
+
+
+@dataclass
+class RequestCooperationController:
+    session: Session
+
+    @dataclass
+    class MalformedInputData:
+        field: str
+        message: str
+
+    def import_form_data(
+        self, form: RequestCooperationForm
+    ) -> Union[RequestCooperationRequest, MalformedInputData, None]:
+        current_user = self.session.get_current_user()
+        if current_user is None:
+            return None
+        try:
+            plan_uuid = UUID(form.get_plan_id_string())
+        except ValueError:
+            return self.MalformedInputData("plan_id", "Plan-ID ist ungültig.")
+        try:
+            cooperation_uuid = UUID(form.get_cooperation_id_string())
+        except ValueError:
+            return self.MalformedInputData(
+                "cooperation_id", "Kooperations-ID ist ungültig."
+            )
+        return RequestCooperationRequest(
+            requester_id=current_user,
+            plan_id=plan_uuid,
+            cooperation_id=cooperation_uuid,
+        )

--- a/project/company/routes.py
+++ b/project/company/routes.py
@@ -12,6 +12,7 @@ from arbeitszeit.use_cases import (
     GetDraftSummary,
     GetPlanSummary,
     ListMessages,
+    RequestCooperation,
     ToggleProductAvailability,
 )
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
@@ -31,6 +32,10 @@ from arbeitszeit_web.query_companies import (
     QueryCompaniesPresenter,
 )
 from arbeitszeit_web.query_plans import QueryPlansController, QueryPlansPresenter
+from arbeitszeit_web.request_cooperation import (
+    RequestCooperationController,
+    RequestCooperationPresenter,
+)
 from arbeitszeit_web.show_my_plans import ShowMyPlansPresenter
 from project.database import (
     AccountRepository,
@@ -39,7 +44,12 @@ from project.database import (
     MemberRepository,
     commit_changes,
 )
-from project.forms import CompanySearchForm, CreateDraftForm, PlanSearchForm
+from project.forms import (
+    CompanySearchForm,
+    CreateDraftForm,
+    PlanSearchForm,
+    RequestCooperationForm,
+)
 from project.models import Company
 from project.template import UserTemplateRenderer
 from project.url_index import CompanyUrlIndex
@@ -48,6 +58,7 @@ from project.views import (
     ListMessagesView,
     QueryCompaniesView,
     QueryPlansView,
+    RequestCooperationView,
 )
 
 from .blueprint import CompanyRoute
@@ -450,6 +461,33 @@ def create_cooperation(
         )
     elif request.method == "GET":
         return template_renderer.render_template("company/create_cooperation.html")
+
+
+@CompanyRoute("/company/request_cooperation", methods=["GET", "POST"])
+@commit_changes
+def request_cooperation(
+    use_case: RequestCooperation,
+    controller: RequestCooperationController,
+    presenter: RequestCooperationPresenter,
+    template_renderer: UserTemplateRenderer,
+):
+    http_404_view = Http404View("company/404.html", template_renderer)
+    form = RequestCooperationForm(request.form)
+    view = RequestCooperationView(
+        form=form,
+        request_cooperation=use_case,
+        controller=controller,
+        presenter=presenter,
+        not_found_view=http_404_view,
+        template_name="company/request_cooperation.html",
+        template_renderer=template_renderer,
+    )
+
+    if request.method == "POST":
+        return view.respond_to_post()
+
+    elif request.method == "GET":
+        return view.respond_to_get()
 
 
 @CompanyRoute("/company/hilfe")

--- a/project/database/repositories.py
+++ b/project/database/repositories.py
@@ -446,8 +446,8 @@ class PlanRepository(repositories.PlanRepository):
             activation_date=plan.activation_date,
             active_days=plan.active_days,
             payout_count=plan.payout_count,
-            requested_cooperation=None,
-            cooperation=None,
+            requested_cooperation=plan.requested_cooperation,
+            cooperation=plan.cooperation,
             is_available=plan.is_available,
         )
 
@@ -1028,7 +1028,9 @@ class CooperationRepository(repositories.CooperationRepository):
         ...
 
     def set_requested_cooperation(self, plan_id: UUID, cooperation_id: UUID) -> None:
-        ...
+        plan_orm = Plan.query.filter_by(id=str(plan_id)).first()
+        assert plan_orm
+        plan_orm.requested_cooperation = str(cooperation_id)
 
     def set_requested_cooperation_to_none(self, plan_id: UUID) -> None:
         ...

--- a/project/dependency_injection.py
+++ b/project/dependency_injection.py
@@ -21,6 +21,7 @@ from arbeitszeit_web.check_for_unread_message import (
     CheckForUnreadMessagesPresenter,
 )
 from arbeitszeit_web.list_messages import ListMessagesController
+from arbeitszeit_web.request_cooperation import RequestCooperationController
 from project.database import get_social_accounting
 from project.database.repositories import (
     AccountOwnerRepository,
@@ -75,6 +76,12 @@ class FlaskModule(Module):
         self, session: FlaskSession
     ) -> ListMessagesController:
         return ListMessagesController(session)
+
+    @provider
+    def provide_request_cooperation_controller(
+        self, session: FlaskSession
+    ) -> RequestCooperationController:
+        return RequestCooperationController(session)
 
     def configure(self, binder: Binder) -> None:
         binder.bind(

--- a/project/forms.py
+++ b/project/forms.py
@@ -155,3 +155,14 @@ class CreateDraftForm(Form):
 
     def get_action_string(self) -> str:
         return self.data["action"]
+
+
+class RequestCooperationForm(Form):
+    plan_id = StringField()
+    cooperation_id = StringField()
+
+    def get_plan_id_string(self) -> str:
+        return self.data["plan_id"]
+
+    def get_cooperation_id_string(self) -> str:
+        return self.data["cooperation_id"]

--- a/project/templates/base_company.html
+++ b/project/templates/base_company.html
@@ -9,7 +9,7 @@
         </div>
 
         <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
-           data-target="navbarOnTop">
+          data-target="navbarOnTop">
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
           <span aria-hidden="true"></span>
@@ -41,17 +41,20 @@
 
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link">
-              Kooperationen (BETA)
+              Kooperationen
             </a>
             <div class="navbar-dropdown">
               <a href="{{ url_for('main_company.create_cooperation') }}" class="navbar-item">
-                Neue Kooperation (BETA)
+                Neue Kooperation
               </a>
-              <a href="" class="navbar-item">
-                Kooperation beitreten (BETA)
+              <a href="{{ url_for('main_company.request_cooperation') }}" class="navbar-item">
+                Kooperation beitreten
               </a>
               <a href="" class="navbar-item">
                 Meine Kooperationen (BETA)
+              </a>
+              <a href="" class="navbar-item">
+                Alle Kooperationen (BETA)
               </a>
             </div>
           </div>
@@ -97,10 +100,10 @@
             Meine Daten
           </a>
 
-	  <a href="{{ url_for('main_company.list_messages') }}"
-	     class="navbar-item {% if message_indicator.show_unread_messages_indicator %}unread-messages-indicator{% endif %}">
-	    Nachrichten
-	  </a>
+          <a href="{{ url_for('main_company.list_messages') }}"
+            class="navbar-item {% if message_indicator.show_unread_messages_indicator %}unread-messages-indicator{% endif %}">
+            Nachrichten
+          </a>
           {% endif %}
 
         </div>
@@ -117,7 +120,7 @@
               <a class="button" href="{{ url_for('auth.zurueck') }}">
                 Zurück
               </a>
-	      {% else %}
+              {% else %}
               <a class="button" href="{{ url_for('auth.logout') }}">
                 Logout
               </a>

--- a/project/templates/company/request_cooperation.html
+++ b/project/templates/company/request_cooperation.html
@@ -1,0 +1,71 @@
+{% extends "base_company.html" %}
+
+{% block content2 %}
+<div class="columns is-centered">
+    <div class="column is-three-fifth">
+
+
+        <div class="content">
+            <h1 class="title">
+                Kooperation anfragen
+            </h1>
+        </div>
+
+        <div class="box has-background-info-light has-text-info-dark">
+            <div class="icon"><i class="fas fa-info-circle"></i></div>
+            <p>
+                Frage hier eine Kooperation an. <br><br>
+                Der "Koordinator" der Kooperation entscheidet dann darüber, ob er deinen
+                Plan zur Kooperation hinzufügt.<br>
+                Alle Pläne in einer Kooperation sollten das gleiche oder ein ähnliches Produkt anbieten.
+            </p>
+        </div>
+
+        {% if view_model %}
+        <div class="box">
+            {% for notification in view_model.notifications %}
+            <div {% if view_model.is_error %}class="notification is-danger" {% else %}class="notification is-primary" {%
+                endif %}>{{ notification }}</div>
+            {% endfor %}
+        </div>
+        {% endif %}
+
+        {% if form %}
+        {% for field_name, field_errors in form.errors|dictsort if field_errors %}
+        {% for error in field_errors %}
+        <div class="notification is-danger">
+            {{ error }}
+        </div>
+        {% endfor %}
+        {% endfor %}
+        {% endif %}
+
+        <div class="content">
+            <form method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <div class="field has-addons">
+                    <div class="control">
+                        <input class="input" type="text" placeholder="Plan-ID" , name="plan_id" required>
+                    </div>
+                    <div class="control">
+                        <input class="input" type="text" placeholder="Kooperation-ID" , name="cooperation_id" required>
+                    </div>
+                    <div class="field">
+                        <div class="control">
+                            <button class="button is-primary" name="request_coop" value="request_coop"
+                                type="submit">Kooperation anfragen</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+
+
+
+
+    </div>
+</div>
+
+
+{% endblock %}

--- a/project/views/__init__.py
+++ b/project/views/__init__.py
@@ -3,6 +3,7 @@ from .list_messages_view import ListMessagesView
 from .pay_consumer_product import PayConsumerProductView
 from .query_companies import QueryCompaniesView
 from .query_plans import QueryPlansView
+from .request_cooperation_view import RequestCooperationView
 
 __all__ = [
     "Http404View",
@@ -10,4 +11,5 @@ __all__ = [
     "PayConsumerProductView",
     "QueryPlansView",
     "QueryCompaniesView",
+    "RequestCooperationView",
 ]

--- a/project/views/request_cooperation_view.py
+++ b/project/views/request_cooperation_view.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass
+
+from flask import Response
+
+from arbeitszeit.use_cases import RequestCooperation
+from arbeitszeit_web.request_cooperation import (
+    RequestCooperationController,
+    RequestCooperationPresenter,
+)
+from arbeitszeit_web.template import TemplateRenderer
+from project.forms import RequestCooperationForm
+
+from .http_404_view import Http404View
+
+
+@dataclass
+class RequestCooperationView:
+    form: RequestCooperationForm
+    request_cooperation: RequestCooperation
+    controller: RequestCooperationController
+    presenter: RequestCooperationPresenter
+    not_found_view: Http404View
+    template_name: str
+    template_renderer: TemplateRenderer
+
+    def respond_to_get(self) -> Response:
+        return Response(self.template_renderer.render_template(self.template_name))
+
+    def respond_to_post(self) -> Response:
+        use_case_request = self.controller.import_form_data(self.form)
+        if use_case_request is None:
+            return self.not_found_view.get_response()
+        if isinstance(use_case_request, self.controller.MalformedInputData):
+            return self._handle_malformed_data(use_case_request)
+        use_case_response = self.request_cooperation(use_case_request)
+        view_model = self.presenter.present(use_case_response)
+        return Response(
+            self.template_renderer.render_template(
+                self.template_name, context=dict(view_model=view_model)
+            )
+        )
+
+    def _handle_malformed_data(
+        self, result: RequestCooperationController.MalformedInputData
+    ) -> Response:
+        field = getattr(self.form, result.field)
+        field.errors += (result.message,)
+        return Response(
+            self.template_renderer.render_template(
+                self.template_name, context=dict(form=self.form)
+            ),
+            status=400,
+        )

--- a/tests/controllers/test_request_cooperation_controller.py
+++ b/tests/controllers/test_request_cooperation_controller.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass, replace
+from unittest import TestCase
+from uuid import UUID, uuid4
+
+from arbeitszeit.use_cases import RequestCooperationRequest
+from arbeitszeit_web.request_cooperation import RequestCooperationController
+from tests.flask_integration.session import FakeSession
+
+
+@dataclass
+class FakeRequestCooperationForm:
+    plan_id: str
+    cooperation_id: str
+
+    def get_plan_id_string(self) -> str:
+        return self.plan_id
+
+    def get_cooperation_id_string(self) -> str:
+        return self.cooperation_id
+
+
+fake_form = FakeRequestCooperationForm(
+    plan_id=str(uuid4()), cooperation_id=str(uuid4())
+)
+
+
+class RequestCooperationControllerTests(TestCase):
+    def setUp(self) -> None:
+        self.session = FakeSession()
+        self.controller = RequestCooperationController(session=self.session)
+
+    def test_when_user_is_not_authenticated_then_we_cannot_get_a_use_case_request(
+        self,
+    ) -> None:
+        self.session.set_current_user_id(None)
+        self.assertIsNone(self.controller.import_form_data(form=fake_form))
+
+    def test_when_user_is_authenticated_then_the_user_is_identified_in_use_case_request(
+        self,
+    ) -> None:
+        expected_user_id = uuid4()
+        self.session.set_current_user_id(expected_user_id)
+        use_case_request = self.controller.import_form_data(form=fake_form)
+        assert use_case_request is not None
+        assert isinstance(use_case_request, RequestCooperationRequest)
+        self.assertEqual(use_case_request.requester_id, expected_user_id)
+
+    def test_returns_malformed_data_instance_if_plan_id_cannot_be_converted_to_uuid(
+        self,
+    ):
+        malformed_form = replace(fake_form, plan_id="malformed plan id")
+        self.session.set_current_user_id(uuid4())
+        use_case_request = self.controller.import_form_data(form=malformed_form)
+        assert use_case_request is not None
+        assert isinstance(
+            use_case_request, RequestCooperationController.MalformedInputData
+        )
+        self.assertEqual(use_case_request.field, "plan_id")
+        self.assertEqual(use_case_request.message, "Plan-ID ist ungültig.")
+
+    def test_returns_malformed_data_instance_if_coop_id_cannot_be_converted_to_uuid(
+        self,
+    ):
+        malformed_form = replace(fake_form, cooperation_id="malformed coop id")
+        self.session.set_current_user_id(uuid4())
+        use_case_request = self.controller.import_form_data(form=malformed_form)
+        assert use_case_request is not None
+        assert isinstance(
+            use_case_request, RequestCooperationController.MalformedInputData
+        )
+        self.assertEqual(use_case_request.field, "cooperation_id")
+        self.assertEqual(use_case_request.message, "Kooperations-ID ist ungültig.")
+
+    def test_controller_can_convert_plan_and_cooperation_id_into_correct_uuid(self):
+        self.session.set_current_user_id(uuid4())
+        use_case_request = self.controller.import_form_data(form=fake_form)
+        assert use_case_request is not None
+        assert isinstance(use_case_request, RequestCooperationRequest)
+        self.assertEqual(use_case_request.plan_id, UUID(fake_form.plan_id))
+        self.assertEqual(
+            use_case_request.cooperation_id, UUID(fake_form.cooperation_id)
+        )

--- a/tests/flask_integration/test_cooperation_repository.py
+++ b/tests/flask_integration/test_cooperation_repository.py
@@ -3,8 +3,8 @@ from unittest import TestCase
 
 import arbeitszeit.repositories
 from arbeitszeit.entities import Cooperation
-from project.database.repositories import CooperationRepository
-from tests.data_generators import CompanyGenerator
+from project.database.repositories import CooperationRepository, PlanRepository
+from tests.data_generators import CompanyGenerator, PlanGenerator
 
 from .dependency_injection import get_dependency_injector
 
@@ -13,7 +13,9 @@ class CooperationRepositoryTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
         self.company_generator = self.injector.get(CompanyGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
         self.repo = self.injector.get(CooperationRepository)
+        self.plan_repo = self.injector.get(PlanRepository)
         self.DEFAULT_CREATE_ARGUMENTS = dict(
             creation_timestamp=datetime.now(),
             name="test name",
@@ -68,3 +70,12 @@ class CooperationRepositoryTests(TestCase):
         self.repo.create_cooperation(**self.DEFAULT_CREATE_ARGUMENTS)
         query = "test"
         self.assertFalse(list(self.repo.get_by_name(query)))
+
+    def test_possible_to_set_requested_cooperation_attribute(self):
+        cooperation = self.repo.create_cooperation(**self.DEFAULT_CREATE_ARGUMENTS)
+        plan = self.plan_generator.create_plan()
+
+        self.repo.set_requested_cooperation(plan.id, cooperation.id)
+
+        plan_from_orm = self.plan_repo.get_plan_by_id(plan.id)
+        self.assertTrue(plan_from_orm.requested_cooperation)

--- a/tests/flask_integration/test_request_cooperation_view.py
+++ b/tests/flask_integration/test_request_cooperation_view.py
@@ -1,0 +1,81 @@
+from uuid import uuid4
+
+from .flask import ViewTestCase
+
+
+class LoggedInMemberTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.member, _ = self.login_member()
+        self.url = "/company/request_cooperation"
+
+    def test_member_gets_redirected_when_trying_to_access_company_page(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+
+
+class NotLoggedInCompanyTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/company/request_cooperation"
+
+    def test_company_gets_302_status_when_not_logged_in(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)
+
+
+class LoggedInCompanyTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company, _ = self.login_company()
+        self.url = "/company/request_cooperation"
+
+    def test_company_gets_200_status_when_opening_view(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_posting_without_data_results_in_400(self) -> None:
+        response = self.client.post(self.url)
+        self.assertEqual(response.status_code, 400)
+
+    def test_posting_malformed_plan_id_data_results_in_400(
+        self,
+    ) -> None:
+        response = self.client.post(
+            self.url, data=dict(plan_id="no uuid", cooperation_id=str(uuid4()))
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_posting_malformed_coop_id_data_results_in_400(
+        self,
+    ) -> None:
+        response = self.client.post(
+            self.url, data=dict(plan_id=str(uuid4()), cooperation_id="no uuid")
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_error_message_shows_up_when_posting_malformed_coop_id_data(
+        self,
+    ) -> None:
+        response = self.client.post(
+            self.url, data=dict(plan_id=str(uuid4()), cooperation_id="no uuid")
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Kooperations-ID ist ungültig", response.get_data(as_text=True))
+
+    def test_error_message_shows_up_when_posting_malformed_plan_id_data(
+        self,
+    ) -> None:
+        response = self.client.post(
+            self.url, data=dict(plan_id="no uuid", cooperation_id=str(uuid4()))
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Plan-ID ist ungültig", response.get_data(as_text=True))
+
+    def test_posting_valid_data_results_in_200(
+        self,
+    ) -> None:
+        response = self.client.post(
+            self.url, data=dict(plan_id=str(uuid4()), cooperation_id=str(uuid4()))
+        )
+        self.assertEqual(response.status_code, 200)

--- a/tests/presenters/test_request_cooperation_presenter.py
+++ b/tests/presenters/test_request_cooperation_presenter.py
@@ -1,0 +1,100 @@
+from unittest import TestCase
+
+from arbeitszeit.use_cases import RequestCooperationResponse
+from arbeitszeit_web.request_cooperation import RequestCooperationPresenter
+
+rr = RequestCooperationResponse.RejectionReason
+
+SUCCESSFUL_COOPERATION_REQUEST = RequestCooperationResponse(rejection_reason=None)
+
+
+class RequestCooperationPresenterTests(TestCase):
+    def setUp(self) -> None:
+        self.presenter = RequestCooperationPresenter()
+
+    def test_do_not_show_as_error_if_request_was_successful(self):
+        presentation = self.presenter.present(SUCCESSFUL_COOPERATION_REQUEST)
+        self.assertFalse(presentation.is_error)
+
+    def test_show_as_error_if_request_was_rejected(self):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.plan_not_found)
+        )
+        self.assertTrue(presentation.is_error)
+
+    def test_correct_notification_when_rejected_because_plan_not_found(self):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.plan_not_found)
+        )
+        self.assertEqual(presentation.notifications[0], "Plan nicht gefunden.")
+
+    def test_correct_notification_when_rejected_because_coop_not_found(self):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.cooperation_not_found)
+        )
+        self.assertEqual(presentation.notifications[0], "Kooperation nicht gefunden.")
+
+    def test_correct_notification_when_rejected_because_plan_inactive(self):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.plan_inactive)
+        )
+        self.assertEqual(presentation.notifications[0], "Plan nicht aktiv.")
+
+    def test_correct_notification_when_rejected_because_plan_has_cooperation(
+        self,
+    ):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.plan_has_cooperation)
+        )
+        self.assertEqual(
+            presentation.notifications[0],
+            "Plan kooperiert bereits oder hat Kooperation angefragt.",
+        )
+
+    def test_correct_notification_when_rejected_because_plan_part_of_cooperation(
+        self,
+    ):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(
+                rejection_reason=rr.plan_already_part_of_cooperation
+            )
+        )
+        self.assertEqual(
+            presentation.notifications[0],
+            "Plan kooperiert bereits oder hat Kooperation angefragt.",
+        )
+
+    def test_correct_notification_when_rejected_because_plan_is_requesting_cooperation(
+        self,
+    ):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(
+                rejection_reason=rr.plan_is_already_requesting_cooperation
+            )
+        )
+        self.assertEqual(
+            presentation.notifications[0],
+            "Plan kooperiert bereits oder hat Kooperation angefragt.",
+        )
+
+    def test_correct_notification_when_rejected_because_plan_is_public_service(
+        self,
+    ):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.plan_is_public_service)
+        )
+        self.assertEqual(
+            presentation.notifications[0],
+            "Öffentliche Pläne können nicht kooperieren.",
+        )
+
+    def test_correct_notification_when_rejected_because_requester_not_planner(
+        self,
+    ):
+        presentation = self.presenter.present(
+            RequestCooperationResponse(rejection_reason=rr.requester_is_not_planner)
+        )
+        self.assertEqual(
+            presentation.notifications[0],
+            "Nur der Ersteller des Plans kann Kooperation anfragen.",
+        )


### PR DESCRIPTION
Here comes the web implementation for the RequestCooperation-Use Case. 

In the future it would be good to have a drop down menu to request cooperations. Right now companies have to search and copy-paste Plan-ID and Cooperation-ID, that's somewhat laborious. 

![image](https://user-images.githubusercontent.com/61537351/142757438-ab447e7d-f160-4ebd-8555-ad576cc17b04.png)


Plan-ID: 1b5b7a2b-e2c9-4fff-a684-e590441597d4

