### PR TITLE
Update Readme ("Getting started") and dev docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ There are three user roles:
 
 .. end-introduction-do-not-delete
 
-.. start-development-setup-do-not-delete
+.. start-development-philosophy-do-not-delete
 
 Development philosophy
 =======================
@@ -94,6 +94,9 @@ directories in the source code.
    Contains all the tests.  You should find at least one test for
    every line of code in the other directories in here.
 
+.. end-development-philosophy-do-not-delete
+
+.. start-getting-started-do-not-delete
 
 Getting started
 ================
@@ -145,6 +148,9 @@ Now you can start the development server with ``python -m flask
 run -h localhost``.  (Unfortunately ``flask run`` might not work due to
 a bug in the ``werkzeug`` library.) Open arbeitszeitapp in a browser via ``http://localhost:5000/``. 
 
+.. end-getting-started-do-not-delete
+
+.. start-further-development-setup-do-not-delete
 
 Further development setup
 ==========================
@@ -341,7 +347,7 @@ We are currently developing a JSON Web API that provides access to core features
 Arbeitszeitapp. It's OpenAPI specification gets rendered in any running instance 
 under path `/api/v1/doc/`
 
-.. end-development-setup-do-not-delete
+.. end-further-development-setup-do-not-delete
 
 .. start-license-do-not-delete
 

--- a/docs/development_philosophy.rst
+++ b/docs/development_philosophy.rst
@@ -1,0 +1,3 @@
+.. include:: ../README.rst
+  :start-after: start-development-philosophy-do-not-delete
+  :end-before: end-development-philosophy-do-not-delete

--- a/docs/development_setup.rst
+++ b/docs/development_setup.rst
@@ -1,3 +1,0 @@
-.. include:: ../README.rst
-  :start-after: start-development-setup-do-not-delete
-  :end-before: end-development-setup-do-not-delete

--- a/docs/further_development_setup.rst
+++ b/docs/further_development_setup.rst
@@ -1,0 +1,3 @@
+.. include:: ../README.rst
+  :start-after: start-further-development-setup-do-not-delete
+  :end-before: end-further-development-setup-do-not-delete

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -1,0 +1,3 @@
+.. include:: ../README.rst
+  :start-after: start-getting-started-do-not-delete
+  :end-before: end-getting-started-do-not-delete

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,9 @@ Source code: `<https://github.com/arbeitszeit/arbeitszeitapp>`_
    :maxdepth: 2
 
    introduction
-   development_setup
+   development_philosophy
+   getting_started
+   further_development_setup
    development_guide
    modules/modules
    license


### PR DESCRIPTION
I made some changes to the README file and the developer's documentation. 

The intention was to make it easier for new developers to "get started" by separating the basic dev setup ("getting started") from further development information. 

Btw: I had to delete my local `build` folder before running `make html`, to render the new dev docs correctly.

Plan-ID: 7fbbf570-41a0-45b3-8f2d-177278c31546