### PR TITLE
Update flake inputs and requirements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,7 +23,7 @@ email-validator==1.3.0
 exceptiongroup==1.1.0
 flake8==6.0.0
 Flask==2.2.2
-flask-babel==3.0.0
+flask-babel==3.0.1
 Flask-HTTPAuth==4.7.0
 Flask-Login==0.6.2
 Flask-Mail==0.9.1

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1674565085,
-        "narHash": "sha256-DUTk1hPCFYvDt/pSpxzXVZJGwhnAQ73ELRiAkGyglZ4=",
+        "lastModified": 1676117043,
+        "narHash": "sha256-sFcQH7kpOSCoVfvvLpHlozKkmTWgGGSULZuCRhdu4hQ=",
         "owner": "seppeljordan",
         "repo": "flask-profiler",
-        "rev": "881736981681056ffd3ffda837375279b04f68ad",
+        "rev": "bf2631145c3be1cfe8b0e604eb25b9c025a22adb",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixos-stable": {
       "locked": {
-        "lastModified": 1675681488,
-        "narHash": "sha256-0E/oYpixC+joFk7UrY60TwZcdthzP2BXmJwne3Ni8ZI=",
+        "lastModified": 1675918889,
+        "narHash": "sha256-hy7re4F9AEQqwZxubct7jBRos6md26bmxnCjxf5utJA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "13fdd3945d8a2da5e4afe35d8a629193a9680911",
+        "rev": "49efda9011e8cdcd6c1aad30384cb1dc230c82fe",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1673631141,
-        "narHash": "sha256-AprpYQ5JvLS4wQG/ghm2UriZ9QZXvAwh1HlgA/6ZEVQ=",
+        "lastModified": 1675763311,
+        "narHash": "sha256-bz0Q2H3mxsF1CUfk26Sl9Uzi8/HFjGFD/moZHz1HebU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "befc83905c965adfd33e5cae49acb0351f6e0404",
+        "rev": "fab09085df1b60d6a0870c8a89ce26d5a4a708c2",
         "type": "github"
       },
       "original": {
@@ -83,11 +83,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1675698036,
-        "narHash": "sha256-BgsQkQewdlQi8gapJN4phpxkI/FCE/2sORBaFcYbp/A=",
+        "lastModified": 1675940568,
+        "narHash": "sha256-epG6pOT9V0kS+FUqd7R6/CWkgnZx2DMT5Veqo+y6G3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1046c7b92e908a1202c0f1ba3fc21d19e1cf1b62",
+        "rev": "6ccc4a59c3f1b56d039d93da52696633e641bc71",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Nix flake inputs and `contraints.txt` were updated.

No certs required.