### PR TITLE
Reduce code duplication in templates

### DIFF
--- a/arbeitszeit_flask/templates/auth/login_company.html
+++ b/arbeitszeit_flask/templates/auth/login_company.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium">
     <div class="container">
         <div class="column is-4 is-offset-4">

--- a/arbeitszeit_flask/templates/auth/login_member.html
+++ b/arbeitszeit_flask/templates/auth/login_member.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 <div class="section is-medium">
     <div class="container">
         <div class="column is-4 is-offset-4">

--- a/arbeitszeit_flask/templates/auth/signup_company.html
+++ b/arbeitszeit_flask/templates/auth/signup_company.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium">
     <div class="container">
         <div class="column is-4 is-offset-4">

--- a/arbeitszeit_flask/templates/auth/signup_member.html
+++ b/arbeitszeit_flask/templates/auth/signup_member.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 <div class="section is-medium">
     <div class="container">
         <div class="column is-4 is-offset-4">

--- a/arbeitszeit_flask/templates/auth/start.html
+++ b/arbeitszeit_flask/templates/auth/start.html
@@ -1,58 +1,31 @@
 {% extends "base_general_pages.html" %}
 
-{% block general_pages %}
+{% block body %}
 <section class="hero is-fullheight">
-  <div class="hero-head">
-    <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
-      <div class="navbar-brand">
-        <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
-          data-target="navbarOnTop">
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-          <span aria-hidden="true"></span>
-        </a>
-      </div>
-      <div id="navbarOnTop" class="navbar-menu">
-        <div class="navbar-end">
-          <div class="navbar-item has-dropdown is-hoverable">
-            <a class="navbar-link">
-              {{ gettext('Language') }}
-            </a>
-            <div class="navbar-dropdown">
-              {% if languages is defined and languages | length %}
-              {% for lang_code, lang_name in languages.items() %}
-              <a href="{{ url_for('auth.set_language', language=lang_code) }}" class="navbar-item">
-                {{ lang_name }}
-              </a>
-              {% endfor %}
-              {% endif %}
-            </div>
-          </div>
-          <div class="navbar-item">
-            <a class="button is-primary" href="{{ url_for('auth.help') }}">
-              {{ gettext('Help') }}
-            </a>
-          </div>
-        </div>
-      </div>
-    </nav>
-  </div>
+  {{ super() }}
+</section>
+{% endblock %}
 
-  <div class="hero-body pt-0">
-    <div class="container has-text-centered">
-      <h1 class="title">
-        <!-- do not translate -->
-        Arbeitszeit
-      </h1>
-      <h2 class="subtitle">
-        {{ gettext('A platform for working time calculation.') }}
-      </h2>
-      <div class="buttons is-centered">
-        <a class="button" href="{{ url_for('auth.login_member') }}">{{ gettext('Member') }}</a>
-        <a class="button" href="{{ url_for('auth.login_company') }}">{{ gettext('Company') }}</a>
-      </div>
+{% block navigation %}
+<div class="hero-head">
+  {{ super() }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="hero-body">
+  <div class="container has-text-centered">
+    <h1 class="title">
+      <!-- do not translate -->
+      Arbeitszeit
+    </h1>
+    <h2 class="subtitle">
+      {{ gettext('A platform for working time calculation.') }}
+    </h2>
+    <div class="buttons is-centered">
+      <a class="button" href="{{ url_for('auth.login_member') }}">{{ gettext('Member') }}</a>
+      <a class="button" href="{{ url_for('auth.login_company') }}">{{ gettext('Company') }}</a>
     </div>
   </div>
-  <div class="hero-foot"></div>
-</section>
+</div>
 {% endblock %}

--- a/arbeitszeit_flask/templates/auth/start_hilfe.html
+++ b/arbeitszeit_flask/templates/auth/start_hilfe.html
@@ -1,27 +1,14 @@
 {% extends "base_general_pages.html" %}
-
-{% block general_pages %}
-<nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
-  <div class="navbar-brand">
-    <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
-      data-target="navbarOnTop">
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-      <span aria-hidden="true"></span>
-    </a>
-  </div>
-  <div id="navbarOnTop" class="navbar-menu">
-    <div class="navbar-end">
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.start') }}">
-          {{ gettext("Back") }}
-        </a>
-      </div>
-    </div>
-  </div>
-</nav>
-
 {% from 'macros/start_hilfe.html' import start_hilfe %}
-{{ start_hilfe() }}
 
+{% block navigation_items %}
+<div class="navbar-item">
+  <a class="button is-primary" href="{{ url_for('auth.start') }}">
+    {{ gettext('Start') }}
+  </a>
+</div>
+{% endblock %}
+
+{% block content %}
+{{ start_hilfe() }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/auth/unconfirmed_company.html
+++ b/arbeitszeit_flask/templates/auth/unconfirmed_company.html
@@ -1,31 +1,6 @@
-{% extends "base_general_pages.html" %}
+{% extends "base_company.html" %}
 
-{% block general_pages %}
-<nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
-    <div class="navbar-brand">
-        <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
-            data-target="navbarOnTop">
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-        </a>
-    </div>
-    <div id="navbarOnTop" class="navbar-menu">
-        <div class="navbar-end">
-            <div class="navbar-item">
-                <div class="buttons">
-                    <a class="button" href="{{ url_for('auth.logout') }}">
-                        {{ gettext("Logout") }}
-                    </a>
-                    <a class="button is-primary" href="{{ url_for('auth.help') }}">
-                        {{ gettext("Help") }}
-                    </a>
-                </div>
-            </div>
-        </div>
-    </div>
-</nav>
-
+{% block content %}
 <div class="section is-medium has-text-centered">
     <h1 class="title">
         Arbeitszeit

--- a/arbeitszeit_flask/templates/auth/unconfirmed_member.html
+++ b/arbeitszeit_flask/templates/auth/unconfirmed_member.html
@@ -1,31 +1,6 @@
-{% extends "base_general_pages.html" %}
+{% extends "base_member.html" %}
 
-{% block general_pages %}
-<nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
-    <div class="navbar-brand">
-        <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
-            data-target="navbarOnTop">
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-            <span aria-hidden="true"></span>
-        </a>
-    </div>
-    <div id="navbarOnTop" class="navbar-menu">
-        <div class="navbar-end">
-            <div class="navbar-item">
-                <div class="buttons">
-                    <a class="button" href="{{ url_for('auth.logout') }}">
-                        {{ gettext("Logout") }}
-                    </a>
-                    <a class="button is-primary" href="{{ url_for('auth.help') }}">
-                        {{ gettext("Help") }}
-                    </a>
-                </div>
-            </div>
-        </div>
-    </div>
-</nav>
-
+{% block content %}
 <div class="section is-medium has-text-centered">
     <h1 class="title">
         Arbeitszeit

--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -1,3 +1,5 @@
+{% from 'macros/show_notifications.html' import show_notifications %}
+
 <!DOCTYPE html>
 <html>
 
@@ -17,6 +19,13 @@
 
 <body>
   {% block body %}
+  {% block navigation %}
+  {% endblock %}
+
+  {{ show_notifications() }}
+
+  {% block content %}
+  {% endblock %}
   {% endblock %}
 </body>
 

--- a/arbeitszeit_flask/templates/base_company.html
+++ b/arbeitszeit_flask/templates/base_company.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 {% from 'macros/show_notifications.html' import show_notifications %}
 
-{% block body %}
+{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
-    <div class="navbar-item has-background-primary	has-text-white">
+    <div class="navbar-item has-background-primary has-text-white">
       {{ gettext("Company view") }}
     </div>
 
@@ -20,7 +20,7 @@
     <div class="navbar-start">
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_company.dashboard') }}" class="navbar-item">
-        {{ gettext("Dashboard") }}
+	{{ gettext("Dashboard") }}
       </a>
       {% block navbar_start %}
       {% endblock %}
@@ -28,34 +28,28 @@
     </div>
     <div class="navbar-end">
       <div class="navbar-item">
-        <div class="buttons">
-          {% if not current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.login_company') }}">
-            {{ gettext("Sign in") }}
-          </a>
-          <a class="button" href="{{ url_for('auth.signup_company') }}">
-            {{ gettext("Sign up") }}
-          </a>
-          <a class="button" href="{{ url_for('auth.zurueck') }}">
-            {{ gettext("Back") }}
-          </a>
-          {% else %}
-          <a class="button" href="{{ url_for('auth.logout') }}">
-            {{ gettext("Sign out") }}
-          </a>
-          <a class="button" href="{{ url_for('main_company.hilfe') }}">
-            {{ gettext("?") }}
-          </a>
-          {% endif %}
-        </div>
+	<div class="buttons">
+	  {% if not current_user.is_authenticated %}
+	  <a class="button" href="{{ url_for('auth.login_company') }}">
+	    {{ gettext("Sign in") }}
+	  </a>
+	  <a class="button" href="{{ url_for('auth.signup_company') }}">
+	    {{ gettext("Sign up") }}
+	  </a>
+	  <a class="button" href="{{ url_for('auth.zurueck') }}">
+	    {{ gettext("Back") }}
+	  </a>
+	  {% else %}
+	  <a class="button" href="{{ url_for('auth.logout') }}">
+	    {{ gettext("Sign out") }}
+	  </a>
+	  <a class="button" href="{{ url_for('main_company.hilfe') }}">
+	    {{ gettext("?") }}
+	  </a>
+	  {% endif %}
+	</div>
       </div>
     </div>
   </div>
 </nav>
-
-{{ show_notifications() }}
-
-{% block company %}
-{% endblock %}
-
 {% endblock %}

--- a/arbeitszeit_flask/templates/base_general_pages.html
+++ b/arbeitszeit_flask/templates/base_general_pages.html
@@ -1,11 +1,39 @@
 {% extends "base.html" %}
-{% from 'macros/show_notifications.html' import show_notifications %}
 
-{% block body %}
-
-{{ show_notifications() }}
-
-{% block general_pages %}
-{% endblock %}
-
+{% block navigation %}
+<nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
+  <div class="navbar-brand">
+    <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
+      data-target="navbarOnTop">
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+      <span aria-hidden="true"></span>
+    </a>
+  </div>
+  <div id="navbarOnTop" class="navbar-menu">
+    <div class="navbar-end">
+      <div class="navbar-item has-dropdown is-hoverable">
+	<a class="navbar-link">
+	  {{ gettext('Language') }}
+	</a>
+	<div class="navbar-dropdown">
+	  {% if languages is defined and languages | length %}
+	  {% for lang_code, lang_name in languages.items() %}
+	  <a href="{{ url_for('auth.set_language', language=lang_code) }}" class="navbar-item">
+	    {{ lang_name }}
+	  </a>
+	  {% endfor %}
+	  {% endif %}
+	</div>
+      </div>
+      {% block navigation_items %}
+      <div class="navbar-item">
+	<a class="button is-primary" href="{{ url_for('auth.help') }}">
+	  {{ gettext('Help') }}
+	</a>
+      </div>
+      {% endblock %}
+    </div>
+  </div>
+</nav>
 {% endblock %}

--- a/arbeitszeit_flask/templates/base_member.html
+++ b/arbeitszeit_flask/templates/base_member.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% from 'macros/show_notifications.html' import show_notifications %}
 
-{% block body %}
+{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary	has-text-white">
@@ -21,29 +21,29 @@
 
       {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_member.query_plans') }}" class="navbar-item">
-        {{ gettext("All plans") }}
+	{{ gettext("All plans") }}
       </a>
       <a href="{{ url_for('main_member.pay_consumer_product') }}" class="navbar-item">
-        {{ gettext("Pay product")}}
+	{{ gettext("Pay product")}}
       </a>
       <a href="{{ url_for('main_member.my_account') }}" class="navbar-item">
-        {{ gettext("My account")}}
+	{{ gettext("My account")}}
       </a>
       <a href="{{ url_for('main_member.my_purchases') }}" class="navbar-item">
-        {{ gettext("My purchases")}}
+	{{ gettext("My purchases")}}
       </a>
       <a href="{{ url_for('main_member.statistics') }}" class="navbar-item">
-        {{ gettext("Statistics")}}
+	{{ gettext("Statistics")}}
       </a>
       <a href="{{ url_for('main_member.query_companies') }}" class="navbar-item">
-        {{ gettext("Companies")}}
+	{{ gettext("Companies")}}
       </a>
       <a href="{{ url_for('main_member.profile') }}" class="navbar-item">
-        {{ gettext("My profile")}}
+	{{ gettext("My profile")}}
       </a>
       <a href="{{ url_for('main_member.list_messages') }}"
-        class="navbar-item {% if message_indicator is defined %}{% if message_indicator.show_unread_messages_indicator %}unread-messages-indicator{% endif %}{% endif %}">
-        {{ gettext("Messages")}}
+	class="navbar-item {% if message_indicator is defined %}{% if message_indicator.show_unread_messages_indicator %}unread-messages-indicator{% endif %}{% endif %}">
+	{{ gettext("Messages")}}
       </a>
       {% endif %}
 
@@ -51,36 +51,30 @@
 
     <div class="navbar-end">
       <div class="navbar-item">
-        <div class="buttons">
-          {% if not current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.login_member') }}">
-            {{ gettext("Sign in")}}
-          </a>
-          <a class="button" href="{{ url_for('auth.signup_member') }}">
-            {{ gettext("Sign up")}}
-          </a>
-          <a class="button" href="{{ url_for('auth.zurueck') }}">
-            {{ gettext("Back")}}
-          </a>
-          {% endif %}
-          {% if current_user.is_authenticated %}
-          <a class="button" href="{{ url_for('auth.logout') }}">
-            {{ gettext("Sign out")}}
-          </a>
-          <a class="button" href="{{ url_for('main_member.hilfe') }}">
-            ?
-          </a>
-          {% endif %}
+	<div class="buttons">
+	  {% if not current_user.is_authenticated %}
+	  <a class="button" href="{{ url_for('auth.login_member') }}">
+	    {{ gettext("Sign in")}}
+	  </a>
+	  <a class="button" href="{{ url_for('auth.signup_member') }}">
+	    {{ gettext("Sign up")}}
+	  </a>
+	  <a class="button" href="{{ url_for('auth.zurueck') }}">
+	    {{ gettext("Back")}}
+	  </a>
+	  {% endif %}
+	  {% if current_user.is_authenticated %}
+	  <a class="button" href="{{ url_for('auth.logout') }}">
+	    {{ gettext("Sign out")}}
+	  </a>
+	  <a class="button" href="{{ url_for('main_member.hilfe') }}">
+	    ?
+	  </a>
+	  {% endif %}
 
-        </div>
+	</div>
       </div>
     </div>
   </div>
 </nav>
-
-{{ show_notifications() }}
-
-{% block member %}
-{% endblock %}
-
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/404.html
+++ b/arbeitszeit_flask/templates/company/404.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 
 HTTP 404 NOT FOUND
 

--- a/arbeitszeit_flask/templates/company/account_a.html
+++ b/arbeitszeit_flask/templates/company/account_a.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("Account a") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/account_p.html
+++ b/arbeitszeit_flask/templates/company/account_p.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("Account p") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("Account prd") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium has-text-centered">
     <h1 class="title">
         {{ gettext("Account prd") }}

--- a/arbeitszeit_flask/templates/company/account_r.html
+++ b/arbeitszeit_flask/templates/company/account_r.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("Account r") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/company_summary.html
+++ b/arbeitszeit_flask/templates/company/company_summary.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Company overview") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/company_summary.html' import company_summary %}
 {{ company_summary(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/coop_summary.html
+++ b/arbeitszeit_flask/templates/company/coop_summary.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Cooperation") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/coop_summary.html' import coop_summary %}
 {{ coop_summary(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/create_cooperation.html
+++ b/arbeitszeit_flask/templates/company/create_cooperation.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("Create Cooperation") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section has-text-centered">
     <h1 class="title">
         {{ gettext("Create Cooperation") }}

--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Create plan") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section has-text-centered">
     <h1 class="title">
         {{ gettext("Create plan") }}

--- a/arbeitszeit_flask/templates/company/create_plan_response.html
+++ b/arbeitszeit_flask/templates/company/create_plan_response.html
@@ -1,4 +1,4 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/dashboard.html
+++ b/arbeitszeit_flask/templates/company/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 
 <div class="section">
     <div class="has-text-centered pb-5">

--- a/arbeitszeit_flask/templates/company/help.html
+++ b/arbeitszeit_flask/templates/company/help.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 
 {% from 'macros/start_hilfe.html' import start_hilfe %}
 {{ start_hilfe() }}

--- a/arbeitszeit_flask/templates/company/invite_worker_to_company.html
+++ b/arbeitszeit_flask/templates/company/invite_worker_to_company.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Invite worker") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
   <div class="columns">

--- a/arbeitszeit_flask/templates/company/list_all_cooperations.html
+++ b/arbeitszeit_flask/templates/company/list_all_cooperations.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("All cooperations") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/list_all_transactions.html
+++ b/arbeitszeit_flask/templates/company/list_all_transactions.html
@@ -5,7 +5,7 @@
 <div class="navbar-item">{{ gettext("All transactions") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/list_messages.html
+++ b/arbeitszeit_flask/templates/company/list_messages.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Messages") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/list_messages.html' import list_messages %}
 {{ list_messages(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Accounts") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("My cooperations") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section has-text-centered">
     <h1 class="title">
         {{ gettext("My cooperations") }}

--- a/arbeitszeit_flask/templates/company/my_drafts.html
+++ b/arbeitszeit_flask/templates/company/my_drafts.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Plan drafts") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section has-text-centered">
     <div class="content">
         <h1 class="title">

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("My plans") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section has-text-centered">
   <div class="content">
     <h1>{{ gettext("My plans") }}</h1>

--- a/arbeitszeit_flask/templates/company/my_purchases.html
+++ b/arbeitszeit_flask/templates/company/my_purchases.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("My purchases") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 <div class="section has-text-centered">
   <div class="content">

--- a/arbeitszeit_flask/templates/company/plan_summary.html
+++ b/arbeitszeit_flask/templates/company/plan_summary.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Plan information") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 {% from 'macros/plan_summary.html' import plan_summary %}
 {{ plan_summary(view_model) }}

--- a/arbeitszeit_flask/templates/company/query_companies.html
+++ b/arbeitszeit_flask/templates/company/query_companies.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("All companies") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/query_companies.html' import query_companies %}
 {{ query_companies(form, view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/query_plans.html
+++ b/arbeitszeit_flask/templates/company/query_plans.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("All plans") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/query_plans.html' import query_plans %}
 {{ query_plans(form, view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/read_message.html
+++ b/arbeitszeit_flask/templates/company/read_message.html
@@ -1,6 +1,6 @@
 {% extends "base_company.html" %}
 
-{% block company %}
+{% block content %}
 {% from 'macros/read_message.html' import read_message %}
 {{ read_message(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/request_cooperation.html
+++ b/arbeitszeit_flask/templates/company/request_cooperation.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Request cooperation")}}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium has-text-centered">
     <h1 class="title">
         {{ gettext("Request cooperation")}}

--- a/arbeitszeit_flask/templates/company/statistics.html
+++ b/arbeitszeit_flask/templates/company/statistics.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Global statistics") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 
 {% from 'macros/statistics.html' import statistics %}
 {{ statistics(view_model) }}

--- a/arbeitszeit_flask/templates/company/transfer_to_company.html
+++ b/arbeitszeit_flask/templates/company/transfer_to_company.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Payment of means of production") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium has-text-centered">
     <div class="columns">
         <div class="column"></div>

--- a/arbeitszeit_flask/templates/company/transfer_to_worker.html
+++ b/arbeitszeit_flask/templates/company/transfer_to_worker.html
@@ -4,7 +4,7 @@
 <div class="navbar-item">{{ gettext("Transfer to worker") }}</div>
 {% endblock %}
 
-{% block company %}
+{% block content %}
 <div class="section is-medium has-text-centered">
     <div class="columns">
         <div class="column"></div>

--- a/arbeitszeit_flask/templates/member/404.html
+++ b/arbeitszeit_flask/templates/member/404.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 
 <div class="section has-text-centered">
     HTTP 404 NOT FOUND

--- a/arbeitszeit_flask/templates/member/company_summary.html
+++ b/arbeitszeit_flask/templates/member/company_summary.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/company_summary.html' import company_summary %}
 {{ company_summary(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/coop_summary.html
+++ b/arbeitszeit_flask/templates/member/coop_summary.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/coop_summary.html' import coop_summary %}
 {{ coop_summary(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/help.html
+++ b/arbeitszeit_flask/templates/member/help.html
@@ -1,5 +1,5 @@
 {% extends "base_member.html" %}
-{% block member %}
+{% block content %}
 
 {% from 'macros/start_hilfe.html' import start_hilfe %}
 {{ start_hilfe() }}

--- a/arbeitszeit_flask/templates/member/list_messages.html
+++ b/arbeitszeit_flask/templates/member/list_messages.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/list_messages.html' import list_messages %}
 {{ list_messages(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 
 <div class="section has-text-centered">
     <h1 class="title">

--- a/arbeitszeit_flask/templates/member/my_purchases.html
+++ b/arbeitszeit_flask/templates/member/my_purchases.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 
 <div class="section has-text-centered">
   <div class="content">

--- a/arbeitszeit_flask/templates/member/pay_consumer_product.html
+++ b/arbeitszeit_flask/templates/member/pay_consumer_product.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 <div class="section has-text-centered">
     <div class="columns">
         <div class="column"></div>

--- a/arbeitszeit_flask/templates/member/plan_summary.html
+++ b/arbeitszeit_flask/templates/member/plan_summary.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/plan_summary.html' import plan_summary %}
 {{ plan_summary(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/profile.html
+++ b/arbeitszeit_flask/templates/member/profile.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 
 <div class="section is-medium has-text-centered">
   <div class="columns is-centered">

--- a/arbeitszeit_flask/templates/member/query_companies.html
+++ b/arbeitszeit_flask/templates/member/query_companies.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/query_companies.html' import query_companies %}
 {{ query_companies(form, view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/query_plans.html
+++ b/arbeitszeit_flask/templates/member/query_plans.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/query_plans.html' import query_plans %}
 {{ query_plans(form, view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/read_message.html
+++ b/arbeitszeit_flask/templates/member/read_message.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 {% from 'macros/read_message.html' import read_message %}
 {{ read_message(view_model) }}
 {% endblock %}

--- a/arbeitszeit_flask/templates/member/show_company_work_invite_details.html
+++ b/arbeitszeit_flask/templates/member/show_company_work_invite_details.html
@@ -1,5 +1,5 @@
 {% extends "base_member.html" %}
-{% block member %}
+{% block content %}
 <div class="section">
   <p>
     {{ view_model.explanation_text }}

--- a/arbeitszeit_flask/templates/member/statistics.html
+++ b/arbeitszeit_flask/templates/member/statistics.html
@@ -1,6 +1,6 @@
 {% extends "base_member.html" %}
 
-{% block member %}
+{% block content %}
 
 {% from 'macros/statistics.html' import statistics %}
 {{ statistics(view_model) }}


### PR DESCRIPTION
The goal of the PR was to streamline the templating in the app.

I refactored the `base.html` template to include two basic blocks: The `navigation` block and the `content` block. All other templates should follow this basic structure. With this change the `base_member.html` and `base_company.html` can simply override the `navigation` block. Also the `unconfirmed_member.html` and `unconfirmed_company.html` no derive from their respective user types base template `base_member.html` and `base_company.html`.

As a consequence the `block member` and `block company` directives both got deleted. Instead we use `block content` everywhere.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c