### PR TITLE
Use proper 'static' macro in base template to include styles and js

### DIFF
--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -9,12 +9,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- do not translate -->
   <title>Arbeitszeit</title>
-  <link rel="stylesheet" href="/static/bulma.css">
-  <link rel="stylesheet" href="/static/main.css">
+  <link rel="stylesheet" href="{{ url_for('.static', filename='bulma.css') }}">
+  <link rel="stylesheet" href="{{ url_for('.static', filename='main.css') }}">
   {% block style %}
   {% endblock %}
   <script defer src="https://use.fontawesome.com/releases/v6.1.1/js/all.js"></script>
-  <script src="/static/main.js"></script>
+  <script src="{{ url_for('.static', filename='main.js') }}"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Previously we hardcoded the link target for our static files into the base template. This PR changes this to utilize the proper `static` macro provided by flask.

No certs needed.