### PR TITLE
Implement CompanyRepository methods for company confirmation

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -308,12 +308,12 @@ class CompanyRepository(repositories.CompanyRepository):
                 return UUID(company.id)
         return None
 
-    def confirm(self, company: UUID, confirmed_on: datetime) -> None:
+    def confirm_company(self, company: UUID, confirmed_on: datetime) -> None:
         self.db.session.query(models.Company).filter(
             models.Company.id == str(company)
         ).update({models.Company.confirmed_on: confirmed_on})
 
-    def is_confirmed(self, company: UUID) -> bool:
+    def is_company_confirmed(self, company: UUID) -> bool:
         orm = (
             self.db.session.query(models.Company)
             .filter(models.Company.id == str(company))

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -572,6 +572,11 @@ class FlaskModule(PresenterModule):
 class with_injection:
     def __init__(self, modules: Optional[List[Module]] = None) -> None:
         self._modules = modules if modules is not None else []
+        all_modules: List[Module] = []
+        all_modules.append(FlaskModule())
+        all_modules.append(ViewsModule())
+        all_modules += self._modules
+        self._injector = Injector(all_modules)
 
     def __call__(self, original_function):
         """When you wrap a function, make sure that the parameters to be
@@ -581,15 +586,12 @@ class with_injection:
 
         @wraps(original_function)
         def wrapped_function(*args, **kwargs):
-            return self.get_injector().call_with_injection(
+            return self._injector.call_with_injection(
                 inject(original_function), args=args, kwargs=kwargs
             )
 
         return wrapped_function
 
-    def get_injector(self) -> Injector:
-        all_modules: List[Module] = []
-        all_modules.append(FlaskModule())
-        all_modules.append(ViewsModule())
-        all_modules += self._modules
-        return Injector(all_modules)
+    @property
+    def injector(self) -> Injector:
+        return self._injector

--- a/tests/flask_integration/test_company_repository.py
+++ b/tests/flask_integration/test_company_repository.py
@@ -279,21 +279,21 @@ class ConfirmCompanyTests(FlaskTestCase):
 
     def test_that_newly_created_company_is_not_confirmed(self) -> None:
         company = self._create_company()
-        self.assertFalse(self.repository.is_confirmed(company.id))
+        self.assertFalse(self.repository.is_company_confirmed(company.id))
 
     def test_that_company_is_confirmed_after_confirm_was_called(self) -> None:
         company = self._create_company()
-        self.repository.confirm(company.id, datetime(2000, 1, 2))
-        self.assertTrue(self.repository.is_confirmed(company.id))
+        self.repository.confirm_company(company.id, datetime(2000, 1, 2))
+        self.assertTrue(self.repository.is_company_confirmed(company.id))
 
     def test_when_confirming_company_other_company_stays_unconfirmed(self) -> None:
         company = self._create_company()
         other_company = self._create_company("other@company.org")
-        self.repository.confirm(company.id, datetime(2000, 1, 2))
-        self.assertFalse(self.repository.is_confirmed(other_company.id))
+        self.repository.confirm_company(company.id, datetime(2000, 1, 2))
+        self.assertFalse(self.repository.is_company_confirmed(other_company.id))
 
     def test_non_existing_company_counts_as_unconfirmed(self) -> None:
-        self.assertFalse(self.repository.is_confirmed(company=uuid4()))
+        self.assertFalse(self.repository.is_company_confirmed(company=uuid4()))
 
     def _create_company(self, email: str = "test@test.test") -> Company:
         means_account = self.account_repository.create_account(AccountTypes.p)


### PR DESCRIPTION
I implemented `CompanyRepository.confirm` and `CompanyRepository.is_confirmed` to move away from using models directly in views. This is part of a move towards implementing proper use cases for user confirmation.

Plan-ID: 7b0abfbd-a0cf-4b59-bcba-c23c95af1051

EDIT: I took the liberty to move all instances of confirmation handling to the respective repositories.