### PR TITLE
Repplace deprecated nix flake features

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,9 +19,9 @@
             overlays = [ self.overlays.development ];
           };
         in {
-          devShell = developmentPkgs.callPackage nix/devShell.nix { };
-          defaultPackage = pkgs.python3.pkgs.arbeitszeitapp;
+          devShells.default = developmentPkgs.callPackage nix/devShell.nix { };
           packages = {
+            default = pkgs.python3.pkgs.arbeitszeitapp;
             inherit (pkgs) python3;
             arbeitszeitapp-docker-image = pkgs.arbeitszeitapp-docker-image;
           };


### PR DESCRIPTION
The following nix flake features were replaced by implementations following the current coding guidelines:

* `<flake>.devShell.<system>` was replaced by `<flake>.devShells.<system>.default`
* `<flake>.defaultPackage.<system>` was replaced by `<flake>.packages.<system>.default`

See https://nixos.wiki/wiki/Flakes#Output_schema for more information on the flake format.

No certificate transfer required.