### PR TITLE
API: Authenticate requests of 2 API endpoints

### DIFF
--- a/arbeitszeit_flask/api/companies.py
+++ b/arbeitszeit_flask/api/companies.py
@@ -3,6 +3,7 @@ from flask_restx import Namespace, Resource
 from arbeitszeit.use_cases.query_companies import (
     QueryCompanies as QueryCompaniesUseCase,
 )
+from arbeitszeit_flask.api.authentication import authentication_check
 from arbeitszeit_flask.api.input_documentation import generate_input_documentation
 from arbeitszeit_flask.api.response_handling import error_response_handling
 from arbeitszeit_flask.api.schema_converter import SchemaConverter
@@ -31,6 +32,7 @@ class QueryCompanies(Resource):
     @namespace.expect(input_documentation)
     @namespace.marshal_with(model, skip_none=True)
     @error_response_handling(error_responses=[BadRequest], namespace=namespace)
+    @authentication_check
     @with_injection()
     def get(
         self,

--- a/arbeitszeit_flask/api/plans.py
+++ b/arbeitszeit_flask/api/plans.py
@@ -59,8 +59,9 @@ plan_get_model = SchemaConverter(namespace).json_schema_to_flaskx(
 class Plan(Resource):
     @namespace.marshal_with(plan_get_model, skip_none=True)
     @error_response_handling(
-        error_responses=[BadRequest, NotFound], namespace=namespace
+        error_responses=[BadRequest, NotFound, Unauthorized], namespace=namespace
     )
+    @authentication_check
     @with_injection()
     def get(
         self,

--- a/tests/api/integration/test_get_plan.py
+++ b/tests/api/integration/test_get_plan.py
@@ -1,9 +1,41 @@
 from tests.api.integration.base_test_case import ApiTestCase
 
 
-class GetPlanTests(ApiTestCase):
+class UnauthenticatedUsersTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
+
+    def test_unauthenticated_user_gets_401_with_valid_path_params(self):
+        valid_plan_id = str(self.plan_generator.create_plan().id)
+        valid_url = self.create_url(valid_plan_id)
+        response = self.client.get(valid_url)
+        self.assertEqual(response.status_code, 401)
+
+    def create_url(self, path_param: str) -> str:
+        url = self.url_prefix + "/plans/" + path_param
+        return url
+
+
+class AuthenticatedCompanyTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+
+    def test_get_returns_200_with_valid_path_parameter(self) -> None:
+        valid_plan_id = str(self.plan_generator.create_plan().id)
+        valid_url = self.create_url(path_param=valid_plan_id)
+        response = self.client.get(valid_url)
+        self.assertEqual(response.status_code, 200)
+
+    def create_url(self, path_param: str) -> str:
+        url = self.url_prefix + "/plans/" + path_param
+        return url
+
+
+class AuthenticatedMemberTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_member()
 
     def test_get_returns_200_with_valid_path_parameter(self) -> None:
         valid_plan_id = str(self.plan_generator.create_plan().id)

--- a/tests/api/integration/test_query_companies_api.py
+++ b/tests/api/integration/test_query_companies_api.py
@@ -1,9 +1,31 @@
 from tests.api.integration.base_test_case import ApiTestCase
 
 
-class QueryCompaniesTests(ApiTestCase):
+class UnauthenticatedUsersTests(ApiTestCase):
     def setUp(self) -> None:
         super().setUp()
+        self.url = self.url_prefix + "/companies"
+
+    def test_unauthenticated_user_gets_401(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 401)
+
+
+class AuthenticatedCompanyTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+        self.url = self.url_prefix + "/companies"
+
+    def test_get_returns_200(self):
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+
+class AuthenticatedMemberTests(ApiTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_member()
         self.url = self.url_prefix + "/companies"
 
     def test_get_returns_200(self):


### PR DESCRIPTION
Authenticate requests of `/plans/{plan_id}` and `/companies`. Only logged in members or companies are now able to use these endpoints.

Plan: f3031122-347b-4b50-aeb4-640d81121383