### PR TITLE
change to plan_summary parameter

### DIFF
--- a/arbeitszeit/plan_summary.py
+++ b/arbeitszeit/plan_summary.py
@@ -5,7 +5,6 @@ from typing import Optional
 from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.entities import Plan
 from arbeitszeit.price_calculator import PriceCalculator
 from arbeitszeit.repositories import CompanyRepository, PlanRepository
 
@@ -37,12 +36,16 @@ class PlanSummary:
 
 @dataclass
 class PlanSummaryService:
+
     plan_repository: PlanRepository
     company_repository: CompanyRepository
     price_calculator: PriceCalculator
     datetime_service: DatetimeService
 
-    def get_summary_from_plan(self, plan: Plan) -> PlanSummary:
+    def get_summary_from_plan(self, plan_id: UUID) -> Optional[PlanSummary]:
+        plan = self.plan_repository.get_plans().with_id(plan_id).first()
+        if plan is None:
+            return None
         price_per_unit = self.price_calculator.calculate_cooperative_price(plan)
         planner = self.company_repository.get_companies().with_id(plan.planner).first()
         assert planner

--- a/arbeitszeit/use_cases/get_plan_summary_accountant.py
+++ b/arbeitszeit/use_cases/get_plan_summary_accountant.py
@@ -22,9 +22,7 @@ class GetPlanSummaryAccountant:
     plan_summary_service: PlanSummaryService
 
     def get_plan_summary(self, plan_id: UUID) -> Union[Success, Failure]:
-        plan = self.plan_repository.get_plans().with_id(plan_id).first()
-        if plan is None:
+        plan_summary = self.plan_summary_service.get_summary_from_plan(plan_id)
+        if plan_summary is None:
             return self.Failure()
-        return self.Success(
-            plan_summary=self.plan_summary_service.get_summary_from_plan(plan)
-        )
+        return self.Success(plan_summary=plan_summary)

--- a/arbeitszeit/use_cases/get_plan_summary_company.py
+++ b/arbeitszeit/use_cases/get_plan_summary_company.py
@@ -20,13 +20,15 @@ class GetPlanSummaryCompany:
     plan_summary_service: PlanSummaryService
 
     def get_plan_summary_for_company(self, plan_id: UUID, company_id: UUID) -> Response:
-        plan = self.plan_repository.get_plans().with_id(plan_id).first()
-        if plan is None:
+        plan_summary = self.plan_summary_service.get_summary_from_plan(plan_id)
+        if plan_summary is None:
             return self.Response(
                 plan_summary=None,
                 current_user_is_planner=False,
             )
+        plan = self.plan_repository.get_plans().with_id(plan_id).first()
+        assert plan  # exists because plan_summary exists
         return self.Response(
-            plan_summary=self.plan_summary_service.get_summary_from_plan(plan),
+            plan_summary=plan_summary,
             current_user_is_planner=(plan.planner == company_id),
         )

--- a/arbeitszeit/use_cases/get_plan_summary_member.py
+++ b/arbeitszeit/use_cases/get_plan_summary_member.py
@@ -22,9 +22,7 @@ class GetPlanSummaryMember:
     plan_summary_service: PlanSummaryService
 
     def __call__(self, plan_id: UUID) -> Union[Success, Failure]:
-        plan = self.plan_repository.get_plans().with_id(plan_id).first()
-        if plan is None:
+        plan_summary = self.plan_summary_service.get_summary_from_plan(plan_id)
+        if plan_summary is None:
             return self.Failure()
-        return self.Success(
-            plan_summary=self.plan_summary_service.get_summary_from_plan(plan)
-        )
+        return self.Success(plan_summary=plan_summary)


### PR DESCRIPTION
I slightly refactored the plan_summary service method in order to be called with a plan_id (UUID) instead of a plan entity. I did this in preparation of an API route that should return the summary of a specific plan.

Plan-ID: 7fbbf570-41a0-45b3-8f2d-177278c31546