### PR TITLE
Refactor /company/seek_approval

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -162,6 +162,7 @@ from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
     RegistrationEmailTemplate,
 )
+from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
 from arbeitszeit_web.presenters.send_confirmation_email_presenter import (
     SendConfirmationEmailPresenter,
 )
@@ -982,6 +983,15 @@ class FlaskModule(Module):
     ) -> GetLatestActivatedPlansPresenter:
         return GetLatestActivatedPlansPresenter(
             url_index=url_index, datetime_service=datetime_service
+        )
+
+    @provider
+    def provide_seek_plan_approval_presenter(
+        self, notifier: Notifier, translator: Translator
+    ) -> SeekPlanApprovalPresenter:
+        return SeekPlanApprovalPresenter(
+            notifier=notifier,
+            translator=translator,
         )
 
     def configure(self, binder: Binder) -> None:

--- a/arbeitszeit_flask/templates/company/create_plan_response.html
+++ b/arbeitszeit_flask/templates/company/create_plan_response.html
@@ -1,4 +1,0 @@
-{% extends "base_company.html" %}
-
-{% block content %}
-{% endblock %}

--- a/arbeitszeit_web/presenters/seek_plan_approval.py
+++ b/arbeitszeit_web/presenters/seek_plan_approval.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.seek_approval import SeekApproval
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class SeekPlanApprovalPresenter:
+    @dataclass
+    class ViewModel:
+        pass
+
+    notifier: Notifier
+    translator: Translator
+
+    def present_response(self, response: SeekApproval.Response) -> ViewModel:
+        if response.is_approved:
+            self.notifier.display_info(
+                self.translator.gettext("Plan was successfully created and approved.")
+            )
+            self.notifier.display_info(
+                self.translator.gettext(
+                    "Plan was activated. Credit for means of production were granted. Certificates for labour will be transferred daily"
+                )
+            )
+        else:
+            self.notifier.display_warning(
+                self.translator.gettext("Plan not approved. Reason: %(reason)s")
+                % dict(reason=response.reason)
+            )
+        return self.ViewModel()

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -38,6 +38,7 @@ from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberP
 from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
+from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
 from arbeitszeit_web.presenters.send_work_certificates_to_worker_presenter import (
     SendWorkCertificatesToWorkerPresenter,
 )
@@ -524,6 +525,15 @@ class PresenterTestsInjector(Module):
             session=session,
             translator=translator,
             dashboard_url_index=dashboard_url_index,
+        )
+
+    @provider
+    def provide_seek_plan_approval_presenter(
+        self, notifier: NotifierTestImpl, translator: FakeTranslator
+    ) -> SeekPlanApprovalPresenter:
+        return SeekPlanApprovalPresenter(
+            notifier=notifier,
+            translator=translator,
         )
 
 

--- a/tests/presenters/test_seek_plan_approval.py
+++ b/tests/presenters/test_seek_plan_approval.py
@@ -1,0 +1,47 @@
+from typing import Optional
+from unittest import TestCase
+from uuid import uuid4
+
+from arbeitszeit.use_cases.seek_approval import SeekApproval
+from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
+from tests.presenters.notifier import NotifierTestImpl
+
+from .dependency_injection import get_dependency_injector
+
+
+class PresenterTests(TestCase):
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()
+        self.presenter = self.injector.get(SeekPlanApprovalPresenter)
+        self.notifier = self.injector.get(NotifierTestImpl)
+
+    def test_show_info_notification_when_plan_was_approved(self) -> None:
+        response = self.create_response(is_approved=True)
+        self.presenter.present_response(response)
+        self.assertTrue(self.notifier.infos)
+
+    def test_dont_show_info_notification_if_plan_was_not_approved(self) -> None:
+        response = self.create_response(is_approved=False)
+        self.presenter.present_response(response)
+        self.assertFalse(self.notifier.infos)
+
+    def test_dont_show_warning_when_plan_was_approved(self) -> None:
+        response = self.create_response(is_approved=True)
+        self.presenter.present_response(response)
+        self.assertFalse(self.notifier.warnings)
+
+    def test_show_warning_when_plan_was_not_approved(self) -> None:
+        response = self.create_response(is_approved=False)
+        self.presenter.present_response(response)
+        self.assertTrue(self.notifier.warnings)
+
+    def create_response(
+        self, *, is_approved: Optional[bool] = None
+    ) -> SeekApproval.Response:
+        if is_approved is None:
+            is_approved = True
+        return SeekApproval.Response(
+            is_approved=is_approved,
+            reason="",
+            new_plan_id=uuid4(),
+        )


### PR DESCRIPTION
A presenter was introduce and a obsolete template
/templates/company/create_plan_response.html was removed.

When filing a plan the application redirects to the companies plan overview page /company/my_plans since the create_plan_response.html template, which was used to render the response to /company/seek_approval, did not provide any information.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c

EDIT: The testing done on the presenter is not as throughout as usual since most of it will get deleted when implementing proper plan inspection anyway.