### PR TITLE
Remove hypothesis from dependencies

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,9 +12,6 @@ on:
 jobs:
   build-nix:
     runs-on: ubuntu-latest
-    env:
-      HYPOTHESIS_PROFILE: ci
-
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v16
@@ -25,9 +22,6 @@ jobs:
 
   build-pip:
     runs-on: ubuntu-latest
-    env:
-      HYPOTHESIS_PROFILE: ci
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10

--- a/README.rst
+++ b/README.rst
@@ -173,17 +173,6 @@ the command::
 
     coverage run --source arbeitszeit_flask,arbeitszeit,arbeitszeit_web -m pytest && coverage html
 
-In some circumstances we use ``hypothesis`` to check for edge cases.
-By default ``hypothesis`` generates only 10 examples per test to keep
-testing times reasonably low. However if you want to run more examples
-you can configure ``hypothesis`` for "CI mode" where at least 1000
-examples are run per test.  This behavior can be controlled via the
-``HYPOTHESIS_PROFILE`` environment variable.::
-
-  # this runs all hypothesis tests with at least 1000 different
-  # examples
-  HYPOTHESIS_PROFILE=ci pytest
-
 Translation
 -----------
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -35,7 +35,6 @@ fonttools==4.33.3
 frozenlist==1.3.0
 greenlet==1.1.2
 gunicorn==20.1.0
-hypothesis==6.46.10
 idna==3.3
 imagesize==1.3.0
 iniconfig==1.1.1
@@ -81,7 +80,6 @@ requests==2.28.1
 setuptools==61.2.0
 six==1.16.0
 snowballstemmer==2.2.0
-sortedcontainers==2.4.0
 speaklater==1.3
 Sphinx==4.5.0
 sphinxcontrib-apidoc==0.3.0

--- a/nix/pythonPackages/arbeitszeitapp.nix
+++ b/nix/pythonPackages/arbeitszeitapp.nix
@@ -2,8 +2,7 @@
 
 # python packages
 , email_validator, flask, flask-babel, flask-talisman, flask_login, flask_mail
-, flask_migrate, flask_wtf, hypothesis, injector, is_safe_url, matplotlib
-, sphinx }:
+, flask_migrate, flask_wtf, injector, is_safe_url, matplotlib, sphinx }:
 buildPythonPackage {
   pname = "arbeitszeitapp";
   version = "develop";
@@ -12,7 +11,6 @@ buildPythonPackage {
   postPhases = [ "buildDocsPhase" ];
   format = "pyproject";
   buildInputs = [ pytestCheckHook sphinx ];
-  checkInputs = [ hypothesis ];
   propagatedBuildInputs = [
     email_validator
     flask

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 black
 flake8
 gunicorn
-hypothesis
 isort
 mypy
 psycopg2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,0 @@
-import os
-
-from hypothesis import settings
-
-settings.register_profile("default", max_examples=10)
-settings.register_profile("ci", max_examples=1000)
-settings.load_profile(os.getenv("HYPOTHESIS_PROFILE", "default"))

--- a/tests/presenters/test_list_all_cooperations.py
+++ b/tests/presenters/test_list_all_cooperations.py
@@ -2,8 +2,6 @@ from typing import Optional
 from unittest import TestCase
 from uuid import UUID, uuid4
 
-from hypothesis import given, strategies
-
 from arbeitszeit.use_cases import ListAllCooperationsResponse, ListedCooperation
 from arbeitszeit_web.list_all_cooperations import ListAllCooperationsPresenter
 from arbeitszeit_web.session import UserRole
@@ -35,12 +33,12 @@ class ListMessagesPresenterTests(TestCase):
         self.assertTrue(view_model.cooperations)
         self.assertTrue(view_model.show_results)
 
-    @given(name=strategies.text())
-    def test_name_is_propagated_to_view_model(self, name: str) -> None:
+    def test_name_is_propagated_to_view_model(self) -> None:
+        expected_name = "test123"
         view_model = self.presenter.present(
-            self._create_response_with_one_cooperation(name=name)
+            self._create_response_with_one_cooperation(name=expected_name)
         )
-        self.assertEqual(view_model.cooperations[0].name, name)
+        self.assertEqual(view_model.cooperations[0].name, expected_name)
 
     def test_plan_count_is_propagated_to_view_model(self) -> None:
         view_model = self.presenter.present(


### PR DESCRIPTION
I removed the test dependencies `hypothesis`. It was only used in one test case and nowhere else. I think that the additional overhead of having `hypothesis` around (compile time, maintaining compatability) is not worth it.

No certs needed.