### PR TITLE
Remove flaky tests

### DIFF
--- a/tests/flask_integration/test_register_company_view.py
+++ b/tests/flask_integration/test_register_company_view.py
@@ -1,5 +1,4 @@
 from project.extensions import mail
-from project.token import FlaskTokenService
 
 from .flask import ViewTestCase
 

--- a/tests/flask_integration/test_register_member_view.py
+++ b/tests/flask_integration/test_register_member_view.py
@@ -1,5 +1,4 @@
 from project.extensions import mail
-from project.token import FlaskTokenService
 
 from .flask import ViewTestCase
 


### PR DESCRIPTION
This addresses #261 

I removed a check that the registration token is found in the confirmation mail sent on registration. This is unstable since the token is generated twice. The expected token might differ from the actual token in the mail since generating a token twice might yield different results. My guess is that the creation time plays in role when generating a token. So when the current time progressed from one second to the next during test execution we get an error.

PlanID: eee97aff-6bb7-42df-873e-ddacbabf6fcf