### PR TITLE
Check if package builds with nixpkgs-22.05 package set

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -31,10 +31,27 @@
         "type": "github"
       }
     },
+    "nixpkgs-22_05": {
+      "locked": {
+        "lastModified": 1656754140,
+        "narHash": "sha256-8thJUtZWIimyBtkYQ0tdmmnH0yJvOaw1K5W3OgKc6/A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "09c32b0bda4db98d6454e910206188e85d5b04cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-22_05": "nixpkgs-22_05"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,20 @@
   description = "Arbeitszeitapp";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs-22_05.url = "github:NixOS/nixpkgs/nixos-22.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, nixpkgs-22_05, flake-utils }:
     let
       supportedSystems = [ "x86_64-linux" ];
       systemDependent = flake-utils.lib.eachSystem supportedSystems (system:
         let
           pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          };
+          pkgs_22_05 = import nixpkgs-22_05 {
             inherit system;
             overlays = [ self.overlays.default ];
           };
@@ -24,6 +29,9 @@
             default = pkgs.python3.pkgs.arbeitszeitapp;
             inherit (pkgs) python3;
             arbeitszeitapp-docker-image = pkgs.arbeitszeitapp-docker-image;
+          };
+          checks = {
+            arbeitszeitapp-22_05 = pkgs_22_05.python3.pkgs.arbeitszeitapp;
           };
         });
       systemIndependent = {


### PR DESCRIPTION
This PR introduces a new CI testing job in the nix context. This new job checks if the package builds in the context of the `nixpkgs-22.05`. This also executes the test suite in this build context.

Currently we only build the package in the context of `nixpkgs-unstable`.  This is useful since we check if the package builds with a relatively fresh set of dependencies. The execution context of the app on a potential server will probably not be the `nixpkgs-unstable` package set but instead the stable package set `nixos-22.05`.

This is why we should make sure that the package builds in the stable package context.

No certs necessary.