### PR TITLE
Allow pinning of mccabe package

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -17,6 +17,7 @@ coverage==6.4.4
 cycler==0.11.0
 defusedxml==0.7.1
 dnspython==2.2.1
+docutils==0.19
 email-validator==1.3.0
 flake8==6.0.0
 Flask==2.2.2

--- a/update-requirements-from-nix
+++ b/update-requirements-from-nix
@@ -118,15 +118,9 @@ class VersionStringCleaner:
 
 class PackageFilter:
     def is_package_to_be_included_in_requirements(self, package_name: str) -> bool:
-        # As of 12. Jul 2022 the nix environment uses mccabe 0.7,
-        # which is in conflict with flake8 requirements 'mccabe <
-        # 0.7'. mccabe 0.6.1 and 0.7 seem to work fine with flake8. So
-        # to avoid pip complaining about dependency conflicts we
-        # filter mccabe and let pip decide which version to use. There
-        # is a similar situation with docutils and sphinx.  Since we
-        # use a custom flask-profiler package we need to exclude it
-        # from constraints.txt
-        return package_name not in ["docutils", "flask-profiler"]
+        # Since we use a custom flask-profiler package we need to
+        # exclude it from constraints.txt
+        return package_name not in ["flask-profiler"]
 
 
 def parse_arguments():


### PR DESCRIPTION
Previously we forbade pinning `mccabe` and `docutils` in `constraints.txt`. This has become obsolete. This can be verified by seeing the "pip-tests" pass.

No certs needed.