### PR TITLE
Introduce PlanUpdate to arbeitszeit.repositories

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -99,14 +99,23 @@ class PlanResult(QueryResult[Plan], Protocol):
         coordinator.
         """
 
-    def set_cooperation(self, cooperation: Optional[UUID]) -> int:
+    def update(self) -> PlanUpdate:
+        """Prepare an update for all selected Plans."""
+
+
+class PlanUpdate(Protocol):
+    """Aggregate updates on a previously selected set of plan rows in
+    the DB and execute them all in one.
+    """
+
+    def set_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
         """Set the associated cooperation of all matching plans to the
         one specified via the cooperation argument. Specifying `None`
         will unset the cooperation field. The return value counts all
         plans that were updated through this method.
         """
 
-    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> int:
+    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
         """Set the `requested_cooperation` field of all matching plans
         to the specified value.  A value `None` means that these plans
         are marked as not requesting membership in any
@@ -114,14 +123,19 @@ class PlanResult(QueryResult[Plan], Protocol):
         updated through this method.
         """
 
-    def set_approval_date(self, approval_date: Optional[datetime]) -> int:
+    def set_approval_date(self, approval_date: Optional[datetime]) -> PlanUpdate:
         """Set the approval date of all matching plans. The return
         value counts all the plans that were changed by this methods.
         """
 
-    def set_approval_reason(self, reason: Optional[str]) -> int:
+    def set_approval_reason(self, reason: Optional[str]) -> PlanUpdate:
         """Set the approval reason for all matching plans. The return
         value counts all the plans that were changed by this method.
+        """
+
+    def perform(self) -> int:
+        """Perform the update action and return the number of columns
+        affected.
         """
 
 

--- a/arbeitszeit/use_cases/accept_cooperation.py
+++ b/arbeitszeit/use_cases/accept_cooperation.py
@@ -50,8 +50,9 @@ class AcceptCooperation:
         except AcceptCooperationResponse.RejectionReason as reason:
             return AcceptCooperationResponse(rejection_reason=reason)
         plan = self.plan_repository.get_plans().with_id(request.plan_id)
-        plan.set_cooperation(request.cooperation_id)
-        plan.set_requested_cooperation(None)
+        plan.update().set_cooperation(request.cooperation_id).set_requested_cooperation(
+            None
+        ).perform()
         return AcceptCooperationResponse(rejection_reason=None)
 
     def _validate_request(self, request: AcceptCooperationRequest) -> None:

--- a/arbeitszeit/use_cases/approve_plan.py
+++ b/arbeitszeit/use_cases/approve_plan.py
@@ -40,8 +40,9 @@ class ApprovePlanUseCase:
         assert planner
         if plan.is_approved:
             return self.Response(is_approved=False)
-        matching_plans.set_approval_date(self.datetime_service.now())
-        matching_plans.set_approval_reason("approved")
+        matching_plans.update().set_approval_date(
+            self.datetime_service.now()
+        ).set_approval_reason("approved").perform()
         self.plan_repository.activate_plan(
             plan=plan, activation_date=self.datetime_service.now()
         )

--- a/arbeitszeit/use_cases/cancel_cooperation_solicitation.py
+++ b/arbeitszeit/use_cases/cancel_cooperation_solicitation.py
@@ -23,6 +23,8 @@ class CancelCooperationSolicitation:
             .with_id(request.plan_id)
             .planned_by(request.requester_id)
             .that_request_cooperation_with_coordinator()
+            .update()
             .set_requested_cooperation(None)
+            .perform()
         )
         return bool(plans_changed_count)

--- a/arbeitszeit/use_cases/deny_cooperation.py
+++ b/arbeitszeit/use_cases/deny_cooperation.py
@@ -49,7 +49,7 @@ class DenyCooperation:
 
         self.plan_repository.get_plans().with_id(
             request.plan_id
-        ).set_requested_cooperation(None)
+        ).update().set_requested_cooperation(None).perform()
         return DenyCooperationResponse(rejection_reason=None)
 
     def _validate_request(self, request: DenyCooperationRequest) -> None:

--- a/arbeitszeit/use_cases/end_cooperation.py
+++ b/arbeitszeit/use_cases/end_cooperation.py
@@ -44,7 +44,9 @@ class EndCooperation:
         assert (
             self.plan_repository.get_plans()
             .with_id(request.plan_id)
+            .update()
             .set_cooperation(None)
+            .perform()
         )
         return EndCooperationResponse(rejection_reason=None)
 

--- a/arbeitszeit/use_cases/request_cooperation.py
+++ b/arbeitszeit/use_cases/request_cooperation.py
@@ -58,7 +58,7 @@ class RequestCooperation:
             )
         self.plan_repository.get_plans().with_id(
             request.plan_id
-        ).set_requested_cooperation(request.cooperation_id)
+        ).update().set_requested_cooperation(request.cooperation_id).perform()
         return RequestCooperationResponse(
             coordinator_name=cooperation.coordinator.name,
             coordinator_email=cooperation.coordinator.email,

--- a/arbeitszeit/use_cases/update_plans_and_payout.py
+++ b/arbeitszeit/use_cases/update_plans_and_payout.py
@@ -128,5 +128,4 @@ class UpdatePlansAndPayout:
 
     def _delete_cooperation_and_coop_request_from_plan(self, plan: Plan) -> None:
         plans = self.plan_repository.get_plans().with_id(plan.id)
-        plans.set_requested_cooperation(None)
-        plans.set_cooperation(None)
+        plans.update().set_requested_cooperation(None).set_cooperation(None).perform()

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -502,7 +502,9 @@ class CooperationGenerator:
             assert (
                 self.plan_repository.get_plans()
                 .with_id(*[plan.id for plan in plans])
+                .update()
                 .set_cooperation(cooperation.id)
+                .perform()
             )
         return cooperation
 

--- a/tests/flask_integration/test_plan_repository.py
+++ b/tests/flask_integration/test_plan_repository.py
@@ -437,14 +437,16 @@ class GetAllPlans(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         plan = self.plan_generator.create_plan()
 
-        self.plan_repository.get_plans().with_id(plan.id).set_cooperation(
+        self.plan_repository.get_plans().with_id(plan.id).update().set_cooperation(
             cooperation.id
-        )
+        ).perform()
         plan_from_orm = self.plan_repository.get_plans().with_id(plan.id).first()
         assert plan_from_orm
         assert plan_from_orm.cooperation == cooperation.id
 
-        self.plan_repository.get_plans().with_id(plan.id).set_cooperation(None)
+        self.plan_repository.get_plans().with_id(plan.id).update().set_cooperation(
+            None
+        ).perform()
         plan_from_orm = self.plan_repository.get_plans().with_id(plan.id).first()
         assert plan_from_orm
         assert plan_from_orm.cooperation is None
@@ -453,21 +455,21 @@ class GetAllPlans(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         plan = self.plan_generator.create_plan()
         plan_result = self.plan_repository.get_plans().with_id(plan.id)
-        plan_result.set_requested_cooperation(cooperation.id)
+        plan_result.update().set_requested_cooperation(cooperation.id).perform()
         assert plan_result.that_request_cooperation_with_coordinator()
-        plan_result.set_requested_cooperation(None)
+        plan_result.update().set_requested_cooperation(None).perform()
         assert not plan_result.that_request_cooperation_with_coordinator()
 
     def test_can_set_approval_date(self) -> None:
         plan = self.plan_generator.create_plan()
         plans = self.plan_repository.get_plans().with_id(plan.id)
         expected_approval_date = datetime(2000, 3, 2)
-        assert plans.set_approval_date(expected_approval_date)
+        assert plans.update().set_approval_date(expected_approval_date).perform()
         assert all(plan.approval_date == expected_approval_date for plan in plans)
 
     def test_can_set_approval_reason(self) -> None:
         plan = self.plan_generator.create_plan()
         plans = self.plan_repository.get_plans().with_id(plan.id)
         expected_approval_reason = "test approval reason"
-        assert plans.set_approval_reason(expected_approval_reason)
+        assert plans.update().set_approval_reason(expected_approval_reason).perform()
         assert all(plan.approval_reason == expected_approval_reason for plan in plans)


### PR DESCRIPTION
This PR introduces a new concept to our database interface: The `*Update` object.

With this PR there is only one instance of such a `Protocol` introduced, the `PlanUpdate`.

## The problem

When defining methods on `PlanResult` one needs to decide how granular the individual update methods would be. For example:
Is it better have one method `.set_plan_approval_date_and_reason(self, date, reason)` or is it better to have two separate methods `.set_approval_reason(self, reason)` and `.set_approval_date(self)`. On first glance it looks like the second option (to have two separate methods) is superior since you can have combine both methods into the hypothetical `set_plan_approval_date_and_reason` method from before. But this can lead to performance problems later down the line, since you have to hit the database twice now. The first option is also bad. Let's say that we would have the `set_plan_approval_date_and_reason` in our code. Later we would find out that we need to manipulate the `approval_reason` independently of the `approval_date`. Now we need to introduce a separate method `.set_approval_reason(self, reason)` which is code duplication and error prone.

## The (proposed) solution

This PR proposes a new `PlanUpdate` objects. It can be created from a `PlanResult` by calling the `update(self)` method on a `PlanResult`. This `PlanUpdate` objects allows the programmer to aggregate multiple "update actions" and then executing them all in one go by calling the `perform(self)` method on the `PlanUpdate` object. This way we can define very granular udpate actions like e.g. `set_approval_date` and `set_approval_reason` without the performance penalty of our old approach.

Please comment any concerns that you might have, since this is introducing something new to our code base.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418