### PR TITLE
PayConsumerProduct: Account for the case that buyer is not valid

### DIFF
--- a/arbeitszeit/use_cases/pay_consumer_product/rejection_reason.py
+++ b/arbeitszeit/use_cases/pay_consumer_product/rejection_reason.py
@@ -5,3 +5,4 @@ class RejectionReason(Enum):
     plan_inactive = auto()
     plan_not_found = auto()
     insufficient_balance = auto()
+    buyer_does_not_exist = auto()

--- a/arbeitszeit_web/pay_consumer_product.py
+++ b/arbeitszeit_web/pay_consumer_product.py
@@ -94,6 +94,13 @@ class PayConsumerProductPresenter:
                 self.translator.gettext("You do not have enough work certificates.")
             )
             return PayConsumerProductViewModel(status_code=406)
+        elif use_case_response.rejection_reason == RejectionReason.buyer_does_not_exist:
+            self.user_notifier.display_warning(
+                self.translator.gettext(
+                    "Failed to pay for consumer product. Are you logged in as a member?"
+                )
+            )
+            return PayConsumerProductViewModel(status_code=404)
         else:
             self.user_notifier.display_warning(
                 self.translator.gettext(

--- a/tests/presenters/test_pay_consumer_product_presenter.py
+++ b/tests/presenters/test_pay_consumer_product_presenter.py
@@ -88,3 +88,28 @@ class PayConsumerProductPresenterTests(TestCase):
             )
         )
         self.assertEqual(view_model.status_code, 406)
+
+    def test_for_proper_error_message_if_user_does_not_exist(
+        self,
+    ) -> None:
+        self.presenter.present(
+            PayConsumerProductResponse(
+                rejection_reason=RejectionReason.buyer_does_not_exist
+            )
+        )
+        self.assertIn(
+            self.translator.gettext(
+                "Failed to pay for consumer product. Are you logged in as a member?"
+            ),
+            self.notifier.warnings,
+        )
+
+    def test_presenter_returns_404_status_code_when_buyer_does_not_exist(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(
+            PayConsumerProductResponse(
+                rejection_reason=RejectionReason.buyer_does_not_exist
+            )
+        )
+        self.assertEqual(view_model.status_code, 404)


### PR DESCRIPTION
I wanted to remove the `assert` statement in PayConsumerProduct use case. This PR implements all the logic for that.

Plan-ID: a06bef2a-629b-491e-ae76-9fa95fe5929e