### PR TITLE
Implement price checking interface for testing

### DIFF
--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -11,6 +11,7 @@ from tests.data_generators import (
 from tests.datetime_service import FakeDatetimeService
 
 from .dependency_injection import get_dependency_injector
+from .price_checker import PriceChecker
 
 T = TypeVar("T")
 
@@ -59,3 +60,4 @@ class BaseTestCase(TestCase):
     accountant_generator = _lazy_property(AccountantGenerator)
     coop_generator = _lazy_property(CooperationGenerator)
     datetime_service = _lazy_property(FakeDatetimeService)
+    price_checker = _lazy_property(PriceChecker)

--- a/tests/use_cases/price_checker.py
+++ b/tests/use_cases/price_checker.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from injector import inject
+
+from arbeitszeit.use_cases.get_plan_summary_member import GetPlanSummaryMember
+
+
+@inject
+@dataclass
+class PriceChecker:
+    get_plan_summary_member: GetPlanSummaryMember
+
+    def get_unit_price(self, plan: UUID) -> Decimal:
+        response = self.get_plan_summary_member(plan)
+        assert isinstance(response, GetPlanSummaryMember.Success)
+        return response.plan_summary.price_per_unit
+
+    def get_unit_cost(self, plan: UUID) -> Decimal:
+        response = self.get_plan_summary_member(plan)
+        assert isinstance(response, GetPlanSummaryMember.Success)
+        summary = response.plan_summary
+        return (
+            summary.means_cost + summary.resources_cost + summary.labour_cost
+        ) / summary.amount

--- a/tests/use_cases/test_accept_cooperation.py
+++ b/tests/use_cases/test_accept_cooperation.py
@@ -3,262 +3,214 @@ from decimal import Decimal
 from uuid import uuid4
 
 from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.price_calculator import calculate_price
 from arbeitszeit.use_cases import AcceptCooperation, AcceptCooperationRequest
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.data_generators import CooperationGenerator
 
-from .dependency_injection import injection_test
-from .repositories import PlanRepository
-
-
-@injection_test
-def test_error_is_raised_when_plan_does_not_exist(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=uuid4(), cooperation_id=cooperation.id
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert response.rejection_reason == response.RejectionReason.plan_not_found
+from .base_test_case import BaseTestCase
 
 
-@injection_test
-def test_error_is_raised_when_cooperation_does_not_exist(
-    accept_cooperation: AcceptCooperation,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan = plan_generator.create_plan()
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=uuid4()
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert response.rejection_reason == response.RejectionReason.cooperation_not_found
+class AcceptCooperationTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.cooperation_generator = self.injector.get(CooperationGenerator)
+        self.accept_cooperation = self.injector.get(AcceptCooperation)
 
-
-@injection_test
-def test_error_is_raised_when_plan_is_already_in_cooperation(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    cooperation1 = cooperation_generator.create_cooperation()
-    cooperation2 = cooperation_generator.create_cooperation(coordinator=requester)
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), cooperation=cooperation1
-    )
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation2.id
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert response.rejection_reason == response.RejectionReason.plan_has_cooperation
-
-
-@injection_test
-def test_error_is_raised_when_plan_is_public_plan(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), is_public_service=True
-    )
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert response.rejection_reason == response.RejectionReason.plan_is_public_service
-
-
-@injection_test
-def test_error_is_raised_when_cooperation_was_not_requested(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan = plan_generator.create_plan(activation_date=datetime.now())
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert (
-        response.rejection_reason
-        == response.RejectionReason.cooperation_was_not_requested
-    )
-
-
-@injection_test
-def test_error_is_raised_when_requester_is_not_coordinator_of_cooperation(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    coordinator = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=coordinator)
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), requested_cooperation=cooperation
-    )
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    response = accept_cooperation(request)
-    assert response.is_rejected
-    assert (
-        response.rejection_reason
-        == response.RejectionReason.requester_is_not_coordinator
-    )
-
-
-@injection_test
-def test_possible_to_add_plan_to_cooperation(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), requested_cooperation=cooperation
-    )
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    response = accept_cooperation(request)
-    assert not response.is_rejected
-
-
-@injection_test
-def test_cooperation_is_added_to_plan(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), requested_cooperation=cooperation
-    )
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    accept_cooperation(request)
-    assert plan.cooperation == cooperation.id
-
-
-@injection_test
-def test_two_cooperating_plans_have_same_prices(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-    plan_repository: PlanRepository,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    plan1 = plan_generator.create_plan(
-        activation_date=datetime.now(),
-        costs=ProductionCosts(Decimal(10), Decimal(20), Decimal(30)),
-        requested_cooperation=cooperation,
-    )
-    plan2 = plan_generator.create_plan(
-        activation_date=datetime.now(),
-        costs=ProductionCosts(Decimal(1), Decimal(2), Decimal(3)),
-        requested_cooperation=cooperation,
-    )
-    request1 = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
-    )
-    request2 = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
-    )
-    accept_cooperation(request1)
-    accept_cooperation(request2)
-    assert calculate_price(
-        list(plan_repository.get_plans().that_are_in_same_cooperation_as(plan1.id))
-    ) == calculate_price(
-        list(plan_repository.get_plans().that_are_in_same_cooperation_as(plan2.id))
-    )
-
-
-@injection_test
-def test_price_of_cooperating_plans_is_correctly_calculated(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-    plan_repository: PlanRepository,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    plan1 = plan_generator.create_plan(
-        activation_date=datetime.now(),
-        costs=ProductionCosts(Decimal(10), Decimal(5), Decimal(5)),
-        amount=10,
-        requested_cooperation=cooperation,
-    )
-    plan2 = plan_generator.create_plan(
-        activation_date=datetime.now(),
-        costs=ProductionCosts(Decimal(5), Decimal(3), Decimal(2)),
-        amount=10,
-        requested_cooperation=cooperation,
-    )
-    request1 = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
-    )
-    request2 = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
-    )
-    accept_cooperation(request1)
-    accept_cooperation(request2)
-    # In total costs of 30h and 20 units -> price should be 1.5h per unit
-    assert (
-        calculate_price(
-            list(plan_repository.get_plans().that_are_in_same_cooperation_as(plan1.id))
+    def test_error_is_raised_when_plan_does_not_exist(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
         )
-        == calculate_price(
-            list(plan_repository.get_plans().that_are_in_same_cooperation_as(plan2.id))
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=uuid4(), cooperation_id=cooperation.id
         )
-        == Decimal("1.5")
-    )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert response.rejection_reason == response.RejectionReason.plan_not_found
 
+    def test_error_is_raised_when_cooperation_does_not_exist(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan = self.plan_generator.create_plan()
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=uuid4()
+        )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert (
+            response.rejection_reason == response.RejectionReason.cooperation_not_found
+        )
 
-@injection_test
-def test_that_attribute_requested_cooperation_is_set_to_none_after_start_of_cooperation(
-    accept_cooperation: AcceptCooperation,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    cooperation = cooperation_generator.create_cooperation(coordinator=requester)
-    plan = plan_generator.create_plan(
-        activation_date=datetime.now(), requested_cooperation=cooperation
-    )
-    request = AcceptCooperationRequest(
-        requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
-    )
-    assert plan.requested_cooperation == cooperation.id
-    accept_cooperation(request)
-    assert plan.requested_cooperation is None
+    def test_error_is_raised_when_plan_is_already_in_cooperation(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation1 = self.cooperation_generator.create_cooperation()
+        cooperation2 = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), cooperation=cooperation1
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation2.id
+        )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert (
+            response.rejection_reason == response.RejectionReason.plan_has_cooperation
+        )
+
+    def test_error_is_raised_when_plan_is_public_plan(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), is_public_service=True
+        )
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert (
+            response.rejection_reason == response.RejectionReason.plan_is_public_service
+        )
+
+    def test_error_is_raised_when_cooperation_was_not_requested(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan = self.plan_generator.create_plan(activation_date=datetime.now())
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert (
+            response.rejection_reason
+            == response.RejectionReason.cooperation_was_not_requested
+        )
+
+    def test_error_is_raised_when_requester_is_not_coordinator_of_cooperation(
+        self,
+    ) -> None:
+        requester = self.company_generator.create_company_entity()
+        coordinator = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=coordinator
+        )
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), requested_cooperation=cooperation
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        response = self.accept_cooperation(request)
+        assert response.is_rejected
+        assert (
+            response.rejection_reason
+            == response.RejectionReason.requester_is_not_coordinator
+        )
+
+    def test_possible_to_add_plan_to_cooperation(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), requested_cooperation=cooperation
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        response = self.accept_cooperation(request)
+        assert not response.is_rejected
+
+    def test_cooperation_is_added_to_plan(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), requested_cooperation=cooperation
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        self.accept_cooperation(request)
+        assert plan.cooperation == cooperation.id
+
+    def test_two_cooperating_plans_have_same_prices(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan1 = self.plan_generator.create_plan(
+            activation_date=datetime.now(),
+            costs=ProductionCosts(Decimal(10), Decimal(20), Decimal(30)),
+            requested_cooperation=cooperation,
+        )
+        plan2 = self.plan_generator.create_plan(
+            activation_date=datetime.now(),
+            costs=ProductionCosts(Decimal(1), Decimal(2), Decimal(3)),
+            requested_cooperation=cooperation,
+        )
+        request1 = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
+        )
+        request2 = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
+        )
+        self.accept_cooperation(request1)
+        self.accept_cooperation(request2)
+        assert self.price_checker.get_unit_price(
+            plan1.id
+        ) == self.price_checker.get_unit_price(plan2.id)
+
+    def test_price_of_cooperating_plans_is_correctly_calculated(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan1 = self.plan_generator.create_plan(
+            activation_date=datetime.now(),
+            costs=ProductionCosts(Decimal(10), Decimal(5), Decimal(5)),
+            amount=10,
+            requested_cooperation=cooperation,
+        )
+        plan2 = self.plan_generator.create_plan(
+            activation_date=datetime.now(),
+            costs=ProductionCosts(Decimal(5), Decimal(3), Decimal(2)),
+            amount=10,
+            requested_cooperation=cooperation,
+        )
+        request1 = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
+        )
+        request2 = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
+        )
+        self.accept_cooperation(request1)
+        self.accept_cooperation(request2)
+        # In total costs of 30h and 20 units -> price should be 1.5h per unit
+        assert (
+            self.price_checker.get_unit_price(plan1.id)
+            == self.price_checker.get_unit_price(plan2.id)
+            == Decimal("1.5")
+        )
+
+    def test_that_attribute_requested_cooperation_is_set_to_none_after_start_of_cooperation(
+        self,
+    ) -> None:
+        requester = self.company_generator.create_company_entity()
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
+        plan = self.plan_generator.create_plan(
+            activation_date=datetime.now(), requested_cooperation=cooperation
+        )
+        request = AcceptCooperationRequest(
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+        )
+        assert plan.requested_cooperation == cooperation.id
+        self.accept_cooperation(request)
+        assert plan.requested_cooperation is None

--- a/tests/use_cases/test_approve_plan.py
+++ b/tests/use_cases/test_approve_plan.py
@@ -23,12 +23,7 @@ from arbeitszeit.use_cases.query_plans import (
 )
 
 from .base_test_case import BaseTestCase
-from .repositories import (
-    AccountRepository,
-    PlanDraftRepository,
-    PlanRepository,
-    TransactionRepository,
-)
+from .repositories import AccountRepository, PlanDraftRepository, TransactionRepository
 
 
 class UseCaseTests(BaseTestCase):
@@ -38,7 +33,6 @@ class UseCaseTests(BaseTestCase):
         self.get_company_summary = self.injector.get(GetCompanySummary)
         self.query_plans = self.injector.get(QueryPlans)
         self.draft_repository = self.injector.get(PlanDraftRepository)
-        self.plan_repository = self.injector.get(PlanRepository)
         self.pay_means_of_production = self.injector.get(PayMeansOfProduction)
         self.account_repository = self.injector.get(AccountRepository)
         self.transaction_repository = self.injector.get(TransactionRepository)

--- a/tests/use_cases/test_get_coop_summary.py
+++ b/tests/use_cases/test_get_coop_summary.py
@@ -3,128 +3,96 @@ from decimal import Decimal
 from typing import Callable
 from uuid import uuid4
 
+from pytest import approx
+
 from arbeitszeit.entities import ProductionCosts
-from arbeitszeit.price_calculator import calculate_price
 from arbeitszeit.use_cases import (
     GetCoopSummary,
     GetCoopSummaryRequest,
     GetCoopSummaryResponse,
     GetCoopSummarySuccess,
 )
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.data_generators import CooperationGenerator
 
-from .dependency_injection import injection_test
-
-
-@injection_test
-def test_that_none_is_returned_when_cooperation_does_not_exist(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company_entity()
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, uuid4()))
-    assert summary is None
+from .base_test_case import BaseTestCase
 
 
-@injection_test
-def test_that_requester_is_correctly_defined_as_equal_to_coordinator(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-):
-    requester = company_generator.create_company_entity()
-    coop = cooperation_generator.create_cooperation(coordinator=requester)
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: s.requester_is_coordinator == True)
+class GetCoopSummaryTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.get_coop_summary = self.injector.get(GetCoopSummary)
+        self.cooperation_generator = self.injector.get(CooperationGenerator)
 
+    def test_that_none_is_returned_when_cooperation_does_not_exist(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, uuid4()))
+        assert summary is None
 
-@injection_test
-def test_that_requester_is_correctly_defined_as_different_from_coordinator(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-):
-    requester = company_generator.create_company_entity()
-    coop = cooperation_generator.create_cooperation()
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: s.requester_is_coordinator == False)
+    def test_that_requester_is_correctly_defined_as_equal_to_coordinator(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        coop = self.cooperation_generator.create_cooperation(coordinator=requester)
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(summary, lambda s: s.requester_is_coordinator == True)
 
+    def test_that_requester_is_correctly_defined_as_different_from_coordinator(
+        self,
+    ) -> None:
+        requester = self.company_generator.create_company_entity()
+        coop = self.cooperation_generator.create_cooperation()
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(summary, lambda s: s.requester_is_coordinator == False)
 
-@injection_test
-def test_that_correct_amount_of_associated_plans_are_shown(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan1 = plan_generator.create_plan(activation_date=datetime.min)
-    plan2 = plan_generator.create_plan(activation_date=datetime.min)
-    coop = cooperation_generator.create_cooperation(plans=[plan1, plan2])
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: len(s.plans) == 2)
+    def test_that_correct_amount_of_associated_plans_are_shown(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan1 = self.plan_generator.create_plan(activation_date=datetime.min)
+        plan2 = self.plan_generator.create_plan(activation_date=datetime.min)
+        coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(summary, lambda s: len(s.plans) == 2)
 
+    def test_that_correct_coordinator_id_is_shown(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan1 = self.plan_generator.create_plan(activation_date=datetime.min)
+        plan2 = self.plan_generator.create_plan(activation_date=datetime.min)
+        coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(summary, lambda s: s.coordinator_id == coop.coordinator.id)
 
-@injection_test
-def test_that_correct_coordinator_id_is_shown(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan1 = plan_generator.create_plan(activation_date=datetime.min)
-    plan2 = plan_generator.create_plan(activation_date=datetime.min)
-    coop = cooperation_generator.create_cooperation(plans=[plan1, plan2])
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: s.coordinator_id == coop.coordinator.id)
+    def test_that_correct_coordinator_name_is_shown(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan1 = self.plan_generator.create_plan(activation_date=datetime.min)
+        plan2 = self.plan_generator.create_plan(activation_date=datetime.min)
+        coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(
+            summary, lambda s: s.coordinator_name == coop.coordinator.name
+        )
 
+    def test_that_correct_info_of_associated_plan_is_shown(self) -> None:
+        requester = self.company_generator.create_company_entity()
+        plan1 = self.plan_generator.create_plan(
+            activation_date=datetime.min,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(1)),
+            amount=10,
+        )
+        plan2 = self.plan_generator.create_plan(
+            activation_date=datetime.min,
+            costs=ProductionCosts(Decimal(4), Decimal(4), Decimal(2)),
+            amount=10,
+        )
+        coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        self.assert_success(summary, lambda s: len(s.plans) == 2)
+        assert summary is not None
+        assert summary.plans[0].plan_id == plan1.id
+        assert summary.plans[0].plan_name == plan1.prd_name
+        assert summary.plans[0].plan_individual_price == approx(Decimal("0.5"))
+        assert summary.plans[0].plan_coop_price == approx(Decimal("0.75"))
 
-@injection_test
-def test_that_correct_coordinator_name_is_shown(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan1 = plan_generator.create_plan(activation_date=datetime.min)
-    plan2 = plan_generator.create_plan(activation_date=datetime.min)
-    coop = cooperation_generator.create_cooperation(plans=[plan1, plan2])
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: s.coordinator_name == coop.coordinator.name)
-
-
-@injection_test
-def test_that_correct_info_of_associated_plan_is_shown(
-    get_coop_summary: GetCoopSummary,
-    company_generator: CompanyGenerator,
-    cooperation_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-):
-    requester = company_generator.create_company_entity()
-    plan1 = plan_generator.create_plan(
-        activation_date=datetime.min,
-        costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(1)),
-        amount=10,
-    )
-    plan2 = plan_generator.create_plan(
-        activation_date=datetime.min,
-        costs=ProductionCosts(Decimal(4), Decimal(4), Decimal(2)),
-        amount=10,
-    )
-    coop = cooperation_generator.create_cooperation(plans=[plan1, plan2])
-    summary = get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
-    assert_success(summary, lambda s: len(s.plans) == 2)
-    assert summary is not None
-    assert summary.plans[0].plan_id == plan1.id
-    assert summary.plans[0].plan_name == plan1.prd_name
-    assert summary.plans[0].plan_individual_price == calculate_price([plan1])
-    assert summary.plans[0].plan_coop_price == calculate_price([plan1, plan2])
-
-
-def assert_success(
-    response: GetCoopSummaryResponse, assertion: Callable[[GetCoopSummarySuccess], bool]
-) -> None:
-    assert isinstance(response, GetCoopSummarySuccess)
-    assert assertion(response)
+    def assert_success(
+        self,
+        response: GetCoopSummaryResponse,
+        assertion: Callable[[GetCoopSummarySuccess], bool],
+    ) -> None:
+        assert isinstance(response, GetCoopSummarySuccess)
+        assert assertion(response)


### PR DESCRIPTION
This PR implements a new `PriceChecker` class. Instances of this class allow the programmer to access per-unit-prices and per-unit-cost of plans, which might be different if a plan is part of a coop. This was done to decouple the tests from the concrete price calculation implementation. Instead this price checker uses the `GetPlanSummaryMember` use case to get its information.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418

EDIT: I also refactored some use case tests into the class based approach.