### PR TITLE
Implement DeleteDraft use case

### DIFF
--- a/arbeitszeit/use_cases/delete_draft.py
+++ b/arbeitszeit/use_cases/delete_draft.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from injector import inject
+
+from arbeitszeit.repositories import CompanyRepository, PlanDraftRepository
+
+
+@inject
+@dataclass
+class DeleteDraftUseCase:
+    @dataclass
+    class Request:
+        deleter: UUID
+        draft: UUID
+
+    @dataclass
+    class Response:
+        pass
+
+    class Failure(Exception):
+        pass
+
+    company_repository: CompanyRepository
+    draft_repository: PlanDraftRepository
+
+    def delete_draft(self, request: Request) -> Response:
+        deleter = self.company_repository.get_by_id(request.deleter)
+        draft = self.draft_repository.get_by_id(request.draft)
+        if not draft or not deleter:
+            raise self.Failure()
+        if draft.planner.id != deleter.id:
+            raise self.Failure()
+        self.draft_repository.delete_draft(request.draft)
+        return self.Response()

--- a/tests/presenters/test_register_company_presenter.py
+++ b/tests/presenters/test_register_company_presenter.py
@@ -1,5 +1,6 @@
-from typing import List
+from typing import List, Optional
 from unittest import TestCase
+from uuid import UUID, uuid4
 
 from arbeitszeit.use_cases.register_company import RegisterCompany
 from arbeitszeit_web.presenters.register_company_presenter import (
@@ -23,7 +24,7 @@ class PresenterTests(TestCase):
         self,
     ) -> None:
         reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = RegisterCompany.Response(rejection_reason=reason)
+        response = self.create_response(rejection_reason=reason)
         self.presenter.present_company_registration(response, self.form)
         self.assertEqual(
             self.form.errors[0],
@@ -34,7 +35,7 @@ class PresenterTests(TestCase):
         self,
     ) -> None:
         reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = RegisterCompany.Response(rejection_reason=reason)
+        response = self.create_response(rejection_reason=reason)
         view_model = self.presenter.present_company_registration(response, self.form)
         self.assertFalse(view_model.is_success_view)
 
@@ -42,26 +43,40 @@ class PresenterTests(TestCase):
         self,
     ) -> None:
         reason = RegisterCompany.Response.RejectionReason.company_already_exists
-        response = RegisterCompany.Response(rejection_reason=reason)
+        response = self.create_response(rejection_reason=reason)
         self.presenter.present_company_registration(response, self.form)
         self.assertFalse(self.session.is_logged_in())
 
     def test_that_no_error_is_displayed_when_registration_was_successful(self) -> None:
-        response = RegisterCompany.Response(rejection_reason=None)
+        response = self.create_response()
         self.presenter.present_company_registration(response, self.form)
         self.assertFalse(self.form.errors)
 
     def test_view_model_signals_successful_registration_if_view_model_signals_success(
         self,
     ) -> None:
-        response = RegisterCompany.Response(rejection_reason=None)
+        response = self.create_response()
         view_model = self.presenter.present_company_registration(response, self.form)
         self.assertTrue(view_model.is_success_view)
 
     def test_that_user_is_logged_in_on_successful_registration(self) -> None:
-        response = RegisterCompany.Response(rejection_reason=None)
+        response = self.create_response()
         self.presenter.present_company_registration(response, self.form)
         self.assertTrue(self.session.is_logged_in())
+
+    def create_response(
+        self,
+        *,
+        rejection_reason: Optional[RegisterCompany.Response.RejectionReason] = None,
+    ) -> RegisterCompany.Response:
+        company_id: Optional[UUID]
+        if rejection_reason is None:
+            company_id = uuid4()
+        else:
+            company_id = None
+        return RegisterCompany.Response(
+            rejection_reason=rejection_reason, company_id=company_id
+        )
 
 
 class FakeRegisterForm:

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -1,0 +1,10 @@
+from unittest import TestCase
+
+from .dependency_injection import get_dependency_injector
+
+
+class BaseTestCase(TestCase):
+    "Use case unit tests should inherit from this class."
+
+    def setUp(self) -> None:
+        self.injector = get_dependency_injector()

--- a/tests/use_cases/test_delete_draft.py
+++ b/tests/use_cases/test_delete_draft.py
@@ -1,0 +1,78 @@
+from uuid import UUID, uuid4
+
+from arbeitszeit.use_cases.delete_draft import DeleteDraftUseCase
+from arbeitszeit.use_cases.get_draft_summary import GetDraftSummary
+from tests.data_generators import CompanyGenerator, PlanGenerator
+
+from .base_test_case import BaseTestCase
+
+
+class UseCaseTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(DeleteDraftUseCase)
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
+        self.get_draft_summary = self.injector.get(GetDraftSummary)
+
+    def test_that_failure_is_raised_if_non_existing_plan_is_deleted_for_non_existing_company(
+        self,
+    ) -> None:
+        with self.assertRaises(DeleteDraftUseCase.Failure):
+            self.use_case.delete_draft(
+                self.create_request(deleter=uuid4(), draft=uuid4())
+            )
+
+    def test_that_no_failure_is_raised_if_draft_is_deleted_by_its_owner(self) -> None:
+        planner = self.company_generator.create_company()
+        draft = self.plan_generator.draft_plan(planner=planner)
+        self.use_case.delete_draft(
+            self.create_request(deleter=planner.id, draft=draft.id)
+        )
+
+    def test_that_failure_is_raised_if_draft_does_not_exist(self) -> None:
+        planner = self.company_generator.create_company()
+        with self.assertRaises(DeleteDraftUseCase.Failure):
+            self.use_case.delete_draft(
+                self.create_request(deleter=planner.id, draft=uuid4()),
+            )
+
+    def test_that_failure_is_raised_if_company_does_not_exist(self) -> None:
+        draft = self.plan_generator.draft_plan()
+        with self.assertRaises(DeleteDraftUseCase.Failure):
+            self.use_case.delete_draft(
+                self.create_request(deleter=uuid4(), draft=draft.id),
+            )
+
+    def test_that_after_deleting_draft_summary_is_not_available_anymore(self) -> None:
+        planner = self.company_generator.create_company()
+        draft = self.plan_generator.draft_plan(planner=planner)
+        self.use_case.delete_draft(
+            self.create_request(deleter=planner.id, draft=draft.id)
+        )
+        response = self.get_draft_summary(draft_id=draft.id)
+        self.assertIsNone(response)
+
+    def test_that_plan_is_not_deleted_if_deleter_is_not_planner(self) -> None:
+        company = self.company_generator.create_company()
+        draft = self.plan_generator.draft_plan()
+        with self.assertRaises(DeleteDraftUseCase.Failure):
+            self.use_case.delete_draft(
+                self.create_request(deleter=company.id, draft=draft.id)
+            )
+        response = self.get_draft_summary(draft_id=draft.id)
+        self.assertIsNotNone(response)
+
+    def test_failure_is_raised_if_deleter_is_not_planner(self) -> None:
+        company = self.company_generator.create_company()
+        draft = self.plan_generator.draft_plan()
+        with self.assertRaises(DeleteDraftUseCase.Failure):
+            self.use_case.delete_draft(
+                self.create_request(deleter=company.id, draft=draft.id)
+            )
+
+    def create_request(self, deleter: UUID, draft: UUID) -> DeleteDraftUseCase.Request:
+        return DeleteDraftUseCase.Request(
+            deleter=deleter,
+            draft=draft,
+        )


### PR DESCRIPTION
This PR implements the business logic for deleting plan drafts. It is implemented such that only the planner themself can delete a draft. In a follow up PR I want to implement the web logic for deleting plans.

Plan-ID: 7b0abfbd-a0cf-4b59-bcba-c23c95af1051