### PR TITLE
Update dependencies

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -12,6 +12,7 @@ certifi==2022.9.24
 cffi==1.15.1
 charset-normalizer==2.1.0
 click==8.1.3
+coverage==6.4.4
 cycler==0.11.0
 defusedxml==0.7.1
 dnspython==2.2.1

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667292599,
-        "narHash": "sha256-7ISOUI1aj6UKMPIL+wwthENL22L3+A9V+jS8Is3QsRo=",
+        "lastModified": 1668266328,
+        "narHash": "sha256-+nAW+XR8nswyEnt5IkQlkrz9erTcQWBVLkhtNHxckFw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef2f213d9659a274985778bff4ca322f3ef3ac68",
+        "rev": "5ca8e2e9e1fa5e66a749b39261ad6bd0e07bc87f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This PR update the nix build inputs (dependencies) for the project. Also the `constraints.txt` file was regenerated since it did not contain a version for the `coverage` package.

No certs needed.