### PR TITLE
Refactor dependency injection code

### DIFF
--- a/arbeitszeit/injector.py
+++ b/arbeitszeit/injector.py
@@ -91,7 +91,25 @@ class Provider(Protocol, Generic[T_cov]):
         ...
 
 
+class AliasProvider(Generic[T]):
+    """This provider provides instances by simply refering to another
+    class.  This can be useful when specifying the concret
+    implementation of an abstract base class (ABC) or a Protocol.
+    """
+
+    def __init__(self, cls: Type[T]) -> None:
+        self.cls = cls
+
+    def provide(self, binder: Binder) -> T:
+        provider = binder.get(self.cls)
+        return provider.provide(binder)
+
+
 class InstanceProvider(Provider[T]):
+    """Provide an instance of of a class by specifying the concrete
+    instance in the provider.
+    """
+
     def __init__(self, instance: T) -> None:
         self.instance = instance
 
@@ -100,6 +118,15 @@ class InstanceProvider(Provider[T]):
 
 
 class ClassProvider(Provider[T]):
+    """Provide an instance of a type by calling its constructor
+    (__init__ method) and providing its arguments from dependency
+    injection.
+
+    This provider usually doen't need to be specified directly since
+    it is assumed to be the default in case no other provider was
+    specified.
+    """
+
     def __init__(self, cls: Type[T]) -> None:
         self.cls = cls
 
@@ -128,6 +155,10 @@ class ClassProvider(Provider[T]):
 
 
 class CallableProvider(Provider[T]):
+    """Provide an instance by calling a function.  The arguments to
+    the function will be provide by dependency injection.
+    """
+
     def __init__(self, f: Callable[..., T], is_singleton: bool = False) -> None:
         self.f = f
         self._is_singleton = is_singleton

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -9,9 +9,9 @@ from arbeitszeit.accountant_notifications import NotifyAccountantsAboutNewPlanPr
 from arbeitszeit.control_thresholds import ControlThresholds
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.injector import (
+    AliasProvider,
     Binder,
     CallableProvider,
-    ClassProvider,
     Injector,
     Module,
 )
@@ -91,21 +91,21 @@ from arbeitszeit_web.url_index import (
 class AccountantModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[TemplateIndex] = ClassProvider(AccountantTemplateIndex)  # type: ignore
+        binder[TemplateIndex] = AliasProvider(AccountantTemplateIndex)  # type: ignore
 
 
 class MemberModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[TemplateIndex] = ClassProvider(MemberTemplateIndex)  # type: ignore
+        binder[TemplateIndex] = AliasProvider(MemberTemplateIndex)  # type: ignore
 
 
 class CompanyModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[RenewPlanUrlIndex] = ClassProvider(CompanyUrlIndex)  # type: ignore
-        binder[HidePlanUrlIndex] = ClassProvider(CompanyUrlIndex)  # type: ignore
-        binder[TemplateIndex] = ClassProvider(CompanyTemplateIndex)  # type: ignore
+        binder[RenewPlanUrlIndex] = AliasProvider(CompanyUrlIndex)  # type: ignore
+        binder[HidePlanUrlIndex] = AliasProvider(CompanyUrlIndex)  # type: ignore
+        binder[TemplateIndex] = AliasProvider(CompanyTemplateIndex)  # type: ignore
 
 
 class FlaskModule(Module):
@@ -113,7 +113,7 @@ class FlaskModule(Module):
         super().configure(binder)
         binder.bind(
             interfaces.PurchaseRepository,  # type: ignore
-            to=ClassProvider(PurchaseRepository),
+            to=AliasProvider(PurchaseRepository),
         )
         binder.bind(
             entities.SocialAccounting,
@@ -121,39 +121,39 @@ class FlaskModule(Module):
         )
         binder.bind(
             interfaces.AccountRepository,  # type: ignore
-            to=ClassProvider(AccountRepository),
+            to=AliasProvider(AccountRepository),
         )
         binder.bind(
             interfaces.MemberRepository,  # type: ignore
-            to=ClassProvider(MemberRepository),
+            to=AliasProvider(MemberRepository),
         )
         binder.bind(
             interfaces.CompanyRepository,  # type: ignore
-            to=ClassProvider(CompanyRepository),
+            to=AliasProvider(CompanyRepository),
         )
         binder.bind(
             interfaces.PurchaseRepository,  # type: ignore
-            to=ClassProvider(PurchaseRepository),
+            to=AliasProvider(PurchaseRepository),
         )
         binder.bind(
             interfaces.PlanRepository,  # type: ignore
-            to=ClassProvider(PlanRepository),
+            to=AliasProvider(PlanRepository),
         )
         binder.bind(
             interfaces.AccountOwnerRepository,  # type: ignore
-            to=ClassProvider(AccountOwnerRepository),
+            to=AliasProvider(AccountOwnerRepository),
         )
         binder.bind(
             interfaces.PlanDraftRepository,  # type: ignore
-            to=ClassProvider(PlanDraftRepository),
+            to=AliasProvider(PlanDraftRepository),
         )
         binder.bind(
             DatetimeService,  # type: ignore
-            to=ClassProvider(RealtimeDatetimeService),
+            to=AliasProvider(RealtimeDatetimeService),
         )
         binder.bind(
             interfaces.WorkerInviteRepository,  # type: ignore
-            to=ClassProvider(WorkerInviteRepository),
+            to=AliasProvider(WorkerInviteRepository),
         )
         binder.bind(
             SQLAlchemy,
@@ -161,38 +161,38 @@ class FlaskModule(Module):
         )
         binder.bind(
             interfaces.CooperationRepository,  # type: ignore
-            to=ClassProvider(CooperationRepository),
+            to=AliasProvider(CooperationRepository),
         )
-        binder.bind(TokenService, to=ClassProvider(FlaskTokenService))  # type: ignore
-        binder.bind(UserAddressBook, to=ClassProvider(UserAddressBookImpl))  # type: ignore
+        binder.bind(TokenService, to=AliasProvider(FlaskTokenService))  # type: ignore
+        binder.bind(UserAddressBook, to=AliasProvider(UserAddressBookImpl))  # type: ignore
         binder.bind(
             interfaces.PayoutFactorRepository,  # type: ignore
-            to=ClassProvider(PayoutFactorRepository),
+            to=AliasProvider(PayoutFactorRepository),
         )
-        binder[NotifyAccountantsAboutNewPlanPresenter] = ClassProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
-        binder[TextRenderer] = ClassProvider(TextRendererImpl)  # type: ignore
-        binder[Request] = ClassProvider(FlaskRequest)  # type: ignore
-        binder[UrlIndex] = ClassProvider(GeneralUrlIndex)  # type: ignore
-        binder[InvitationTokenValidator] = ClassProvider(FlaskTokenService)  # type: ignore
-        binder[RegistrationEmailTemplate] = ClassProvider(MemberRegistrationEmailTemplateImpl)  # type: ignore
-        binder[interfaces.LanguageRepository] = ClassProvider(LanguageRepositoryImpl)  # type: ignore
-        binder[LanguageService] = ClassProvider(LanguageRepositoryImpl)  # type: ignore
-        binder[EmailConfiguration] = ClassProvider(FlaskEmailConfiguration)  # type: ignore
-        binder[interfaces.TransactionRepository] = ClassProvider(TransactionRepository)  # type: ignore
-        binder[interfaces.AccountantRepository] = ClassProvider(AccountantRepository)  # type: ignore
-        binder[TemplateRenderer] = ClassProvider(FlaskTemplateRenderer)  # type: ignore
-        binder[Session] = ClassProvider(FlaskSession)  # type: ignore
-        binder[Notifier] = ClassProvider(FlaskFlashNotifier)  # type: ignore
+        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
+        binder[TextRenderer] = AliasProvider(TextRendererImpl)  # type: ignore
+        binder[Request] = AliasProvider(FlaskRequest)  # type: ignore
+        binder[UrlIndex] = AliasProvider(GeneralUrlIndex)  # type: ignore
+        binder[InvitationTokenValidator] = AliasProvider(FlaskTokenService)  # type: ignore
+        binder[RegistrationEmailTemplate] = AliasProvider(MemberRegistrationEmailTemplateImpl)  # type: ignore
+        binder[interfaces.LanguageRepository] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
+        binder[LanguageService] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
+        binder[EmailConfiguration] = AliasProvider(FlaskEmailConfiguration)  # type: ignore
+        binder[interfaces.TransactionRepository] = AliasProvider(TransactionRepository)  # type: ignore
+        binder[interfaces.AccountantRepository] = AliasProvider(AccountantRepository)  # type: ignore
+        binder[TemplateRenderer] = AliasProvider(FlaskTemplateRenderer)  # type: ignore
+        binder[Session] = AliasProvider(FlaskSession)  # type: ignore
+        binder[Notifier] = AliasProvider(FlaskFlashNotifier)  # type: ignore
         binder[MailService] = CallableProvider(get_mail_service)  # type: ignore
-        binder[Translator] = ClassProvider(FlaskTranslator)  # type: ignore
-        binder[Plotter] = ClassProvider(FlaskPlotter)  # type: ignore
-        binder[Colors] = ClassProvider(FlaskColors)  # type: ignore
-        binder[ControlThresholds] = ClassProvider(ControlThresholdsFlask)  # type: ignore
-        binder[LanguageChangerUrlIndex] = ClassProvider(GeneralUrlIndex)  # type: ignore
-        binder[CompanyRegistrationMessagePresenter] = ClassProvider(  # type: ignore
+        binder[Translator] = AliasProvider(FlaskTranslator)  # type: ignore
+        binder[Plotter] = AliasProvider(FlaskPlotter)  # type: ignore
+        binder[Colors] = AliasProvider(FlaskColors)  # type: ignore
+        binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)  # type: ignore
+        binder[LanguageChangerUrlIndex] = AliasProvider(GeneralUrlIndex)  # type: ignore
+        binder[CompanyRegistrationMessagePresenter] = AliasProvider(  # type: ignore
             RegistrationEmailPresenter
         )
-        binder[MemberRegistrationMessagePresenter] = ClassProvider(  # type: ignore
+        binder[MemberRegistrationMessagePresenter] = AliasProvider(  # type: ignore
             RegistrationEmailPresenter
         )
 

--- a/tests/controllers/dependency_injection.py
+++ b/tests/controllers/dependency_injection.py
@@ -1,4 +1,4 @@
-from arbeitszeit.injector import Binder, ClassProvider, Injector, Module
+from arbeitszeit.injector import AliasProvider, Binder, Injector, Module
 from arbeitszeit_web.session import Session
 from tests.dependency_injection import TestingModule
 from tests.session import FakeSession
@@ -8,7 +8,7 @@ from tests.use_cases.dependency_injection import InMemoryModule
 class ControllerTestsModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[Session] = ClassProvider(FakeSession)  # type: ignore
+        binder[Session] = AliasProvider(FakeSession)  # type: ignore
 
 
 def get_dependency_injector() -> Injector:

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -1,6 +1,6 @@
 from arbeitszeit.control_thresholds import ControlThresholds
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.injector import Binder, ClassProvider, Module
+from arbeitszeit.injector import AliasProvider, Binder, Module
 from arbeitszeit.token import (
     CompanyRegistrationMessagePresenter,
     MemberRegistrationMessagePresenter,
@@ -29,22 +29,22 @@ from tests.translator import FakeTranslator
 class TestingModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[CompanyRegistrationMessagePresenter] = ClassProvider(  # type: ignore
+        binder[CompanyRegistrationMessagePresenter] = AliasProvider(  # type: ignore
             TokenDeliveryService
         )
-        binder[MemberRegistrationMessagePresenter] = ClassProvider(  # type: ignore
+        binder[MemberRegistrationMessagePresenter] = AliasProvider(  # type: ignore
             TokenDeliveryService
         )
-        binder[TextRenderer] = ClassProvider(TextRendererImpl)  # type: ignore
-        binder[Colors] = ClassProvider(ColorsTestImpl)  # type: ignore
-        binder[Plotter] = ClassProvider(FakePlotter)  # type: ignore
-        binder[ControlThresholds] = ClassProvider(  # type: ignore
+        binder[TextRenderer] = AliasProvider(TextRendererImpl)  # type: ignore
+        binder[Colors] = AliasProvider(ColorsTestImpl)  # type: ignore
+        binder[Plotter] = AliasProvider(FakePlotter)  # type: ignore
+        binder[ControlThresholds] = AliasProvider(  # type: ignore
             ControlThresholdsTestImpl
         )
-        binder[Translator] = ClassProvider(FakeTranslator)  # type: ignore
-        binder[AccountantInvitationPresenter] = ClassProvider(  # type: ignore
+        binder[Translator] = AliasProvider(FakeTranslator)  # type: ignore
+        binder[AccountantInvitationPresenter] = AliasProvider(  # type: ignore
             AccountantInvitationPresenterTestImpl
         )
-        binder[DatetimeService] = ClassProvider(FakeDatetimeService)  # type: ignore
-        binder[UserAddressBook] = ClassProvider(FakeAddressBook)  # type: ignore
-        binder[Request] = ClassProvider(FakeRequest)  # type: ignore
+        binder[DatetimeService] = AliasProvider(FakeDatetimeService)  # type: ignore
+        binder[UserAddressBook] = AliasProvider(FakeAddressBook)  # type: ignore
+        binder[Request] = AliasProvider(FakeRequest)  # type: ignore

--- a/tests/presenters/dependency_injection.py
+++ b/tests/presenters/dependency_injection.py
@@ -1,4 +1,4 @@
-from arbeitszeit.injector import Binder, ClassProvider, Injector, Module
+from arbeitszeit.injector import AliasProvider, Binder, Injector, Module
 from arbeitszeit_web.email import EmailConfiguration, MailService
 from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
@@ -35,20 +35,20 @@ from .url_index import (
 class PresenterTestsInjector(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[AccountantInvitationEmailView] = ClassProvider(  # type: ignore
+        binder[AccountantInvitationEmailView] = AliasProvider(  # type: ignore
             AccountantInvitationEmailViewImpl
         )
-        binder[EmailConfiguration] = ClassProvider(FakeEmailConfiguration)  # type: ignore
-        binder[AccountantInvitationUrlIndex] = ClassProvider(AccountantInvitationUrlIndexImpl)  # type: ignore
-        binder[Notifier] = ClassProvider(NotifierTestImpl)  # type: ignore
-        binder[UrlIndex] = ClassProvider(UrlIndexTestImpl)
-        binder[Session] = ClassProvider(FakeSession)  # type: ignore
-        binder[Request] = ClassProvider(FakeRequest)  # type: ignore
-        binder[LanguageChangerUrlIndex] = ClassProvider(LanguageChangerUrlIndexImpl)  # type: ignore
-        binder[LanguageService] = ClassProvider(FakeLanguageService)  # type: ignore
-        binder[MailService] = ClassProvider(FakeEmailSender)  # type: ignore
-        binder[RenewPlanUrlIndex] = ClassProvider(RenewPlanUrlIndexTestImpl)  # type: ignore
-        binder[HidePlanUrlIndex] = ClassProvider(HidePlanUrlIndexTestImpl)  # type: ignore
+        binder[EmailConfiguration] = AliasProvider(FakeEmailConfiguration)  # type: ignore
+        binder[AccountantInvitationUrlIndex] = AliasProvider(AccountantInvitationUrlIndexImpl)  # type: ignore
+        binder[Notifier] = AliasProvider(NotifierTestImpl)  # type: ignore
+        binder[UrlIndex] = AliasProvider(UrlIndexTestImpl)
+        binder[Session] = AliasProvider(FakeSession)  # type: ignore
+        binder[Request] = AliasProvider(FakeRequest)  # type: ignore
+        binder[LanguageChangerUrlIndex] = AliasProvider(LanguageChangerUrlIndexImpl)  # type: ignore
+        binder[LanguageService] = AliasProvider(FakeLanguageService)  # type: ignore
+        binder[MailService] = AliasProvider(FakeEmailSender)  # type: ignore
+        binder[RenewPlanUrlIndex] = AliasProvider(RenewPlanUrlIndexTestImpl)  # type: ignore
+        binder[HidePlanUrlIndex] = AliasProvider(HidePlanUrlIndexTestImpl)  # type: ignore
 
 
 def get_dependency_injector() -> Injector:

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -2,9 +2,9 @@ import arbeitszeit.repositories as interfaces
 from arbeitszeit import entities
 from arbeitszeit.accountant_notifications import NotifyAccountantsAboutNewPlanPresenter
 from arbeitszeit.injector import (
+    AliasProvider,
     Binder,
     CallableProvider,
-    ClassProvider,
     Injector,
     Module,
 )
@@ -31,59 +31,56 @@ def provide_social_accounting_instance(
 class InMemoryModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[NotifyAccountantsAboutNewPlanPresenter] = ClassProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
-        binder[interfaces.LanguageRepository] = ClassProvider(  # type: ignore
+        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
+        binder[interfaces.LanguageRepository] = AliasProvider(  # type: ignore
             repositories.FakeLanguageRepository
         )
-        binder[interfaces.AccountantRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.AccountantRepository] = AliasProvider(  # type: ignore
             repositories.AccountantRepositoryTestImpl
         )
-        binder[AccountantInvitationPresenter] = ClassProvider(  # type: ignore
+        binder[AccountantInvitationPresenter] = AliasProvider(  # type: ignore
             AccountantInvitationPresenterTestImpl
         )
-        binder[InvitationTokenValidator] = ClassProvider(FakeTokenService)  # type: ignore
-        binder[InvitationTokenValidator] = ClassProvider(FakeTokenService)  # type: ignore
-        binder[interfaces.PurchaseRepository] = ClassProvider(  # type: ignore
+        binder[InvitationTokenValidator] = AliasProvider(FakeTokenService)  # type: ignore
+        binder[InvitationTokenValidator] = AliasProvider(FakeTokenService)  # type: ignore
+        binder[interfaces.PurchaseRepository] = AliasProvider(  # type: ignore
             repositories.PurchaseRepository
         )
-        binder[interfaces.TransactionRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.TransactionRepository] = AliasProvider(  # type: ignore
             repositories.TransactionRepository
         )
-        binder[interfaces.WorkerInviteRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.WorkerInviteRepository] = AliasProvider(  # type: ignore
             repositories.WorkerInviteRepository
         )
         binder[entities.SocialAccounting] = CallableProvider(
             provide_social_accounting_instance
         )
-        binder[interfaces.AccountRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.AccountRepository] = AliasProvider(  # type: ignore
             repositories.AccountRepository
         )
-        binder[repositories.AccountRepository] = ClassProvider(
-            repositories.AccountRepository
-        )
-        binder[interfaces.MemberRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.MemberRepository] = AliasProvider(  # type: ignore
             repositories.MemberRepository
         )
-        binder[interfaces.MemberRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.MemberRepository] = AliasProvider(  # type: ignore
             repositories.MemberRepository
         )
-        binder[interfaces.CompanyRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.CompanyRepository] = AliasProvider(  # type: ignore
             repositories.CompanyRepository
         )
-        binder[interfaces.PlanRepository] = ClassProvider(repositories.PlanRepository)  # type: ignore
-        binder[interfaces.PlanDraftRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.PlanRepository] = AliasProvider(repositories.PlanRepository)  # type: ignore
+        binder[interfaces.PlanDraftRepository] = AliasProvider(  # type: ignore
             repositories.PlanDraftRepository
         )
-        binder[interfaces.AccountOwnerRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.AccountOwnerRepository] = AliasProvider(  # type: ignore
             repositories.AccountOwnerRepository
         )
-        binder[interfaces.CooperationRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.CooperationRepository] = AliasProvider(  # type: ignore
             repositories.CooperationRepository
         )
-        binder[interfaces.PayoutFactorRepository] = ClassProvider(  # type: ignore
+        binder[interfaces.PayoutFactorRepository] = AliasProvider(  # type: ignore
             repositories.FakePayoutFactorRepository
         )
-        binder[TokenService] = ClassProvider(FakeTokenService)  # type: ignore
+        binder[TokenService] = AliasProvider(FakeTokenService)  # type: ignore
 
 
 def get_dependency_injector() -> Injector:

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -826,7 +826,6 @@ class PlanDraftRepository(interfaces.PlanDraftRepository):
         datetime_service: DatetimeService,
         company_repository: interfaces.CompanyRepository,
     ) -> None:
-        print("hi")
         self.drafts: List[PlanDraft] = []
         self.datetime_service = datetime_service
         self.company_repository = company_repository


### PR DESCRIPTION
This is a minor refactoring of the dependency injection logic. i introduced a new provider type `AliasProvider`. This provider is supposed to express that a specific type `A` should be provided by constructing a instance for type `B`. This is useful in cases where we want to provided an instance for a specific interface/protocol, e.g.

```python
binder.bind(MailService, AliasProvided(MainServiceTestImpl))
```

I think that this is clearer then the "old" version where one would specify a new `ClassProvider` instead. Also: The new design allows for the declaration of singletons on the injector level. This is not implemented yet though and will be a follow up on this PR.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418

EDIT: This change further improved the runtime of tests on my machine by ~5 seconds.