### PR TITLE
Fix bug in DB code regarding 'flask payout' command

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -669,8 +669,8 @@ class PlanRepository(repositories.PlanRepository):
         return (
             self.object_from_orm(plan_orm)
             for plan_orm in Plan.query.filter_by(
-                approved=True, is_active=True, expired=False, is_public_service=False
-            ).all()
+                is_active=True, expired=False, is_public_service=False
+            ).filter(Plan.approval_date != None)
         )
 
     def all_public_plans_approved_active_and_not_expired(
@@ -679,18 +679,19 @@ class PlanRepository(repositories.PlanRepository):
         return (
             self.object_from_orm(plan_orm)
             for plan_orm in Plan.query.filter_by(
-                approved=True, is_active=True, expired=False, is_public_service=True
-            ).all()
+                is_active=True,
+                expired=False,
+                is_public_service=True,
+            ).filter(Plan.approval_date != None)
         )
 
     def all_plans_approved_active_and_not_expired(self) -> Iterator[entities.Plan]:
         return (
             self.object_from_orm(plan_orm)
             for plan_orm in Plan.query.filter_by(
-                approved=True,
                 is_active=True,
                 expired=False,
-            ).all()
+            ).filter(Plan.approval_date != None)
         )
 
     def hide_plan(self, plan_id: UUID) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,8 @@ include_package_data = True
 
 [flake8]
 ignore = E501,W503,E712
+per-file-ignores =
+    arbeitszeit_flask/database/repositories.py: E711
 exclude =
     .git/**
     .direnv/**

--- a/tests/flask_integration/test_plan_repository.py
+++ b/tests/flask_integration/test_plan_repository.py
@@ -336,3 +336,24 @@ def test_that_availability_is_toggled_to_true(
     plan_from_repo = repository.get_plan_by_id(plan.id)
     assert plan_from_repo
     assert plan_from_repo.is_available == True
+
+
+@injection_test
+def test_that_all_productive_plans_approved_active_and_not_expired_returns_no_plans_with_empty_db(
+    repository: PlanRepository,
+) -> None:
+    assert not list(repository.all_productive_plans_approved_active_and_not_expired())
+
+
+@injection_test
+def test_all_public_plans_approved_active_and_not_expired_returns_no_plans_with_empty_db(
+    repository: PlanRepository,
+) -> None:
+    assert not list(repository.all_public_plans_approved_active_and_not_expired())
+
+
+@injection_test
+def test_all_plans_approved_active_and_not_expired_returns_no_plans_with_empty_db(
+    repository: PlanRepository,
+) -> None:
+    assert not list(repository.all_plans_approved_active_and_not_expired())


### PR DESCRIPTION
Due to lack of testing I introduced a bug into the application with the latest change to the DB model for `Plan`. This PR addresses the issue in a way that the `flask payout` command does not crash anymore.