### PR TITLE
Bugfix in AnswerCompanyWorkInvite

### DIFF
--- a/arbeitszeit/use_cases/answer_company_work_invite.py
+++ b/arbeitszeit/use_cases/answer_company_work_invite.py
@@ -52,6 +52,10 @@ class AnswerCompanyWorkInvite:
             self.database_gateway.get_company_work_invites().with_id(
                 request.invite_id
             ).delete()
+        elif not request.is_accepted:
+            self.database_gateway.get_company_work_invites().with_id(
+                request.invite_id
+            ).delete()
         company = self.database_gateway.get_companies().with_id(invite.company).first()
         assert company
         return AnswerCompanyWorkInviteResponse(

--- a/tests/use_cases/test_answer_company_work_invite.py
+++ b/tests/use_cases/test_answer_company_work_invite.py
@@ -114,12 +114,23 @@ class AnwerCompanyWorkInviteTests(BaseTestCase):
         )
         self.assertTrue(response.is_success)
 
-    def test_cannot_answer_to_invite_twice(self) -> None:
+    def test_cannot_accept_invite_twice(self) -> None:
         invite_id = self._invite_worker()
         for _ in range(2):
             response = self.answer_company_work_invite(
                 self._create_request(
                     is_accepted=True,
+                    invite_id=invite_id,
+                )
+            )
+        assert not response.is_success
+
+    def test_cannot_reject_invite_twice(self) -> None:
+        invite_id = self._invite_worker()
+        for _ in range(2):
+            response = self.answer_company_work_invite(
+                self._create_request(
+                    is_accepted=False,
                     invite_id=invite_id,
                 )
             )


### PR DESCRIPTION
fixes #764

There was a bug in our business logic: When a worker rejected a company work invite, the invite did not get deleted. The bug was fixed.

No certs needed.