### PR TITLE
Make QueryCompaniesRequest a concrete data structure

### DIFF
--- a/arbeitszeit_web/api/controllers/query_companies_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_companies_api_controller.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 from arbeitszeit.use_cases.query_companies import CompanyFilter, QueryCompaniesRequest
 from arbeitszeit_web.api.controllers import query_parser
@@ -8,26 +8,6 @@ from arbeitszeit_web.request import Request
 
 DEFAULT_OFFSET: int = 0
 DEFAULT_LIMIT: int = 30
-
-
-@dataclass
-class QueryCompaniesRequestImpl(QueryCompaniesRequest):
-    query: Optional[str]
-    filter_category: CompanyFilter
-    offset: int
-    limit: int
-
-    def get_query_string(self) -> Optional[str]:
-        return self.query
-
-    def get_filter_category(self) -> CompanyFilter:
-        return self.filter_category
-
-    def get_offset(self) -> Optional[int]:
-        return self.offset
-
-    def get_limit(self) -> Optional[int]:
-        return self.limit
 
 
 @dataclass
@@ -56,8 +36,8 @@ class QueryCompaniesApiController:
     def create_request(self) -> QueryCompaniesRequest:
         offset = self._parse_offset(self.request)
         limit = self._parse_limit(self.request)
-        return QueryCompaniesRequestImpl(
-            query=None,
+        return QueryCompaniesRequest(
+            query_string=None,
             filter_category=CompanyFilter.by_name,
             offset=offset,
             limit=limit,

--- a/arbeitszeit_web/api/presenters/query_companies_api_presenter.py
+++ b/arbeitszeit_web/api/presenters/query_companies_api_presenter.py
@@ -42,6 +42,6 @@ class QueryCompaniesApiPresenter:
         return self.ViewModel(
             results=use_case_response.results,
             total_results=use_case_response.total_results,
-            offset=use_case_response.request.get_offset(),
-            limit=use_case_response.request.get_limit(),
+            offset=use_case_response.request.offset,
+            limit=use_case_response.request.limit,
         )

--- a/arbeitszeit_web/www/controllers/query_companies_controller.py
+++ b/arbeitszeit_web/www/controllers/query_companies_controller.py
@@ -18,26 +18,6 @@ _page_size = DEFAULT_PAGE_SIZE
 
 
 @dataclass
-class QueryCompaniesRequestImpl(QueryCompaniesRequest):
-    query: Optional[str]
-    filter_category: CompanyFilter
-    offset: Optional[int]
-    limit: Optional[int]
-
-    def get_query_string(self) -> Optional[str]:
-        return self.query
-
-    def get_filter_category(self) -> CompanyFilter:
-        return self.filter_category
-
-    def get_offset(self) -> Optional[int]:
-        return self.offset
-
-    def get_limit(self) -> Optional[int]:
-        return self.limit
-
-
-@dataclass
 class QueryCompaniesController:
     request: Request
 
@@ -55,8 +35,8 @@ class QueryCompaniesController:
             else:
                 filter_category = CompanyFilter.by_name
         offset = self._get_pagination_offset()
-        return QueryCompaniesRequestImpl(
-            query=query,
+        return QueryCompaniesRequest(
+            query_string=query,
             filter_category=filter_category,
             offset=offset,
             limit=_page_size,

--- a/arbeitszeit_web/www/presenters/query_companies_presenter.py
+++ b/arbeitszeit_web/www/presenters/query_companies_presenter.py
@@ -46,7 +46,7 @@ class QueryCompaniesPresenter:
             self.user_notifier.display_warning(self.translator.gettext("No results"))
         paginator = self._create_paginator(
             total_results=response.total_results,
-            current_offset=response.request.get_offset() or 0,
+            current_offset=response.request.offset or 0,
         )
         return QueryCompaniesViewModel(
             show_results=bool(response.results),

--- a/tests/api/controllers/test_query_companies_api_controller.py
+++ b/tests/api/controllers/test_query_companies_api_controller.py
@@ -18,37 +18,37 @@ class ControllerTests(BaseTestCase):
         self,
     ) -> None:
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_filter_category(), CompanyFilter.by_name)
+        self.assertEqual(use_case_request.filter_category, CompanyFilter.by_name)
 
     def test_that_by_default_a_request_gets_returned_without_query_string(self) -> None:
         use_case_request = self.controller.create_request()
-        self.assertIsNone(use_case_request.get_query_string())
+        self.assertIsNone(use_case_request.query_string)
 
     def test_that_by_default_a_use_case_request_with_offset_0_gets_returned_if_offset_query_string_was_empty(
         self,
     ):
         assert not self.request.query_string().get("offset")
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_offset(), 0)
+        self.assertEqual(use_case_request.offset, 0)
 
     def test_that_by_default_a_use_case_request_with_limit_30_gets_returned_if_limit_query_string_was_empty(
         self,
     ) -> None:
         assert not self.request.query_string().get("limit")
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_limit(), 30)
+        self.assertEqual(use_case_request.limit, 30)
 
     def test_correct_offset_gets_returned_if_it_was_set_in_query_string(self) -> None:
         expected_offset = 8
         self.request.set_arg(arg="offset", value=str(expected_offset))
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_offset(), expected_offset)
+        self.assertEqual(use_case_request.offset, expected_offset)
 
     def test_correct_limit_gets_returned_if_it_was_set_in_query_string(self) -> None:
         expected_limit = 7
         self.request.set_arg(arg="limit", value=expected_limit)
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_limit(), expected_limit)
+        self.assertEqual(use_case_request.limit, expected_limit)
 
     def test_both_correct_limit_and_offset_get_returned_if_specified_in_query_string(
         self,
@@ -58,8 +58,8 @@ class ControllerTests(BaseTestCase):
         expected_offset = 8
         self.request.set_arg(arg="offset", value=str(expected_offset))
         use_case_request = self.controller.create_request()
-        self.assertEqual(use_case_request.get_limit(), expected_limit)
-        self.assertEqual(use_case_request.get_offset(), expected_offset)
+        self.assertEqual(use_case_request.limit, expected_limit)
+        self.assertEqual(use_case_request.offset, expected_offset)
 
     def test_controller_raises_bad_request_if_offset_query_string_has_letters(self):
         input = "123abc"

--- a/tests/controllers/test_query_companies_controller.py
+++ b/tests/controllers/test_query_companies_controller.py
@@ -20,25 +20,25 @@ class QueryCompaniesControllerTests(BaseTestCase):
         self,
     ) -> None:
         request = self.controller.import_form_data(make_fake_form(query=""))
-        self.assertIsNone(request.get_query_string())
+        self.assertIsNone(request.query_string)
 
     def test_that_a_query_string_is_taken_as_the_literal_string_in_request(
         self,
     ) -> None:
         request = self.controller.import_form_data(make_fake_form(query="test"))
-        self.assertEqual(request.get_query_string(), "test")
+        self.assertEqual(request.query_string, "test")
 
     def test_that_leading_and_trailing_whitespaces_are_ignored(self) -> None:
         request = self.controller.import_form_data(make_fake_form(query=" test  "))
-        self.assertEqual(request.get_query_string(), "test")
+        self.assertEqual(request.query_string, "test")
         request = self.controller.import_form_data(make_fake_form(query="   "))
-        self.assertIsNone(request.get_query_string())
+        self.assertIsNone(request.query_string)
 
     def test_that_name_choice_produces_requests_filter_by_company_name(self) -> None:
         request = self.controller.import_form_data(
             make_fake_form(filter_category="Name")
         )
-        self.assertEqual(request.get_filter_category(), CompanyFilter.by_name)
+        self.assertEqual(request.filter_category, CompanyFilter.by_name)
 
     def test_that_email_choice_produces_requests_filter_by_email(
         self,
@@ -46,7 +46,7 @@ class QueryCompaniesControllerTests(BaseTestCase):
         request = self.controller.import_form_data(
             make_fake_form(filter_category="Email")
         )
-        self.assertEqual(request.get_filter_category(), CompanyFilter.by_email)
+        self.assertEqual(request.filter_category, CompanyFilter.by_email)
 
     def test_that_random_string_produces_requests_filter_by_name(
         self,
@@ -54,13 +54,13 @@ class QueryCompaniesControllerTests(BaseTestCase):
         request = self.controller.import_form_data(
             make_fake_form(filter_category="awqwrndaj")
         )
-        self.assertEqual(request.get_filter_category(), CompanyFilter.by_name)
+        self.assertEqual(request.filter_category, CompanyFilter.by_name)
 
     def test_that_default_request_model_includes_no_search_query(
         self,
     ) -> None:
         request = self.controller.import_form_data()
-        self.assertIsNone(request.get_query_string())
+        self.assertIsNone(request.query_string)
 
 
 class PaginationTests(BaseTestCase):
@@ -73,30 +73,30 @@ class PaginationTests(BaseTestCase):
         self,
     ):
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_offset() == 0
+        assert use_case_request.offset == 0
 
     def test_that_without_request_specified_the_offset_is_set_to_0(self) -> None:
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_offset() == 0
+        assert use_case_request.offset == 0
 
     def test_that_page_two_has_an_offset_of_15(self) -> None:
         self.request.set_arg(arg="page", value="2")
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_offset() == 15
+        assert use_case_request.offset == 15
 
     def test_that_offset_0_is_assumed_if_no_valid_integer_is_specified_as_page(self):
         self.request.set_arg(arg="page", value="123abc")
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_offset() == 0
+        assert use_case_request.offset == 0
 
     def test_that_offset_is_150_for_page_11(self) -> None:
         self.request.set_arg(arg="page", value="11")
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_offset() == 150
+        assert use_case_request.offset == 150
 
     def test_that_limit_is_15(self) -> None:
         use_case_request = self.controller.import_form_data()
-        assert use_case_request.get_limit() == 15
+        assert use_case_request.limit == 15
 
 
 def make_fake_form(

--- a/tests/presenters/data_generators.py
+++ b/tests/presenters/data_generators.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional
@@ -106,33 +105,13 @@ class QueriedCompanyGenerator:
         return CompanyQueryResponse(
             results=[company for company in queried_companies],
             total_results=total_results,
-            request=QueryCompaniesRequestTestImpl(
+            request=QueryCompaniesRequest(
                 offset=requested_offset,
                 limit=requested_limit,
-                query=query_string,
+                query_string=query_string,
                 filter_category=requested_filter_category,
             ),
         )
-
-
-@dataclass
-class QueryCompaniesRequestTestImpl(QueryCompaniesRequest):
-    query: Optional[str]
-    filter_category: CompanyFilter
-    offset: Optional[int] = None
-    limit: Optional[int] = None
-
-    def get_query_string(self) -> Optional[str]:
-        return self.query
-
-    def get_filter_category(self) -> CompanyFilter:
-        return self.filter_category
-
-    def get_offset(self) -> Optional[int]:
-        return self.offset
-
-    def get_limit(self) -> Optional[int]:
-        return self.limit
 
 
 class PlanSummaryGenerator:

--- a/tests/use_cases/test_query_companies.py
+++ b/tests/use_cases/test_query_companies.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Optional
 
 from arbeitszeit.entities import Company
@@ -155,29 +154,9 @@ def make_request(
     offset: Optional[int] = None,
     limit: Optional[int] = None,
 ) -> QueryCompaniesRequest:
-    return QueryCompaniesRequestTestImpl(
-        query=query or "",
+    return QueryCompaniesRequest(
+        query_string=query or "",
         filter_category=category or CompanyFilter.by_name,
         offset=offset,
         limit=limit,
     )
-
-
-@dataclass
-class QueryCompaniesRequestTestImpl(QueryCompaniesRequest):
-    query: Optional[str]
-    filter_category: CompanyFilter
-    offset: Optional[int] = None
-    limit: Optional[int] = None
-
-    def get_query_string(self) -> Optional[str]:
-        return self.query
-
-    def get_filter_category(self) -> CompanyFilter:
-        return self.filter_category
-
-    def get_offset(self) -> Optional[int]:
-        return self.offset
-
-    def get_limit(self) -> Optional[int]:
-        return self.limit


### PR DESCRIPTION
This change changes the QueryCompaniesRequest from an abstract base class into a concrete data structure.  The old approach was just not working out as intended. The new approach removes the need for any subclassing or interface implementations. Callers simply construct an instance of the "dataclass" QueryCompaniesRequest if they want to engage the query_companies use case.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf