### PR TITLE
mypy: Don't check site-packages

### DIFF
--- a/arbeitszeit/datetime_service.py
+++ b/arbeitszeit/datetime_service.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from datetime import date, datetime
-from typing import Optional, Union
+from typing import Optional
 
 
 class DatetimeService(ABC):
@@ -15,7 +15,7 @@ class DatetimeService(ABC):
     @abstractmethod
     def format_datetime(
         self,
-        date: Union[str, datetime],
+        date: datetime,
         zone: Optional[str] = ...,
         fmt: Optional[str] = ...,
     ) -> str:

--- a/arbeitszeit_flask/datetime.py
+++ b/arbeitszeit_flask/datetime.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime
-from typing import Optional, Union
+from typing import Optional
 
-from dateutil import parser, tz
+from dateutil import tz
 
 from arbeitszeit.datetime_service import DatetimeService
 
@@ -15,12 +15,10 @@ class RealtimeDatetimeService(DatetimeService):
 
     def format_datetime(
         self,
-        date: Union[str, datetime],
+        date: datetime,
         zone: Optional[str] = None,
         fmt: Optional[str] = None,
     ) -> str:
-        if isinstance(date, str):
-            date = parser.parse(date)
         if zone is not None:
             date = date.astimezone(tz.gettz(zone))
         if fmt is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ mypy_path = "type_stubs"
 exclude = '''
     migrations/
 '''
+no_site_packages = true
 
 [[tool.mypy.overrides]]
 module = "arbeitszeit.*,arbeitszeit_web.*"

--- a/tests/datetime_service.py
+++ b/tests/datetime_service.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
-from typing import Optional, Union
+from typing import Optional
 
-from dateutil import parser, tz
+from dateutil import tz
 from injector import singleton
 
 from arbeitszeit.datetime_service import DatetimeService
@@ -28,12 +28,10 @@ class FakeDatetimeService(DatetimeService):
 
     def format_datetime(
         self,
-        date: Union[str, datetime],
+        date: datetime,
         zone: Optional[str] = None,
         fmt: Optional[str] = None,
     ) -> str:
-        if isinstance(date, str):
-            date = parser.parse(date)
         if zone is not None:
             date = date.astimezone(tz.gettz(zone))
         if fmt is None:


### PR DESCRIPTION
This change directs `mypy` not to check installed "site-packages", meaning installed third party packages.

This improves mypy runtime significantly without compromising type safety in the project.

No cert transfer needed.