### PR TITLE
Improve nix flake struture

### DIFF
--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,0 +1,14 @@
+{ mkShell, python3, nixfmt }:
+mkShell {
+  packages = (with python3.pkgs; [
+    black
+    flake8
+    mypy
+    isort
+    psycopg2
+    gunicorn
+    types-dateutil
+    sphinx
+  ]) ++ [ nixfmt ];
+  inputsFrom = [ python3.pkgs.arbeitszeitapp ];
+}

--- a/nix/developmentOverrides.nix
+++ b/nix/developmentOverrides.nix
@@ -1,0 +1,8 @@
+self: super: {
+  werkzeug = super.werkzeug.overrideAttrs (old: {
+    postPatch = ''
+      substituteInPlace src/werkzeug/_reloader.py \
+        --replace "rv = [sys.executable]" "return sys.argv"
+    '';
+  });
+}

--- a/nix/pythonPackages.nix
+++ b/nix/pythonPackages.nix
@@ -1,10 +1,4 @@
 self: super: {
   arbeitszeitapp = self.callPackage pythonPackages/arbeitszeitapp.nix { };
   is_safe_url = self.callPackage pythonPackages/is_safe_url.nix { };
-  werkzeug = super.werkzeug.overrideAttrs (old: {
-    postPatch = ''
-      substituteInPlace src/werkzeug/_reloader.py \
-        --replace "rv = [sys.executable]" "return sys.argv"
-    '';
-  });
 }


### PR DESCRIPTION
This PR reworks how we create a development environment via the `nix` tooling.

# The Problem

The `werkzeug` cli is responsible for starting the development server of flask. This program cannot deal with being wrapped in a bash script as done by nix. The following console output shows how the `flask` exectutable is a bash wrapper.

```
$ which flask
/nix/store/h2n18x6fd2xmscq6v4rkn0314k7w780m-python3.9-Flask-2.1.1/bin/flask

$ cat /nix/store/h2n18x6fd2xmscq6v4rkn0314k7w780m-python3.9-Flask-2.1.1/bin/flask
#! /nix/store/07ln9bxp9k8nds669r24fsywf4d1jlly-bash-5.1-p16/bin/bash -e
PATH=${PATH:+':'$PATH':'}
PATH=${PATH/':''/nix/store/5i7wa7brmk4472v6i4glnn4p5ql5gbki-python3.9-watchdog-2.1.7/bin'':'/':'}
PATH='/nix/store/5i7wa7brmk4472v6i4glnn4p5ql5gbki-python3.9-watchdog-2.1.7/bin'$PATH
...
exec -a "$0" "/nix/store/h2n18x6fd2xmscq6v4rkn0314k7w780m-python3.9-Flask-2.1.1/bin/.flask-wrapped"  "$@"
```

We patch `werkzeug` to address this problem. See https://github.com/arbeitszeit/arbeitszeitapp/blob/3f580e44e46a7d787f01e36c91c5819fa09ef7f2/nix/pythonPackages.nix#L4 for how we do that. Since `werkzeug` is a dependency of `flask` itself this patch changes the build inputs for `flask`. This means that we cannot use the pre-packaged binary from `nixpkgs` binary server since we change the build. See our CI pipeline for prove of that: https://github.com/arbeitszeit/arbeitszeitapp/runs/6538528957?check_suite_focus=true#step:5:571

# The solution

I addressed this problem by separating the packaging instructions into two parts: A production part and a development part. The production part is located in `nix/pythonPackages.nix` and contains all packaging instructions to run `arbeitszeitapp` as part of a serious web server. The `werkzeug` development server is not required in such a scenario. The development part shall contain all patches that are required to run the dev server. Consumers of the `arbeitszeitapp` can now select only the parts that they need for their setup.

# Consequences

This change makes it easier for us to run the software in a `nix` context since it is less expensive to build the application. This allows us to install security updates more often and with less cost.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c