### PR TITLE
fix miscalculation in coop price calculator

### DIFF
--- a/arbeitszeit/price_calculator.py
+++ b/arbeitszeit/price_calculator.py
@@ -9,14 +9,18 @@ from arbeitszeit.entities import Plan
 @dataclass
 class PriceComponents:
     total_cost: Decimal
-    amount: int
+    amount: Decimal
+    timeframe: Decimal
     is_public_service: bool
 
 
 def calculate_price(cooperating_plans: List[Plan]) -> Decimal:
     components = [
         PriceComponents(
-            plan.production_costs.total_cost(), plan.prd_amount, plan.is_public_service
+            plan.production_costs.total_cost(),
+            Decimal(plan.prd_amount),
+            Decimal(plan.timeframe),
+            plan.is_public_service,
         )
         for plan in cooperating_plans
     ]
@@ -39,12 +43,13 @@ def _calculate_individual_price(components: List[PriceComponents]) -> Decimal:
 
 
 def _calculate_coop_price(components: List[PriceComponents]) -> Decimal:
+
     for comp in components:
         assert (
             not comp.is_public_service
         ), "Public plans are not allowed in cooperations."
 
-    coop_price = (decimal_sum([plan.total_cost for plan in components])) / (
-        sum([plan.amount for plan in components]) or 1
-    )
+    coop_price = (
+        decimal_sum([plan.total_cost / plan.timeframe for plan in components])
+    ) / (decimal_sum([plan.amount / plan.timeframe for plan in components]) or 1)
     return coop_price

--- a/tests/services/test_price_calculator.py
+++ b/tests/services/test_price_calculator.py
@@ -40,4 +40,40 @@ class TestPriceCalculator(TestCase):
             costs=ProductionCosts(Decimal(1), Decimal(1), Decimal(1)), amount=6
         )
         price = calculate_price([plan1, plan2])
-        self.assertEqual(price, Decimal("0.8125"))  # 13/16
+        self.assertEqual(round(price, 4), Decimal(0.8125))  # 13/16
+
+    def test_that_two_productive_plans_with_different_timeframes_return_correct_coop_price_1(
+        self,
+    ):
+        plan1 = self.plan_generator.create_plan(
+            costs=ProductionCosts(Decimal(10), Decimal(0), Decimal(0)),
+            amount=10,
+            timeframe=10,
+        )  # 1 piece/day, 1 costs/day
+        plan2 = self.plan_generator.create_plan(
+            costs=ProductionCosts(Decimal(20), Decimal(0), Decimal(0)),
+            amount=5,
+            timeframe=1,
+        )  # 5 piece/day, 20 costs/day
+        price = calculate_price([plan1, plan2])
+        self.assertEqual(
+            price, Decimal(3.5)
+        )  # coop price = 21 costs/day / 6 pieces/day = 3,5h/piece
+
+    def test_that_two_productive_plans_with_different_timeframes_return_correct_coop_price_2(
+        self,
+    ):
+        plan1 = self.plan_generator.create_plan(
+            costs=ProductionCosts(Decimal(300), Decimal(10), Decimal(0)),
+            amount=20,
+            timeframe=90,
+        )
+        plan2 = self.plan_generator.create_plan(
+            costs=ProductionCosts(Decimal(25), Decimal(0), Decimal(0)),
+            amount=5,
+            timeframe=45,
+        )
+        price = calculate_price([plan1, plan2])
+        self.assertEqual(
+            price, Decimal(12)
+        )  # coop price = 4h/day / 0,3333 pieces/day = 12h/piece


### PR DESCRIPTION
this PR fixes a miscalculation of coop prices (calculation did not take into account the different timeframe of cooperating plans).

for problem description see latest comment in #170

