### PR TITLE
Refactor arbeitszeit.repositories.MemberRepository

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -78,6 +78,12 @@ class MemberResult(QueryResult[Member], Protocol):
     def working_at_company(self, company: UUID) -> MemberResult:
         ...
 
+    def with_id(self, id_: UUID) -> MemberResult:
+        ...
+
+    def with_email_address(self, email: str) -> MemberResult:
+        ...
+
 
 class PurchaseResult(QueryResult[Purchase], Protocol):
     def ordered_by_creation_date(self, *, ascending: bool = ...) -> PurchaseResult:
@@ -259,27 +265,7 @@ class MemberRepository(ABC):
         pass
 
     @abstractmethod
-    def has_member_with_email(self, email: str) -> bool:
-        pass
-
-    @abstractmethod
-    def is_member(self, id: UUID) -> bool:
-        pass
-
-    @abstractmethod
-    def get_by_email(self, email: str) -> Optional[Member]:
-        pass
-
-    @abstractmethod
-    def count_registered_members(self) -> int:
-        pass
-
-    @abstractmethod
-    def get_by_id(self, id: UUID) -> Optional[Member]:
-        pass
-
-    @abstractmethod
-    def get_all_members(self) -> MemberResult:
+    def get_members(self) -> MemberResult:
         pass
 
     @abstractmethod

--- a/arbeitszeit/use_cases/confirm_member.py
+++ b/arbeitszeit/use_cases/confirm_member.py
@@ -28,7 +28,11 @@ class ConfirmMemberUseCase:
     def confirm_member(self, request: Request) -> Response:
         unwrapped_token = self.token_validator.unwrap_confirmation_token(request.token)
         if unwrapped_token:
-            member = self.member_repository.get_by_email(unwrapped_token)
+            member = (
+                self.member_repository.get_members()
+                .with_email_address(unwrapped_token)
+                .first()
+            )
             if not member:
                 return self.Response(is_confirmed=False)
             if member.confirmed_on is None:

--- a/arbeitszeit/use_cases/get_company_dashboard.py
+++ b/arbeitszeit/use_cases/get_company_dashboard.py
@@ -46,7 +46,7 @@ class GetCompanyDashboardUseCase:
             id=company.id, name=company.name, email=company.email
         )
         has_workers = bool(
-            self.member_repository.get_all_members().working_at_company(company_id)
+            self.member_repository.get_members().working_at_company(company_id)
         )
         three_latest_plans = self._get_three_latest_plans()
         return self.Response(

--- a/arbeitszeit/use_cases/get_member_account.py
+++ b/arbeitszeit/use_cases/get_member_account.py
@@ -48,7 +48,7 @@ class GetMemberAccount:
     account_repository: AccountRepository
 
     def __call__(self, member_id: UUID) -> GetMemberAccountResponse:
-        member = self.member_repository.get_by_id(member_id)
+        member = self.member_repository.get_members().with_id(member_id).first()
         assert member
         transaction_info = [
             self._create_info(member, transaction)

--- a/arbeitszeit/use_cases/get_member_dashboard.py
+++ b/arbeitszeit/use_cases/get_member_dashboard.py
@@ -54,7 +54,7 @@ class GetMemberDashboard:
     worker_invite_repository: WorkerInviteRepository
 
     def __call__(self, member: UUID) -> Response:
-        _member = self.member_repository.get_by_id(member)
+        _member = self.member_repository.get_members().with_id(member).first()
         assert _member is not None
         workplaces = [
             self.Workplace(

--- a/arbeitszeit/use_cases/get_statistics.py
+++ b/arbeitszeit/use_cases/get_statistics.py
@@ -48,7 +48,7 @@ class GetStatistics:
         ) = self._count_certificates_and_available_product()
         return StatisticsResponse(
             registered_companies_count=self.company_repository.count_registered_companies(),
-            registered_members_count=self.member_repository.count_registered_members(),
+            registered_members_count=len(self.member_repository.get_members()),
             cooperations_count=self.cooperation_respository.count_cooperations(),
             certificates_count=certs_total,
             available_product=available_product,
@@ -92,7 +92,7 @@ class GetStatistics:
 
     def _count_certs_in_member_accounts(self) -> Decimal:
         certs_in_member_accounts = Decimal(0)
-        all_members = self.member_repository.get_all_members()
+        all_members = self.member_repository.get_members()
         for member in all_members:
             certs_in_member_accounts += self.account_respository.get_account_balance(
                 member.account

--- a/arbeitszeit/use_cases/invite_worker_to_company.py
+++ b/arbeitszeit/use_cases/invite_worker_to_company.py
@@ -31,7 +31,7 @@ class InviteWorkerToCompanyUseCase:
     company_repository: CompanyRepository
 
     def __call__(self, request: Request) -> Response:
-        addressee = self.member_repository.get_by_id(request.worker)
+        addressee = self.member_repository.get_members().with_id(request.worker).first()
         if addressee is None:
             return self.Response(is_success=False)
         sender = self.company_repository.get_by_id(request.company)

--- a/arbeitszeit/use_cases/list_workers.py
+++ b/arbeitszeit/use_cases/list_workers.py
@@ -35,9 +35,7 @@ class ListWorkers:
         company = self.company_repository.get_by_id(request.company)
         if company is None:
             return ListWorkersResponse(workers=[])
-        members = self.member_repository.get_all_members().working_at_company(
-            company.id
-        )
+        members = self.member_repository.get_members().working_at_company(company.id)
         return ListWorkersResponse(
             workers=[self._create_worker_response_model(member) for member in members]
         )

--- a/arbeitszeit/use_cases/log_in_member.py
+++ b/arbeitszeit/use_cases/log_in_member.py
@@ -40,7 +40,7 @@ class LogInMemberUseCase:
                 email=request.email,
                 user_id=member_id,
             )
-        if self.member_repository.has_member_with_email(request.email):
+        if self.member_repository.get_members().with_email_address(request.email):
             reason = self.RejectionReason.invalid_password
         else:
             reason = self.RejectionReason.unknown_email_address

--- a/arbeitszeit/use_cases/pay_consumer_product/__init__.py
+++ b/arbeitszeit/use_cases/pay_consumer_product/__init__.py
@@ -62,7 +62,9 @@ class PayConsumerProduct:
         self, request: PayConsumerProductRequest
     ) -> PayConsumerProductResponse:
         plan = self._get_active_plan(request)
-        buyer = self.member_repository.get_by_id(request.get_buyer_id())
+        buyer = (
+            self.member_repository.get_members().with_id(request.get_buyer_id()).first()
+        )
         if buyer is None:
             return PayConsumerProductResponse(
                 rejection_reason=RejectionReason.buyer_does_not_exist

--- a/arbeitszeit/use_cases/register_member/__init__.py
+++ b/arbeitszeit/use_cases/register_member/__init__.py
@@ -48,7 +48,7 @@ class RegisterMemberUseCase:
         return RegisterMemberUseCase.Response(rejection_reason=None, user_id=user_id)
 
     def _register_member(self, request: Request) -> Optional[UUID]:
-        if self.member_repository.has_member_with_email(request.email):
+        if self.member_repository.get_members().with_email_address(request.email):
             raise self.Response.RejectionReason.member_already_exists
 
         member_account = self.account_repository.create_account(AccountTypes.member)

--- a/arbeitszeit/use_cases/resend_confirmation_mail.py
+++ b/arbeitszeit/use_cases/resend_confirmation_mail.py
@@ -29,7 +29,7 @@ class ResendConfirmationMailUseCase:
     token_service: TokenService
 
     def resend_confirmation_mail(self, request: Request) -> Response:
-        member = self.member_repository.get_by_id(request.user)
+        member = self.member_repository.get_members().with_id(request.user).first()
         if member and member.confirmed_on is None:
             token = self.token_service.generate_token(member.email)
             self.member_registration_message_presenter.show_member_registration_message(

--- a/arbeitszeit/use_cases/send_work_certificates_to_worker.py
+++ b/arbeitszeit/use_cases/send_work_certificates_to_worker.py
@@ -45,10 +45,14 @@ class SendWorkCertificatesToWorker:
         self, use_case_request: SendWorkCertificatesToWorkerRequest
     ) -> SendWorkCertificatesToWorkerResponse:
         company = self.company_repository.get_by_id(use_case_request.company_id)
-        worker = self.member_repository.get_by_id(use_case_request.worker_id)
+        worker = (
+            self.member_repository.get_members()
+            .with_id(use_case_request.worker_id)
+            .first()
+        )
         assert company
         assert worker
-        company_workers = self.member_repository.get_all_members().working_at_company(
+        company_workers = self.member_repository.get_members().working_at_company(
             company.id
         )
         if worker not in company_workers:

--- a/arbeitszeit/use_cases/show_company_work_invite_details.py
+++ b/arbeitszeit/use_cases/show_company_work_invite_details.py
@@ -36,7 +36,7 @@ class ShowCompanyWorkInviteDetailsUseCase:
     def show_company_work_invite_details(
         self, request: ShowCompanyWorkInviteDetailsRequest
     ) -> ShowCompanyWorkInviteDetailsResponse:
-        if not self.member_repository.get_by_id(request.member):
+        if not self.member_repository.get_members().with_id(request.member):
             return failure_response
         invite = self.worker_invite_repository.get_by_id(request.invite)
         if invite is None:

--- a/arbeitszeit_flask/member/blueprint.py
+++ b/arbeitszeit_flask/member/blueprint.py
@@ -54,7 +54,7 @@ class MemberRoute:
                     translator.gettext("Please log in to view this page.")
                 )
                 return redirect(url_for("auth.start", next=self.route_string))
-            elif not member_repository.is_member(user_id):
+            elif not member_repository.get_members().with_id(user_id):
                 # not a member
                 notifier.display_warning(
                     translator.gettext("You are not logged with the correct account.")

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -51,7 +51,7 @@ def my_purchases(
     template_renderer: UserTemplateRenderer,
     presenter: MemberPurchasesPresenter,
 ) -> Response:
-    member = member_repository.get_by_id(UUID(current_user.id))
+    member = member_repository.get_members().with_id(UUID(current_user.id)).first()
     assert member is not None
     response = query_purchases(member)
     view_model = presenter.present_member_purchases(response)

--- a/tests/company.py
+++ b/tests/company.py
@@ -16,7 +16,7 @@ class CompanyManager:
 
     def add_worker_to_company(self, company: UUID, worker: UUID) -> None:
         assert self.company_repository.get_by_id(company)
-        assert self.member_repository.get_by_id(worker)
+        assert self.member_repository.get_members().with_id(worker)
         self.worker_repository.add_worker_to_company(
             company,
             worker,

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -90,7 +90,9 @@ class MemberGenerator:
                 )
             )
             assert not response.is_rejected
-            member = self.member_repository.get_by_email(email)
+            member = (
+                self.member_repository.get_members().with_email_address(email).first()
+            )
             assert member
             return member
         if account is None:
@@ -107,7 +109,7 @@ class MemberGenerator:
             registered_on=registered_on,
         )
         self.member_repository.confirm_member(member.id, confirmed_on=registered_on)
-        member = self.member_repository.get_by_id(member.id)
+        member = self.member_repository.get_members().with_id(member.id).first()
         assert member
         return member
 

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -64,7 +64,9 @@ class ViewTestCase(FlaskTestCase):
         assert response.status_code < 400
         if confirm_member:
             self._confirm_member(email)
-        updated_member = self.member_repository.get_by_email(email)
+        updated_member = (
+            self.member_repository.get_members().with_email_address(email).first()
+        )
         assert updated_member
         return updated_member
 

--- a/tests/use_cases/test_answer_company_work_invite.py
+++ b/tests/use_cases/test_answer_company_work_invite.py
@@ -79,7 +79,7 @@ class AnwerCompanyWorkInviteTests(BaseTestCase):
             self.member,
             {
                 worker.id
-                for worker in self.member_repository.get_all_members().working_at_company(
+                for worker in self.member_repository.get_members().working_at_company(
                     self.company.id
                 )
             },
@@ -108,7 +108,7 @@ class AnwerCompanyWorkInviteTests(BaseTestCase):
             self.member,
             {
                 worker.id
-                for worker in self.member_repository.get_all_members().working_at_company(
+                for worker in self.member_repository.get_members().working_at_company(
                     self.company.id
                 )
             },


### PR DESCRIPTION
This PR removes several methods from the `MemberRepository` in favor of two new methods of the `MemberResult` interface. The methods removed from `MemberRepository` are:

* `has_member_with_email(self, email: str) -> bool`
* `is_member(self, id: UUID) -> bool`
* `get_by_email(self, email: str) -> Optional[Member]`
* `count_registered_members(self) -> int`
* `get_by_id(self, id: UUID) -> Optional[Member]`

The new methods of `MemberResult` protocol are:

* `with_id(self, id_: UUID) -> MemberResult`
* `with_email_address(self, email: str) -> MemberResult`

Plan-ID: a06bef2a-629b-491e-ae76-9fa95fe5929e