### PR TITLE
Allow configuration of https policy

### DIFF
--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -52,7 +52,9 @@ def create_app(config=None, db=None, migrate=None, template_folder=None):
     # Init Flask-Talisman
     if app.config["ENV"] == "production":
         csp = {"default-src": ["'self'", "'unsafe-inline'", "*.fontawesome.com"]}
-        Talisman(app, content_security_policy=csp)
+        Talisman(
+            app, content_security_policy=csp, force_https=app.config["FORCE_HTTPS"]
+        )
 
     # init flask extensions
     CSRFProtect(app)

--- a/arbeitszeit_flask/configuration_base.py
+++ b/arbeitszeit_flask/configuration_base.py
@@ -8,3 +8,4 @@ SQLALCHEMY_DATABASE_URI = "sqlite:////tmp/arbeitszeitapp.db"
 SECURITY_PASSWORD_SALT = environ.get("SECURITY_PASSWORD_SALT")
 LANGUAGES = {"en": "English", "de": "Deutsch"}
 MAIL_PORT = "25"
+FORCE_HTTPS = True

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,6 +13,14 @@ The configuration file must be a valid python script.  Configuration
 options are set as variables on the top level. The following
 configuration options are available
 
+.. py:data:: FORCE_HTTPS
+   This option controls whether the application will allow unsecure
+   HTTP trafic or force a redirect to an HTTPS address.
+
+   Example: ``FORCE_HTTPS = False``
+
+   Default: ``True``
+
 .. py:data:: MAIL_SERVER
    The server name of the SMTP server used to send mails.
 


### PR DESCRIPTION
This PR allows administrators to configure the handling of insecure connections via HTTP.  The admin can now specify `FORCE_HTTPS=False` in the settings file to disable force connection upgrades to HTTPS. This is useful for automatic testing of deployment configurations. The default value for this option is ``True``, meaning that the admin has to make the conscious decision to allow HTTP.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c