### PR TITLE
arbeitszeit_flask.models: Remove UserMixin from non-user models

### DIFF
--- a/arbeitszeit_flask/models.py
+++ b/arbeitszeit_flask/models.py
@@ -15,13 +15,13 @@ def generate_uuid() -> str:
     return str(uuid.uuid4())
 
 
-class User(UserMixin, db.Model):
+class User(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     email = db.Column(db.String(100), unique=True, nullable=False)
     password = db.Column(db.String(100), nullable=False)
 
 
-class SocialAccounting(UserMixin, db.Model):
+class SocialAccounting(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
 
     account = db.relationship(
@@ -81,7 +81,7 @@ class Accountant(UserMixin, db.Model):
     user = db.relationship("User", lazy=True, uselist=False, backref="accountant")
 
 
-class PlanDraft(UserMixin, db.Model):
+class PlanDraft(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     plan_creation_date = db.Column(db.DateTime, nullable=False)
     planner = db.Column(db.String, db.ForeignKey("company.id"), nullable=False)
@@ -96,7 +96,7 @@ class PlanDraft(UserMixin, db.Model):
     is_public_service = db.Column(db.Boolean, nullable=False, default=False)
 
 
-class Plan(UserMixin, db.Model):
+class Plan(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     plan_creation_date = db.Column(db.DateTime, nullable=False)
     planner = db.Column(db.String, db.ForeignKey("company.id"), nullable=False)
@@ -143,7 +143,7 @@ class AccountTypes(Enum):
     accounting = "accounting"
 
 
-class Account(UserMixin, db.Model):
+class Account(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     account_owner_social_accounting = db.Column(
         db.String, db.ForeignKey("social_accounting.id"), nullable=True
@@ -169,7 +169,7 @@ class Account(UserMixin, db.Model):
     )
 
 
-class Transaction(UserMixin, db.Model):
+class Transaction(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     date = db.Column(db.DateTime, nullable=False)
     sending_account = db.Column(db.String, db.ForeignKey("account.id"), nullable=False)
@@ -181,7 +181,7 @@ class Transaction(UserMixin, db.Model):
     purpose = db.Column(db.String(1000), nullable=True)  # Verwendungszweck
 
 
-class Purchase(UserMixin, db.Model):
+class Purchase(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     purchase_date = db.Column(db.DateTime, nullable=False)
     plan_id = db.Column(db.String, db.ForeignKey("plan.id"), nullable=False)
@@ -211,7 +211,7 @@ class Cooperation(db.Model):
     )
 
 
-class PayoutFactor(UserMixin, db.Model):
+class PayoutFactor(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     timestamp = db.Column(db.DateTime, nullable=False)
     payout_factor = db.Column(db.Numeric(), nullable=False)


### PR DESCRIPTION
We used the `UserMixin` on almost all of our models. This is generally not necessary and also confusing. That's why I removed these mixins from all models that do not allow login. This change does not have a migration attached since the `UserMixin` does not add or remove any fields from the models.

No certs needed.