### PR TITLE
Configure babel setuptools integration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 recursive-include arbeitszeit_flask/templates *.html
 recursive-include arbeitszeit_flask/migrations *.ini *.mako *.py
 recursive-include arbeitszeit_flask/static *.js *.css
+recursive-include arbeitszeit_flask/translations *.po *.mo

--- a/README.rst
+++ b/README.rst
@@ -128,19 +128,18 @@ In development mode you can run it manually in the CLI.
 Translation
 ===========
 
-We use `Flask-Babel <https://flask-babel.tkte.ch/>` for translation. 
+We use `Flask-Babel <https://flask-babel.tkte.ch/>` for translation.
 
-1) 
-Add a new language:
+1) Add a new language:
 
 a. Execute::
 
-    $ flask trans-new LANG_CODE
+    $ python setup.py init_catalog -l LANGUAGE_CODE
 
-b. Add the new language to the LANGUAGES variable in ``arbeitszeit_flask/configuration_base.py``.
+b. Add the new language to the LANGUAGES variable in
+   ``arbeitszeit_flask/configuration_base.py``.
 
-2)   
-Mark translatable, user-facing strings in the code. 
+2) Mark translatable, user-facing strings in the code.
 
 In python files use: 
 
@@ -154,18 +153,15 @@ In jinja templates use:
 - ``ngettext(singular: str, plural: str, n)``
 
 
-3) 
-Parse code and update language specific .po-files::
+3) Parse code and update language specific .po-files::
 
-	$ flask trans-update
+    $ python setup.py update_catalog
 
-4) 
-Translate language specific .po-files.
+4) Translate language specific .po-files.
 	
-5)
-Compile translation files::
+5) Compile translation files::
 
-    $ flask trans-compile
+    $ python setup.py compile_catalog
 		
 
 License

--- a/arbeitszeit_flask/__init__.py
+++ b/arbeitszeit_flask/__init__.py
@@ -1,6 +1,5 @@
 import os
 
-import click
 from flask import Flask, current_app, request, session
 from flask_migrate import upgrade
 from flask_talisman import Talisman
@@ -76,18 +75,9 @@ def create_app(config=None, db=None, template_folder=None):
 
     with app.app_context():
 
-        from arbeitszeit_flask.commands import (
-            invite_accountant,
-            trans_compile,
-            trans_new,
-            trans_update,
-            update_and_payout,
-        )
+        from arbeitszeit_flask.commands import invite_accountant, update_and_payout
 
         app.cli.command("payout")(update_and_payout)
-        app.cli.command("trans-update")(trans_update)
-        app.cli.command("trans-compile")(trans_compile)
-        app.cli.command("trans-new")(click.argument("lang_code")(trans_new))
         app.cli.command("invite-accountant")(invite_accountant)
 
         from .models import Accountant, Company, Member

--- a/arbeitszeit_flask/commands.py
+++ b/arbeitszeit_flask/commands.py
@@ -1,5 +1,3 @@
-import subprocess
-
 import click
 from flask_babel import force_locale
 
@@ -32,64 +30,3 @@ def invite_accountant(
         use_case.send_accountant_registration_token(
             SendAccountantRegistrationTokenUseCase.Request(email=email_address)
         )
-
-
-def trans_update():
-    """
-    Parse code and update language specific .po-files.
-    """
-    subprocess.run(
-        [
-            "pybabel",
-            "extract",
-            "-F",
-            "babel.cfg",
-            "-k",
-            "lazy_gettext",
-            "-o",
-            "arbeitszeit_flask/translations/messages.pot",
-            ".",
-        ],
-        check=True,
-    )
-    subprocess.run(
-        [
-            "pybabel",
-            "update",
-            "-i",
-            "arbeitszeit_flask/translations/messages.pot",
-            "-d",
-            "arbeitszeit_flask/translations",
-            "--no-fuzzy-matching",
-            "--width",
-            "78",
-        ],
-        check=True,
-    )
-
-
-def trans_compile():
-    """Compile translation files."""
-    subprocess.run(
-        ["pybabel", "compile", "-d", "arbeitszeit_flask/translations"], check=True
-    )
-
-
-def trans_new(lang_code: str):
-    """
-    Add a new language.
-    Examples for argument lang_code are en, de, fr, etc.
-    """
-    subprocess.run(
-        [
-            "pybabel",
-            "init",
-            "-i",
-            "arbeitszeit_flask/translations/messages.pot",
-            "-d",
-            "arbeitszeit_flask/translations",
-            "-l",
-            lang_code,
-        ],
-        check=True,
-    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,25 @@ classifiers =
 packages = find:
 include_package_data = True
 
+[update_catalog]
+input_file = arbeitszeit_flask/translations/messages.pot
+output_dir = arbeitszeit_flask/translations
+no_fuzzy_matching = True
+width = 78
+
+[compile_catalog]
+directory = arbeitszeit_flask/translations
+
+[extract_messages]
+mapping_file = babel.cfg
+keywords = lazy_gettext
+output_file = arbeitszeit_flask/translations/messages.pot
+input_paths = .
+
+[init_catalog]
+input_file = arbeitszeit_flask/translations/messages.pot
+output_dir = arbeitszeit_flask/translations
+
 [flake8]
 ignore = E501,W503,E712
 per-file-ignores =

--- a/startapp_heroku.sh
+++ b/startapp_heroku.sh
@@ -2,6 +2,6 @@ export FLASK_APP=arbeitszeit_flask
 export ARBEITSZEITAPP_CONFIGURATION_PATH="$PWD/arbeitszeit_flask/production_settings.py"
 
 echo "Compiling translation files..."
-flask trans-compile
+python setup.py compile_catalog
 
 gunicorn arbeitszeit_flask.wsgi:app


### PR DESCRIPTION
This change was done to increase compatibility with python standard
tools. With this change the "old" way of handling translations was
dropped. The "new" way to deal with translations was documented in
README.md.

Plan-ID: 1906a785-a23b-44b3-a599-96ee43dd388c