### PR TITLE
Fix bug in TransactionQueryResult.where_account_is_sender_or_receiver

### DIFF
--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -414,7 +414,7 @@ class TransactionQueryResult(FlaskQueryResult[entities.Transaction]):
     def where_account_is_sender_or_receiver(
         self, *account: UUID
     ) -> TransactionQueryResult:
-        accounts = map(str, account)
+        accounts = list(map(str, account))
         return self._with_modified_query(
             lambda query: query.filter(
                 or_(

--- a/tests/flask_integration/test_transaction_repository.py
+++ b/tests/flask_integration/test_transaction_repository.py
@@ -30,7 +30,7 @@ class TransactionRepositoryTests(FlaskTestCase):
         sender_account = self.account_generator.create_account()
         receiver_account = self.account_generator.create_account()
         transaction = self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account.id,
             receiving_account=receiver_account.id,
             amount_sent=Decimal(1),
@@ -49,7 +49,7 @@ class TransactionRepositoryTests(FlaskTestCase):
         sender_account = self.account_generator.create_account()
         receiver_account = self.account_generator.create_account()
         transaction = self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account.id,
             receiving_account=receiver_account.id,
             amount_sent=Decimal(1),
@@ -63,7 +63,7 @@ class TransactionRepositoryTests(FlaskTestCase):
     ) -> None:
         receiver_account = self.account_generator.create_account()
         transaction = self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=self.social_accounting.account.id,
             receiving_account=receiver_account.id,
             amount_sent=Decimal(1),
@@ -80,7 +80,7 @@ class TransactionRepositoryTests(FlaskTestCase):
         sender_account = self.account_generator.create_account()
         receiver_account = self.account_generator.create_account()
         self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account.id,
             receiving_account=receiver_account.id,
             amount_sent=Decimal(1),
@@ -125,7 +125,7 @@ class TransactionRepositoryTests(FlaskTestCase):
         sender_account = self.account_generator.create_account()
         receiver_account = self.account_generator.create_account()
         transaction = self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account.id,
             receiving_account=receiver_account.id,
             amount_sent=Decimal(1),
@@ -184,7 +184,7 @@ class TransactionRepositoryTests(FlaskTestCase):
             plan
         )
         self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account_1.id,
             receiving_account=UUID(receiver_account.id),
             amount_sent=Decimal(12),
@@ -192,7 +192,7 @@ class TransactionRepositoryTests(FlaskTestCase):
             purpose=f"test {plan.id} test",
         )
         self.repository.create_transaction(
-            datetime.now(),
+            self.datetime_service.now(),
             sending_account=sender_account_2.id,
             receiving_account=UUID(receiver_account.id),
             amount_sent=Decimal(12),
@@ -202,3 +202,53 @@ class TransactionRepositoryTests(FlaskTestCase):
         assert self.repository.get_sales_balance_of_plan(
             plan
         ) == sales_balance_before_transactions + Decimal(25)
+
+
+class TestWhereAccountIsSenderOrReceiver(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.account_generator = self.injector.get(AccountGenerator)
+        self.repository: TransactionRepository = self.injector.get(
+            TransactionRepository
+        )
+        self.datetime_service: FakeDatetimeService = self.injector.get(
+            FakeDatetimeService
+        )
+
+    def test_transactions_are_presented_in_result_when_receiver_matches_account_id(
+        self,
+    ) -> None:
+        sender_account = self.account_generator.create_account()
+        receiver_account = self.account_generator.create_account()
+        transaction = self.repository.create_transaction(
+            self.datetime_service.now(),
+            sending_account=sender_account.id,
+            receiving_account=receiver_account.id,
+            amount_sent=Decimal(1),
+            amount_received=Decimal(1),
+            purpose="test purpose",
+        )
+        assert list(
+            self.repository.get_transactions().where_account_is_sender_or_receiver(
+                receiver_account.id
+            )
+        ) == [transaction]
+
+    def test_transactions_are_presented_in_result_when_sender_matches_account_id(
+        self,
+    ) -> None:
+        sender_account = self.account_generator.create_account()
+        receiver_account = self.account_generator.create_account()
+        transaction = self.repository.create_transaction(
+            self.datetime_service.now(),
+            sending_account=sender_account.id,
+            receiving_account=receiver_account.id,
+            amount_sent=Decimal(1),
+            amount_received=Decimal(1),
+            purpose="test purpose",
+        )
+        assert list(
+            self.repository.get_transactions().where_account_is_sender_or_receiver(
+                sender_account.id
+            )
+        ) == [transaction]


### PR DESCRIPTION
This PR fixes #639 and provides regression tests for repository implementation.

No certs needed.