### PR TITLE
Implement query interface for repositories

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -175,11 +175,11 @@ class PlanRepository(ABC):
         pass
 
     @abstractmethod
-    def query_active_plans_by_product_name(self, query: str) -> Iterator[Plan]:
+    def query_active_plans_by_product_name(self, query: str) -> QueryResult[Plan]:
         pass
 
     @abstractmethod
-    def query_active_plans_by_plan_id(self, query: str) -> Iterator[Plan]:
+    def query_active_plans_by_plan_id(self, query: str) -> QueryResult[Plan]:
         pass
 
     @abstractmethod

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -884,20 +884,24 @@ class PlanRepository(repositories.PlanRepository):
         assert plan_orm
         plan_orm.hidden_by_user = True
 
-    def query_active_plans_by_product_name(self, query: str) -> Iterator[entities.Plan]:
-        return (
-            self.object_from_orm(plan)
-            for plan in models.Plan.query.filter(
+    def query_active_plans_by_product_name(
+        self, query: str
+    ) -> FlaskQueryResult[entities.Plan]:
+        return FlaskQueryResult(
+            mapper=self.object_from_orm,
+            query=models.Plan.query.filter(
                 models.Plan.is_active == True, models.Plan.prd_name.ilike(f"%{query}%")
-            ).all()
+            ).all(),
         )
 
-    def query_active_plans_by_plan_id(self, query: str) -> Iterator[entities.Plan]:
-        return (
-            self.object_from_orm(plan)
-            for plan in models.Plan.query.filter(
+    def query_active_plans_by_plan_id(
+        self, query: str
+    ) -> FlaskQueryResult[entities.Plan]:
+        return FlaskQueryResult(
+            query=models.Plan.query.filter(
                 models.Plan.is_active == True, models.Plan.id.contains(query)
-            ).all()
+            ).all(),
+            mapper=self.object_from_orm,
         )
 
     def get_all_plans_for_company_descending(

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -665,15 +665,23 @@ class PlanRepository(interfaces.PlanRepository):
         self.plans[plan.id] = plan
         return plan
 
-    def query_active_plans_by_product_name(self, query: str) -> Iterator[Plan]:
-        for plan in self.plans.values():
-            if plan.is_active and (query.lower() in plan.prd_name.lower()):
-                yield plan
+    def query_active_plans_by_product_name(self, query: str) -> QueryResultImpl[Plan]:
+        return QueryResultImpl(
+            [
+                plan
+                for plan in self.plans.values()
+                if plan.is_active and (query.lower() in plan.prd_name.lower())
+            ]
+        )
 
-    def query_active_plans_by_plan_id(self, query: str) -> Iterator[Plan]:
-        for plan in self.plans.values():
-            if plan.is_active and (query in str(plan.id)):
-                yield plan
+    def query_active_plans_by_plan_id(self, query: str) -> QueryResultImpl[Plan]:
+        return QueryResultImpl(
+            [
+                plan
+                for plan in self.plans.values()
+                if plan.is_active and (query in str(plan.id))
+            ]
+        )
 
     def toggle_product_availability(self, plan: Plan) -> None:
         plan.is_available = True if (plan.is_available == False) else False


### PR DESCRIPTION
**This PR introduces a new concept to the code of the application. Criticism is very welcome.**

This PR implements a basic query interface for repositories.

The motivation of the change was the need for pagination. Pagination means that only a certain portion of a list of results is fetched on a request and the user is provided with the means to fetch the next portion of list items if they so desire. An example for pagination is the bar at the bottom of your google results where you can request more results for your query (i.e. page 2,3 etc.).

Currently we have no proper strategy for pagination except for defining separate methods or dedicated parameters on query methods or our repositories.

This PR introduces the concept of a `QueryResult`. Classes that implement this `Protocol` need to provided an `__iter__` method for collecting all resulting items for a query (think SELECT statement) and also a `limit` and `offset` method. The semantics of the `limit` and `offset` method are expected to be equivalent to `OFFSET` and `LIMIT` in SQL.

This allows us to have a unified API when dealing with large lists of results, i.e. in transaction overviews or when searching plans. I provided a testing implementation `tests.use_cases.repositories.QueryResultImpl` that is implemented in terms of `list`. The implementation provided for the "production" database `FlaskQueryResult` is based on `sqlalchemy.sql.expression.Select`. `FlaskQueryResult` is lazy. This means that the database is only queried when the `__iter__` method is called.

A further improvement could be done by demanding a `__len__` method from `QueryResult` which is supposed to return the total number of results without querying every single item. This remains to be implemented.

No certs needed.