### PR TITLE
Simplify query_companies view for companies and members

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -180,7 +180,7 @@ def query_plans(
     return view.respond_to_get(search_form, FlaskRequest())
 
 
-@CompanyRoute("/company/query_companies", methods=["GET", "POST"])
+@CompanyRoute("/company/query_companies", methods=["GET"])
 def query_companies(
     query_companies: use_cases.query_companies.QueryCompanies,
     controller: QueryCompaniesController,
@@ -188,7 +188,7 @@ def query_companies(
     presenter: QueryCompaniesPresenter,
 ):
     template_name = "company/query_companies.html"
-    search_form = CompanySearchForm(request.form)
+    search_form = CompanySearchForm(request.args)
     view = QueryCompaniesView(
         search_form,
         query_companies,
@@ -197,10 +197,7 @@ def query_companies(
         template_name,
         template_renderer,
     )
-    if request.method == "POST":
-        return view.respond_to_post()
-    else:
-        return view.respond_to_get()
+    return view.respond_to_get()
 
 
 @CompanyRoute("/company/purchases")

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -233,13 +233,11 @@ class CompanySearchForm(Form):
     select = SelectField(
         trans.lazy_gettext("Search for company"),
         choices=choices,
-        validators=[validators.DataRequired()],
+        default="Name",
     )
     search = StringField(
         trans.lazy_gettext("Search term"),
-        validators=[
-            FieldMustExist(message=trans.lazy_gettext("Required")),
-        ],
+        default="",
     )
 
     def get_query_string(self) -> str:

--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -106,7 +106,7 @@ def query_companies(
     presenter: QueryCompaniesPresenter,
 ):
     template_name = "member/query_companies.html"
-    search_form = CompanySearchForm(request.form)
+    search_form = CompanySearchForm(request.args)
     view = QueryCompaniesView(
         search_form,
         query_companies,
@@ -115,10 +115,7 @@ def query_companies(
         template_name,
         template_renderer,
     )
-    if request.method == "POST":
-        return view.respond_to_post()
-    else:
-        return view.respond_to_get()
+    return view.respond_to_get()
 
 
 @MemberRoute("/member/pay_consumer_product", methods=["GET", "POST"])

--- a/arbeitszeit_flask/templates/macros/query_companies.html
+++ b/arbeitszeit_flask/templates/macros/query_companies.html
@@ -7,8 +7,7 @@
     </h1>
     <div class="columns is-centered">
         <div class="column is-one-third">
-            <form method="post">
-                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <form method="get">
                 <div class="field">
                     <div class="control">
                         <div class="select is-large is-fullwidth">

--- a/arbeitszeit_flask/views/query_companies.py
+++ b/arbeitszeit_flask/views/query_companies.py
@@ -23,14 +23,11 @@ class QueryCompaniesView:
     template_name: str
     template_renderer: TemplateRenderer
 
-    def respond_to_post(self) -> Response:
+    def respond_to_get(self) -> Response:
         if not self.search_form.validate():
             return self._get_invalid_form_response()
         use_case_request = self.controller.import_form_data(self.search_form)
         return self._handle_use_case_request(use_case_request)
-
-    def respond_to_get(self) -> Response:
-        return self._handle_use_case_request(self.controller.import_form_data(None))
 
     def _get_invalid_form_response(self) -> Response:
         return Response(

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -177,10 +177,10 @@ class ViewTestCase(FlaskTestCase):
             self.login_accountant()
 
         if method.lower() == "get":
-            response = self.client.get(url, data=data)
+            response = self.client.get(url, query_string=data)
         elif method.lower() == "post":
             response = self.client.post(url, data=data)
         else:
             raise ValueError(f"Unknown {method=}")
 
-        self.assertEqual(response.status_code, expected_code)
+        assert response.status_code == expected_code


### PR DESCRIPTION
This change simplifies the routes /member/query_companies and /company/query_companies such that the view will only accept GET requests. Before this change these routes accepted POST requests for searching the database. Now this is done via GET requests.