### PR TITLE
Python3.11 support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,7 @@
             inherit (pkgs) python3;
           };
           checks = {
+            arbeitszeit-python311 = pkgs.python311.pkgs.arbeitszeitapp;
             arbeitszeit-python310 = pkgs.python310.pkgs.arbeitszeitapp;
             arbeitszeit-python39 = pkgs.python39.pkgs.arbeitszeitapp;
           };


### PR DESCRIPTION
This PR changes our CI setup so that the test suite is also run against python3.11.

Plan-ID: b0aa02ca-667a-4028-998c-834f3186b418