### PR TITLE
Rename SeekApproval -> SelfApprovePlan

### DIFF
--- a/arbeitszeit/use_cases/__init__.py
+++ b/arbeitszeit/use_cases/__init__.py
@@ -109,7 +109,7 @@ from .resend_confirmation_mail import (
     ResendConfirmationMailRequest,
     ResendConfirmationMailResponse,
 )
-from .seek_approval import SeekApproval
+from .self_approve_plan import SelfApprovePlan
 from .send_work_certificates_to_worker import (
     SendWorkCertificatesToWorker,
     SendWorkCertificatesToWorkerRequest,
@@ -227,7 +227,7 @@ __all__ = [
     "ResendConfirmationMail",
     "ResendConfirmationMailRequest",
     "ResendConfirmationMailResponse",
-    "SeekApproval",
+    "SelfApprovePlan",
     "SendWorkCertificatesToWorker",
     "SendWorkCertificatesToWorkerRequest",
     "SendWorkCertificatesToWorkerResponse",

--- a/arbeitszeit/use_cases/self_approve_plan.py
+++ b/arbeitszeit/use_cases/self_approve_plan.py
@@ -11,7 +11,7 @@ from arbeitszeit.repositories import PlanDraftRepository, PlanRepository
 
 @inject
 @dataclass
-class SeekApproval:
+class SelfApprovePlan:
     @dataclass
     class Request:
         draft_id: UUID

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -65,7 +65,7 @@ from arbeitszeit_web.hide_plan import HidePlanPresenter
 from arbeitszeit_web.list_all_cooperations import ListAllCooperationsPresenter
 from arbeitszeit_web.list_drafts_of_company import ListDraftsPresenter
 from arbeitszeit_web.list_plans import ListPlansPresenter
-from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
+from arbeitszeit_web.presenters.self_approve_plan import SelfApprovePlanPresenter
 from arbeitszeit_web.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
 )
@@ -171,22 +171,19 @@ def create_draft(
         return view.respond_to_get()
 
 
-@CompanyRoute("/company/seek_approval")
+@CompanyRoute("/company/self_approve_plan")
 @commit_changes
-def seek_approval(
-    seek_approval: use_cases.SeekApproval,
+def self_approve_plan(
+    self_approve_plan: use_cases.SelfApprovePlan,
     activate_plan_and_grant_credit: use_cases.ActivatePlanAndGrantCredit,
     template_renderer: UserTemplateRenderer,
-    presenter: SeekPlanApprovalPresenter,
+    presenter: SelfApprovePlanPresenter,
 ):
-    """
-    seek approval for draft.
-    if approved: create plan from draft, activate plan and grant credit.
-    """
+    "Self-approve a plan. Credit is granted automatically."
 
     draft_uuid: UUID = UUID(request.args.get("draft_uuid"))
-    approval_response = seek_approval(
-        use_cases.SeekApproval.Request(draft_id=draft_uuid)
+    approval_response = self_approve_plan(
+        use_cases.SelfApprovePlan.Request(draft_id=draft_uuid)
     )
     if approval_response.is_approved:
         activate_plan_and_grant_credit(approval_response.new_plan_id)

--- a/arbeitszeit_flask/dependency_injection/presenters.py
+++ b/arbeitszeit_flask/dependency_injection/presenters.py
@@ -58,7 +58,7 @@ from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
     RegistrationEmailTemplate,
 )
-from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
+from arbeitszeit_web.presenters.self_approve_plan import SelfApprovePlanPresenter
 from arbeitszeit_web.presenters.send_confirmation_email_presenter import (
     SendConfirmationEmailPresenter,
 )
@@ -230,10 +230,10 @@ class PresenterModule(Module):
         )
 
     @provider
-    def provide_seek_plan_approval_presenter(
+    def provide_self_approve_plan_presenter(
         self, notifier: Notifier, translator: Translator
-    ) -> SeekPlanApprovalPresenter:
-        return SeekPlanApprovalPresenter(
+    ) -> SelfApprovePlanPresenter:
+        return SelfApprovePlanPresenter(
             notifier=notifier,
             translator=translator,
         )

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -50,7 +50,7 @@ class CreateDraftView:
             draft_id = self._create_draft(form)
             return redirect(
                 url_for(
-                    "main_company.seek_approval",
+                    "main_company.self_approve_plan",
                     draft_uuid=draft_id,
                 )
             )

--- a/arbeitszeit_web/presenters/self_approve_plan.py
+++ b/arbeitszeit_web/presenters/self_approve_plan.py
@@ -1,12 +1,12 @@
 from dataclasses import dataclass
 
-from arbeitszeit.use_cases.seek_approval import SeekApproval
+from arbeitszeit.use_cases.self_approve_plan import SelfApprovePlan
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.translator import Translator
 
 
 @dataclass
-class SeekPlanApprovalPresenter:
+class SelfApprovePlanPresenter:
     @dataclass
     class ViewModel:
         pass
@@ -14,7 +14,7 @@ class SeekPlanApprovalPresenter:
     notifier: Notifier
     translator: Translator
 
-    def present_response(self, response: SeekApproval.Response) -> ViewModel:
+    def present_response(self, response: SelfApprovePlan.Response) -> ViewModel:
         if response.is_approved:
             self.notifier.display_info(
                 self.translator.gettext("Plan was successfully created and approved.")

--- a/docs/modules/arbeitszeit.rst
+++ b/docs/modules/arbeitszeit.rst
@@ -12,6 +12,14 @@ Subpackages
 Submodules
 ----------
 
+arbeitszeit.control\_thresholds module
+--------------------------------------
+
+.. automodule:: arbeitszeit.control_thresholds
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit.datetime\_service module
 ------------------------------------
 
@@ -88,14 +96,6 @@ arbeitszeit.transactions module
 -------------------------------
 
 .. automodule:: arbeitszeit.transactions
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit.user\_action module
--------------------------------
-
-.. automodule:: arbeitszeit.user_action
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/modules/arbeitszeit.use_cases.rst
+++ b/docs/modules/arbeitszeit.use_cases.rst
@@ -47,14 +47,6 @@ arbeitszeit.use\_cases.cancel\_cooperation\_solicitation module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit.use\_cases.check\_for\_unread\_messages module
-----------------------------------------------------------
-
-.. automodule:: arbeitszeit.use_cases.check_for_unread_messages
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 arbeitszeit.use\_cases.create\_cooperation module
 -------------------------------------------------
 
@@ -143,10 +135,10 @@ arbeitszeit.use\_cases.get\_member\_account module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit.use\_cases.get\_member\_profile\_info module
---------------------------------------------------------
+arbeitszeit.use\_cases.get\_member\_dashboard module
+----------------------------------------------------
 
-.. automodule:: arbeitszeit.use_cases.get_member_profile_info
+.. automodule:: arbeitszeit.use_cases.get_member_dashboard
    :members:
    :undoc-members:
    :show-inheritance:
@@ -199,6 +191,14 @@ arbeitszeit.use\_cases.list\_all\_cooperations module
    :undoc-members:
    :show-inheritance:
 
+arbeitszeit.use\_cases.list\_available\_languages module
+--------------------------------------------------------
+
+.. automodule:: arbeitszeit.use_cases.list_available_languages
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit.use\_cases.list\_coordinations module
 -------------------------------------------------
 
@@ -219,14 +219,6 @@ arbeitszeit.use\_cases.list\_inbound\_coop\_requests module
 -----------------------------------------------------------
 
 .. automodule:: arbeitszeit.use_cases.list_inbound_coop_requests
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit.use\_cases.list\_messages module
---------------------------------------------
-
-.. automodule:: arbeitszeit.use_cases.list_messages
    :members:
    :undoc-members:
    :show-inheritance:
@@ -311,14 +303,6 @@ arbeitszeit.use\_cases.query\_purchases module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit.use\_cases.read\_message module
--------------------------------------------
-
-.. automodule:: arbeitszeit.use_cases.read_message
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 arbeitszeit.use\_cases.register\_accountant module
 --------------------------------------------------
 
@@ -343,10 +327,10 @@ arbeitszeit.use\_cases.resend\_confirmation\_mail module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit.use\_cases.seek\_approval module
---------------------------------------------
+arbeitszeit.use\_cases.self\_approve\_plan module
+-------------------------------------------------
 
-.. automodule:: arbeitszeit.use_cases.seek_approval
+.. automodule:: arbeitszeit.use_cases.self_approve_plan
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/modules/arbeitszeit_flask.dependency_injection.rst
+++ b/docs/modules/arbeitszeit_flask.dependency_injection.rst
@@ -4,6 +4,14 @@ arbeitszeit\_flask.dependency\_injection package
 Submodules
 ----------
 
+arbeitszeit\_flask.dependency\_injection.presenters module
+----------------------------------------------------------
+
+.. automodule:: arbeitszeit_flask.dependency_injection.presenters
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit\_flask.dependency\_injection.views module
 -----------------------------------------------------
 

--- a/docs/modules/arbeitszeit_flask.rst
+++ b/docs/modules/arbeitszeit_flask.rst
@@ -35,6 +35,14 @@ arbeitszeit\_flask.configuration\_base module
    :undoc-members:
    :show-inheritance:
 
+arbeitszeit\_flask.control\_thresholds module
+---------------------------------------------
+
+.. automodule:: arbeitszeit_flask.control_thresholds
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit\_flask.datetime module
 ----------------------------------
 
@@ -87,6 +95,14 @@ arbeitszeit\_flask.forms module
 -------------------------------
 
 .. automodule:: arbeitszeit_flask.forms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+arbeitszeit\_flask.language\_repository module
+----------------------------------------------
+
+.. automodule:: arbeitszeit_flask.language_repository
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/modules/arbeitszeit_flask.views.rst
+++ b/docs/modules/arbeitszeit_flask.views.rst
@@ -12,6 +12,14 @@ arbeitszeit\_flask.views.accountant\_invitation\_email\_view module
    :undoc-members:
    :show-inheritance:
 
+arbeitszeit\_flask.views.company\_dashboard\_view module
+--------------------------------------------------------
+
+.. automodule:: arbeitszeit_flask.views.company_dashboard_view
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit\_flask.views.company\_work\_invite\_view module
 -----------------------------------------------------------
 
@@ -36,14 +44,6 @@ arbeitszeit\_flask.views.create\_draft\_view module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit\_flask.views.dashboard\_view module
------------------------------------------------
-
-.. automodule:: arbeitszeit_flask.views.dashboard_view
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 arbeitszeit\_flask.views.end\_cooperation\_view module
 ------------------------------------------------------
 
@@ -64,14 +64,6 @@ arbeitszeit\_flask.views.invite\_worker\_to\_company module
 -----------------------------------------------------------
 
 .. automodule:: arbeitszeit_flask.views.invite_worker_to_company
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_flask.views.list\_messages\_view module
-----------------------------------------------------
-
-.. automodule:: arbeitszeit_flask.views.list_messages_view
    :members:
    :undoc-members:
    :show-inheritance:
@@ -104,14 +96,6 @@ arbeitszeit\_flask.views.query\_plans module
 --------------------------------------------
 
 .. automodule:: arbeitszeit_flask.views.query_plans
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_flask.views.read\_message module
----------------------------------------------
-
-.. automodule:: arbeitszeit_flask.views.read_message
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/modules/arbeitszeit_web.formatters.rst
+++ b/docs/modules/arbeitszeit_web.formatters.rst
@@ -1,0 +1,21 @@
+arbeitszeit\_web.formatters package
+===================================
+
+Submodules
+----------
+
+arbeitszeit\_web.formatters.plan\_summary\_formatter module
+-----------------------------------------------------------
+
+.. automodule:: arbeitszeit_web.formatters.plan_summary_formatter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: arbeitszeit_web.formatters
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/modules/arbeitszeit_web.presenters.rst
+++ b/docs/modules/arbeitszeit_web.presenters.rst
@@ -28,10 +28,34 @@ arbeitszeit\_web.presenters.get\_latest\_activated\_plans\_presenter module
    :undoc-members:
    :show-inheritance:
 
+arbeitszeit\_web.presenters.get\_member\_dashboard\_presenter module
+--------------------------------------------------------------------
+
+.. automodule:: arbeitszeit_web.presenters.get_member_dashboard_presenter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+arbeitszeit\_web.presenters.list\_available\_languages\_presenter module
+------------------------------------------------------------------------
+
+.. automodule:: arbeitszeit_web.presenters.list_available_languages_presenter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit\_web.presenters.list\_workers\_presenter module
 -----------------------------------------------------------
 
 .. automodule:: arbeitszeit_web.presenters.list_workers_presenter
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+arbeitszeit\_web.presenters.log\_in\_company\_presenter module
+--------------------------------------------------------------
+
+.. automodule:: arbeitszeit_web.presenters.log_in_company_presenter
    :members:
    :undoc-members:
    :show-inheritance:
@@ -76,10 +100,10 @@ arbeitszeit\_web.presenters.registration\_email\_presenter module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit\_web.presenters.seek\_plan\_approval module
--------------------------------------------------------
+arbeitszeit\_web.presenters.self\_approve\_plan module
+------------------------------------------------------
 
-.. automodule:: arbeitszeit_web.presenters.seek_plan_approval
+.. automodule:: arbeitszeit_web.presenters.self_approve_plan
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/modules/arbeitszeit_web.rst
+++ b/docs/modules/arbeitszeit_web.rst
@@ -8,6 +8,7 @@ Subpackages
    :maxdepth: 4
 
    arbeitszeit_web.controllers
+   arbeitszeit_web.formatters
    arbeitszeit_web.presenters
 
 Submodules
@@ -17,14 +18,6 @@ arbeitszeit\_web.answer\_company\_work\_invite module
 -----------------------------------------------------
 
 .. automodule:: arbeitszeit_web.answer_company_work_invite
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_web.check\_for\_unread\_message module
----------------------------------------------------
-
-.. automodule:: arbeitszeit_web.check_for_unread_message
    :members:
    :undoc-members:
    :show-inheritance:
@@ -85,14 +78,6 @@ arbeitszeit\_web.get\_coop\_summary module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit\_web.get\_member\_profile\_info module
---------------------------------------------------
-
-.. automodule:: arbeitszeit_web.get_member_profile_info
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 arbeitszeit\_web.get\_plan\_summary\_company module
 ---------------------------------------------------
 
@@ -141,6 +126,14 @@ arbeitszeit\_web.invite\_worker\_to\_company module
    :undoc-members:
    :show-inheritance:
 
+arbeitszeit\_web.language\_service module
+-----------------------------------------
+
+.. automodule:: arbeitszeit_web.language_service
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 arbeitszeit\_web.list\_all\_cooperations module
 -----------------------------------------------
 
@@ -153,14 +146,6 @@ arbeitszeit\_web.list\_drafts\_of\_company module
 -------------------------------------------------
 
 .. automodule:: arbeitszeit_web.list_drafts_of_company
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_web.list\_messages module
---------------------------------------
-
-.. automodule:: arbeitszeit_web.list_messages
    :members:
    :undoc-members:
    :show-inheritance:
@@ -205,14 +190,6 @@ arbeitszeit\_web.pay\_means\_of\_production module
    :undoc-members:
    :show-inheritance:
 
-arbeitszeit\_web.plan\_summary\_service module
-----------------------------------------------
-
-.. automodule:: arbeitszeit_web.plan_summary_service
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 arbeitszeit\_web.plotter module
 -------------------------------
 
@@ -233,14 +210,6 @@ arbeitszeit\_web.query\_plans module
 ------------------------------------
 
 .. automodule:: arbeitszeit_web.query_plans
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_web.read\_message module
--------------------------------------
-
-.. automodule:: arbeitszeit_web.read_message
    :members:
    :undoc-members:
    :show-inheritance:
@@ -313,14 +282,6 @@ arbeitszeit\_web.url\_index module
 ----------------------------------
 
 .. automodule:: arbeitszeit_web.url_index
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-arbeitszeit\_web.user\_action module
-------------------------------------
-
-.. automodule:: arbeitszeit_web.user_action
    :members:
    :undoc-members:
    :show-inheritance:

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -43,7 +43,7 @@ from arbeitszeit.use_cases import (
     AcceptCooperationRequest,
     RequestCooperation,
     RequestCooperationRequest,
-    SeekApproval,
+    SelfApprovePlan,
 )
 from arbeitszeit.use_cases.register_accountant import RegisterAccountantUseCase
 from arbeitszeit.use_cases.send_accountant_registration_token import (
@@ -173,7 +173,7 @@ class PlanGenerator:
     company_generator: CompanyGenerator
     datetime_service: FakeDatetimeService
     plan_repository: PlanRepository
-    seek_approval: SeekApproval
+    self_approve_plan: SelfApprovePlan
     request_cooperation: RequestCooperation
     accept_cooperation: AcceptCooperation
     draft_repository: PlanDraftRepository
@@ -210,7 +210,7 @@ class PlanGenerator:
             is_public_service=is_public_service,
             plan_creation_date=plan_creation_date,
         )
-        response = self.seek_approval(SeekApproval.Request(draft_id=draft.id))
+        response = self.self_approve_plan(SelfApprovePlan.Request(draft_id=draft.id))
         plan = self.plan_repository.get_plan_by_id(response.new_plan_id)
         assert plan
         assert plan.is_approved

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -41,7 +41,7 @@ from arbeitszeit_web.presenters.register_member_presenter import RegisterMemberP
 from arbeitszeit_web.presenters.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
-from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
+from arbeitszeit_web.presenters.self_approve_plan import SelfApprovePlanPresenter
 from arbeitszeit_web.presenters.send_work_certificates_to_worker_presenter import (
     SendWorkCertificatesToWorkerPresenter,
 )
@@ -506,10 +506,10 @@ class PresenterTestsInjector(Module):
         )
 
     @provider
-    def provide_seek_plan_approval_presenter(
+    def provide_self_approve_plan_presenter(
         self, notifier: NotifierTestImpl, translator: FakeTranslator
-    ) -> SeekPlanApprovalPresenter:
-        return SeekPlanApprovalPresenter(
+    ) -> SelfApprovePlanPresenter:
+        return SelfApprovePlanPresenter(
             notifier=notifier,
             translator=translator,
         )

--- a/tests/presenters/test_seek_plan_approval.py
+++ b/tests/presenters/test_seek_plan_approval.py
@@ -2,8 +2,8 @@ from typing import Optional
 from unittest import TestCase
 from uuid import uuid4
 
-from arbeitszeit.use_cases.seek_approval import SeekApproval
-from arbeitszeit_web.presenters.seek_plan_approval import SeekPlanApprovalPresenter
+from arbeitszeit.use_cases.self_approve_plan import SelfApprovePlan
+from arbeitszeit_web.presenters.self_approve_plan import SelfApprovePlanPresenter
 from tests.presenters.notifier import NotifierTestImpl
 
 from .dependency_injection import get_dependency_injector
@@ -12,7 +12,7 @@ from .dependency_injection import get_dependency_injector
 class PresenterTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
-        self.presenter = self.injector.get(SeekPlanApprovalPresenter)
+        self.presenter = self.injector.get(SelfApprovePlanPresenter)
         self.notifier = self.injector.get(NotifierTestImpl)
 
     def test_show_info_notification_when_plan_was_approved(self) -> None:
@@ -37,10 +37,10 @@ class PresenterTests(TestCase):
 
     def create_response(
         self, *, is_approved: Optional[bool] = None
-    ) -> SeekApproval.Response:
+    ) -> SelfApprovePlan.Response:
         if is_approved is None:
             is_approved = True
-        return SeekApproval.Response(
+        return SelfApprovePlan.Response(
             is_approved=is_approved,
             reason="",
             new_plan_id=uuid4(),

--- a/tests/use_cases/test_self_approve_plan.py
+++ b/tests/use_cases/test_self_approve_plan.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from unittest import TestCase
 from uuid import UUID
 
-from arbeitszeit.use_cases import SeekApproval
+from arbeitszeit.use_cases import SelfApprovePlan
 from tests.data_generators import PlanGenerator
 from tests.datetime_service import FakeDatetimeService
 
@@ -13,7 +13,7 @@ from .repositories import PlanDraftRepository, PlanRepository
 class UseCaseTests(TestCase):
     def setUp(self) -> None:
         self.injector = get_dependency_injector()
-        self.seek_approval = self.injector.get(SeekApproval)
+        self.self_approve_plan = self.injector.get(SelfApprovePlan)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.draft_repository = self.injector.get(PlanDraftRepository)
         self.plan_repository = self.injector.get(PlanRepository)
@@ -21,35 +21,37 @@ class UseCaseTests(TestCase):
 
     def test_that_any_plan_will_be_approved(self) -> None:
         plan_draft = self.plan_generator.draft_plan()
-        approval_response = self.seek_approval(
-            SeekApproval.Request(draft_id=plan_draft.id)
+        approval_response = self.self_approve_plan(
+            SelfApprovePlan.Request(draft_id=plan_draft.id)
         )
         assert approval_response.is_approved
 
     def test_plan_draft_gets_deleted_after_approval(self) -> None:
         plan_draft = self.plan_generator.draft_plan()
-        response = self.seek_approval(SeekApproval.Request(draft_id=plan_draft.id))
+        response = self.self_approve_plan(
+            SelfApprovePlan.Request(draft_id=plan_draft.id)
+        )
         assert response.is_approved
         assert self.draft_repository.get_by_id(plan_draft.id) is None
 
     def test_that_true_is_returned(self) -> None:
         plan_draft = self.plan_generator.draft_plan()
-        approval_response = self.seek_approval(
-            SeekApproval.Request(draft_id=plan_draft.id)
+        approval_response = self.self_approve_plan(
+            SelfApprovePlan.Request(draft_id=plan_draft.id)
         )
         assert approval_response.is_approved is True
 
     def test_that_returned_new_plan_id_is_uuid(self) -> None:
         plan_draft = self.plan_generator.draft_plan()
-        approval_response = self.seek_approval(
-            SeekApproval.Request(draft_id=plan_draft.id)
+        approval_response = self.self_approve_plan(
+            SelfApprovePlan.Request(draft_id=plan_draft.id)
         )
         assert isinstance(approval_response.new_plan_id, UUID)
 
     def test_that_approval_date_has_correct_day_of_month(self) -> None:
         self.datetime_service.freeze_time(datetime(year=2021, month=5, day=3))
         plan_draft = self.plan_generator.draft_plan()
-        self.seek_approval(SeekApproval.Request(draft_id=plan_draft.id))
+        self.self_approve_plan(SelfApprovePlan.Request(draft_id=plan_draft.id))
         new_plan = self.plan_repository.get_plan_by_id(plan_draft.id)
         assert new_plan
         assert new_plan.approval_date
@@ -57,7 +59,7 @@ class UseCaseTests(TestCase):
 
     def test_that_approved_plan_has_same_planner_as_draft(self) -> None:
         plan_draft = self.plan_generator.draft_plan()
-        self.seek_approval(SeekApproval.Request(draft_id=plan_draft.id))
+        self.self_approve_plan(SelfApprovePlan.Request(draft_id=plan_draft.id))
         new_plan = self.plan_repository.get_plan_by_id(plan_draft.id)
         assert new_plan
         assert new_plan.planner == plan_draft.planner


### PR DESCRIPTION
This PR renames the use case, presenter and associated tests around `SeekApproval` to `SelfApprovePlan`. This is the first step in the refactoring process. The next step will be to incorporate the `ActivatePlanAndGrantCredit` use case into `SelfApprovePlan`.

Plan-ID: 7b0abfbd-a0cf-4b59-bcba-c23c95af1051

EDIT: I also regenerated the API docs via the `./regenerate-api-docs` command.