### PR TITLE
Remove restore-keys from CI-worker yaml

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,7 +29,7 @@ jobs:
       id: cache-venv
       with:
         path: ./venv/
-        key: ${{ runner.os }}-venv-${{ hashFiles('**/requirements*.txt') }}
+        key: ${{ runner.os }}-env-${{ hashFiles('**/requirements*.txt') }}
     
     - name: Install dependencies        
       run: |


### PR DESCRIPTION
I closed PR #209 and opened a new one, since the other PR was used much for testing. I guess @seppeljordan  is right, using restore-keys can cause trouble with missing dependencies due to loading old cache entries. So removing `restore-keys` should fix our CI problem and avoid similar problems in the future.