### PR TITLE
Fix flask run in nix environment

### DIFF
--- a/nix/pythonPackages.nix
+++ b/nix/pythonPackages.nix
@@ -1,4 +1,10 @@
 self: super: {
   arbeitszeitapp = self.callPackage pythonPackages/arbeitszeitapp.nix { };
   is_safe_url = self.callPackage pythonPackages/is_safe_url.nix { };
+  werkzeug = super.werkzeug.overrideAttrs (old: {
+    postPatch = ''
+      substituteInPlace src/werkzeug/_reloader.py \
+        --replace "rv = [sys.executable]" "return sys.argv"
+    '';
+  });
 }


### PR DESCRIPTION
Just a small fix for incompatibilities between nix environment and `werkzeug` (which implements hot reloading for flask).