### PR TITLE
Refactor Api schema converter

### DIFF
--- a/arbeitszeit_flask/api/schema_converter.py
+++ b/arbeitszeit_flask/api/schema_converter.py
@@ -7,6 +7,7 @@ from arbeitszeit_web.api_presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonDict,
+    JsonInteger,
     JsonString,
     JsonValue,
     Namespace,
@@ -67,6 +68,7 @@ def json_schema_to_flaskx(
     type[fields.Arbitrary],
     type[fields.Boolean],
     type[fields.DateTime],
+    type[fields.Integer],
 ]:
     if isinstance(schema, JsonDict):
         model = _convert_json_dict(schema, namespace)
@@ -77,6 +79,8 @@ def json_schema_to_flaskx(
         return fields.Boolean
     elif isinstance(schema, JsonDatetime):
         return fields.DateTime
+    elif isinstance(schema, JsonInteger):
+        return fields.Integer
     else:
         assert isinstance(schema, JsonString)
         return fields.String

--- a/arbeitszeit_web/api_presenters/interfaces.py
+++ b/arbeitszeit_web/api_presenters/interfaces.py
@@ -2,7 +2,12 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol, Union
 
 JsonValue = Union[
-    "JsonDict", "JsonString", "JsonDecimal", "JsonBoolean", "JsonDatetime"
+    "JsonDict",
+    "JsonString",
+    "JsonDecimal",
+    "JsonBoolean",
+    "JsonDatetime",
+    "JsonInteger",
 ]
 
 
@@ -32,6 +37,11 @@ class JsonDecimal:
 
 @dataclass
 class JsonBoolean:
+    as_list: bool = False
+
+
+@dataclass
+class JsonInteger:
     as_list: bool = False
 
 

--- a/arbeitszeit_web/api_presenters/plans.py
+++ b/arbeitszeit_web/api_presenters/plans.py
@@ -3,6 +3,7 @@ from arbeitszeit_web.api_presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonDict,
+    JsonInteger,
     JsonString,
     JsonValue,
 )
@@ -28,7 +29,8 @@ class ActivePlansPresenter:
                     ),
                     schema_name="Plan",
                     as_list=True,
-                )
+                ),
+                total_results=JsonInteger(),
             ),
             schema_name="PlanList",
         )

--- a/tests/api/integration/test_schema_converter.py
+++ b/tests/api/integration/test_schema_converter.py
@@ -11,6 +11,7 @@ from arbeitszeit_web.api_presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonDict,
+    JsonInteger,
     JsonString,
 )
 from tests.api.implementations import NamespaceImpl
@@ -39,6 +40,11 @@ class SchemaConversionTests(ApiTestCase):
         model = JsonBoolean()
         converted = self.convert(model, self.namespace)
         self.assertEqual(converted, fields.Boolean)
+
+    def test_convert_to_integer_if_input_was_integer(self) -> None:
+        model = JsonInteger()
+        converted = self.convert(model, self.namespace)
+        self.assertEqual(converted, fields.Integer)
 
     def test_convert_to_datetime_if_input_was_datetime(self) -> None:
         model = JsonDatetime()

--- a/tests/api/presenters/test_list_active_plans_presenter.py
+++ b/tests/api/presenters/test_list_active_plans_presenter.py
@@ -3,6 +3,7 @@ from arbeitszeit_web.api_presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonDict,
+    JsonInteger,
     JsonString,
 )
 from arbeitszeit_web.api_presenters.plans import ActivePlansPresenter
@@ -26,6 +27,20 @@ class TestGetPresenter(BaseTestCase):
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonDict)
         assert isinstance(schema.members["results"], JsonDict)
+
+    def test_schema_top_level_members_field_types_are_correct(self) -> None:
+        top_level_schema = self.presenter.get_schema()
+        assert isinstance(top_level_schema, JsonDict)
+
+        field_expectations = [
+            ("results", JsonDict),
+            ("total_results", JsonInteger),
+        ]
+
+        assert len(top_level_schema.members) == len(field_expectations)
+
+        for field_name, expected_type in field_expectations:
+            assert isinstance(top_level_schema.members[field_name], expected_type)
 
     def test_schema_second_level(self) -> None:
         top_schema = self.presenter.get_schema()

--- a/type_stubs/flask_restx/fields.py
+++ b/type_stubs/flask_restx/fields.py
@@ -24,3 +24,7 @@ class Boolean:
 
 class DateTime:
     ...
+
+
+class Integer:
+    ...


### PR DESCRIPTION
This PR adds the field `total_results` to the API response when querying plans. 

There are still missing the response fields `limit` and `offset`, they will be added in a future PR.

In this context I changed a few things:
- When setting the attribute `as_list` of an json element to `True`, the element itself gets now returned as a list (also for documentation), not its children. 
- I refactored the api schema converter. I think it is more concise now.

Plan-ID: 7fbbf570-41a0-45b3-8f2d-177278c31546