### PR TITLE
tests: Remove some instances of MemberGenerator.create_member_entity

### DIFF
--- a/tests/api/integration/base_test_case.py
+++ b/tests/api/integration/base_test_case.py
@@ -20,7 +20,7 @@ class ApiTestCase(FlaskTestCase):
     def login_member(self) -> None:
         password = "password123"
         email = self.email_generator.get_random_email()
-        self.member_generator.create_member_entity(
+        self.member_generator.create_member(
             password=password, email=email, confirmed=True
         )
         response = self.client.post(

--- a/tests/control_thresholds.py
+++ b/tests/control_thresholds.py
@@ -1,13 +1,11 @@
-from dataclasses import dataclass
-
 from arbeitszeit.injector import singleton
 
 
 @singleton
-@dataclass
 class ControlThresholdsTestImpl:
-    allowed_overdraw_of_member_account: int = 0
-    acceptable_relative_account_deviation: int = 33
+    def __init__(self) -> None:
+        self.allowed_overdraw_of_member_account: int = 10000000
+        self.acceptable_relative_account_deviation: int = 33
 
     def get_allowed_overdraw_of_member_account(self) -> int:
         return self.allowed_overdraw_of_member_account

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -10,17 +10,7 @@ from decimal import Decimal
 from typing import Iterable, List, Optional, Union
 from uuid import UUID, uuid4
 
-from arbeitszeit.entities import (
-    Account,
-    AccountTypes,
-    Company,
-    Cooperation,
-    Member,
-    Plan,
-    ProductionCosts,
-    PurposesOfPurchases,
-    Transaction,
-)
+from arbeitszeit import entities
 from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.repositories import DatabaseGateway
 from arbeitszeit.use_cases import (
@@ -71,7 +61,7 @@ class MemberGenerator:
         name: str = "test member name",
         password: str = "password",
         confirmed: bool = True,
-    ) -> Member:
+    ) -> entities.Member:
         if email is None:
             email = self.email_generator.get_random_email()
         register_response = self.register_member_use_case.register_member(
@@ -126,7 +116,7 @@ class CompanyGenerator:
         name: str = "Company Name",
         password: str = "password",
         workers: Optional[Iterable[UUID]] = None,
-    ) -> Company:
+    ) -> entities.Company:
         company_id = self.create_company(
             email=email, confirmed=True, name=name, workers=workers, password=password
         )
@@ -172,7 +162,7 @@ class CompanyGenerator:
 class AccountGenerator:
     database: DatabaseGateway
 
-    def create_account(self) -> Account:
+    def create_account(self) -> entities.Account:
         return self.database.create_account()
 
 
@@ -196,18 +186,18 @@ class PlanGenerator:
         *,
         amount: int = 100,
         approved: bool = True,
-        costs: Optional[ProductionCosts] = None,
+        costs: Optional[entities.ProductionCosts] = None,
         description="Beschreibung für Produkt A.",
         is_public_service: bool = False,
         planner: Optional[UUID] = None,
         product_name: str = "Produkt A",
         production_unit: str = "500 Gramm",
         timeframe: Optional[int] = None,
-        requested_cooperation: Optional[Cooperation] = None,
-        cooperation: Optional[Cooperation] = None,
+        requested_cooperation: Optional[entities.Cooperation] = None,
+        cooperation: Optional[entities.Cooperation] = None,
         is_available: bool = True,
         hidden_by_user: bool = False,
-    ) -> Plan:
+    ) -> entities.Plan:
         if planner is None:
             planner = self.company_generator.create_company()
         draft = self.draft_plan(
@@ -285,7 +275,7 @@ class PlanGenerator:
         self,
         planner: Optional[UUID] = None,
         timeframe: Optional[int] = None,
-        costs: Optional[ProductionCosts] = None,
+        costs: Optional[entities.ProductionCosts] = None,
         is_public_service: Optional[bool] = None,
         product_name: Optional[str] = None,
         description: Optional[str] = None,
@@ -303,7 +293,7 @@ class PlanGenerator:
         if product_name is None:
             product_name = "Produkt A."
         if costs is None:
-            costs = ProductionCosts(Decimal(1), Decimal(1), Decimal(1))
+            costs = entities.ProductionCosts(Decimal(1), Decimal(1), Decimal(1))
         if planner is None:
             planner = self.company_generator.create_company()
         if timeframe is None:
@@ -341,7 +331,7 @@ class PurchaseGenerator:
         amount: int = 1,
     ) -> pay_means_of_production.PayMeansOfProductionResponse:
         return self._create_company_purchase(
-            purpose=PurposesOfPurchases.raw_materials,
+            purpose=entities.PurposesOfPurchases.raw_materials,
             buyer=buyer,
             plan=plan,
             amount=amount,
@@ -355,7 +345,7 @@ class PurchaseGenerator:
         amount: int = 1,
     ) -> pay_means_of_production.PayMeansOfProductionResponse:
         return self._create_company_purchase(
-            purpose=PurposesOfPurchases.means_of_prod,
+            purpose=entities.PurposesOfPurchases.means_of_prod,
             buyer=buyer,
             plan=plan,
             amount=amount,
@@ -364,7 +354,7 @@ class PurchaseGenerator:
     def _create_company_purchase(
         self,
         *,
-        purpose: PurposesOfPurchases,
+        purpose: entities.PurposesOfPurchases,
         buyer: Optional[UUID] = None,
         plan: Optional[UUID] = None,
         amount: int = 1,
@@ -415,15 +405,15 @@ class TransactionGenerator:
 
     def create_transaction(
         self,
-        sending_account_type=AccountTypes.p,
-        receiving_account_type=AccountTypes.prd,
+        sending_account_type=entities.AccountTypes.p,
+        receiving_account_type=entities.AccountTypes.prd,
         sending_account: Optional[UUID] = None,
         receiving_account: Optional[UUID] = None,
         amount_sent=None,
         amount_received=None,
         purpose=None,
         date=None,
-    ) -> Transaction:
+    ) -> entities.Transaction:
         if sending_account is None:
             sending_account = self.account_generator.create_account().id
         if receiving_account is None:
@@ -455,14 +445,14 @@ class CooperationGenerator:
     def create_cooperation(
         self,
         name: Optional[str] = None,
-        coordinator: Optional[Union[Company, UUID]] = None,
-        plans: Optional[List[Plan]] = None,
-    ) -> Cooperation:
+        coordinator: Optional[Union[entities.Company, UUID]] = None,
+        plans: Optional[List[entities.Plan]] = None,
+    ) -> entities.Cooperation:
         if name is None:
             name = "test name"
         if coordinator is None:
             coordinator = self.company_generator.create_company_entity()
-        if isinstance(coordinator, Company):
+        if isinstance(coordinator, entities.Company):
             coordinator = coordinator.id
         cooperation = self.database_gateway.create_cooperation(
             self.datetime_service.now(),

--- a/tests/flask_integration/database_gateway_impl/test_account_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_result.py
@@ -47,8 +47,14 @@ class AccountResultTests(FlaskTestCase):
         assert self.database_gateway.get_accounts().with_id(actual_id)
 
     def test_that_account_joined_with_owner_yields_original_member(self) -> None:
-        member = self.member_generator.create_member_entity()
-        assert member
+        account = self.database_gateway.create_account()
+        member = self.database_gateway.create_member(
+            email="test@test.test",
+            name="test name",
+            password_hash="password",
+            account=account,
+            registered_on=datetime(2000, 1, 1),
+        )
         result = (
             self.database_gateway.get_accounts()
             .with_id(member.account)

--- a/tests/flask_integration/database_gateway_impl/test_accountant_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_accountant_result.py
@@ -61,7 +61,7 @@ class CreateAccountantWithExistingMemberEmailTests(FlaskTestCase):
         self.expected_password = "test password"
 
     def test_can_create_accountant_with_same_email_address_as_member(self) -> None:
-        self.member_generator.create_member_entity(email=self.expected_email)
+        self.member_generator.create_member(email=self.expected_email)
         self.database_gateway.create_accountant(
             email=self.expected_email,
             name=self.expected_name,
@@ -72,7 +72,7 @@ class CreateAccountantWithExistingMemberEmailTests(FlaskTestCase):
     def test_can_create_accountant_with_similar_email_address_as_member_case_insensitive(
         self,
     ) -> None:
-        self.member_generator.create_member_entity(email=self.expected_email)
+        self.member_generator.create_member(email=self.expected_email)
         altered_email = Utility.mangle_case(self.expected_email)
         new_accountant_id = self.database_gateway.create_accountant(
             email=altered_email,

--- a/tests/flask_integration/database_gateway_impl/test_company_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_company_result.py
@@ -146,7 +146,7 @@ class CreateCompanyTests(FlaskTestCase):
         self,
     ) -> None:
         email = "test@test.test"
-        self.member_generator.create_member_entity(email=email)
+        self.member_generator.create_member(email=email)
         self.database_gateway.create_company(
             email=email,
             name="test name",

--- a/tests/flask_integration/database_gateway_impl/test_member_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_member_result.py
@@ -26,30 +26,28 @@ class RepositoryTests(FlaskTestCase):
 
     def test_that_member_can_be_retrieved_by_email(self) -> None:
         expected_mail = "test_mail@testmail.com"
-        expected_member = self.member_generator.create_member_entity(
-            email=expected_mail
-        )
-        assert (
+        expected_member = self.member_generator.create_member(email=expected_mail)
+        result = (
             self.database_gateway.get_members()
             .with_email_address(expected_mail)
             .first()
-            == expected_member
         )
+        assert result
+        assert result.id == expected_member
 
     def test_that_member_can_be_retrieved_by_email_case_insensitive(self) -> None:
         expected_mail = "test_mail@testmail.com"
         altered_mail = Utility.mangle_case(expected_mail)
-        expected_member = self.member_generator.create_member_entity(
-            email=expected_mail
-        )
-        assert (
+        expected_member = self.member_generator.create_member(email=expected_mail)
+        result = (
             self.database_gateway.get_members().with_email_address(altered_mail).first()
-            == expected_member
         )
+        assert result
+        assert result.id == expected_member
 
     def test_that_random_email_returns_no_member(self) -> None:
         random_email = "xyz123@testmail.com"
-        self.member_generator.create_member_entity(email="test_mail@testmail.com")
+        self.member_generator.create_member(email="test_mail@testmail.com")
         assert not self.database_gateway.get_members().with_email_address(random_email)
 
     def test_cannot_find_member_by_email_before_it_was_added(self) -> None:
@@ -88,7 +86,7 @@ class RepositoryTests(FlaskTestCase):
         assert len(self.database_gateway.get_members()) == 0
 
     def test_count_one_registered_member_when_one_was_created(self) -> None:
-        self.member_generator.create_member_entity()
+        self.member_generator.create_member()
         assert len(self.database_gateway.get_members()) == 1
 
     def test_with_id_returns_no_members_when_member_does_not_exist(self) -> None:
@@ -111,18 +109,18 @@ class GetAllMembersTests(FlaskTestCase):
         assert member.id == expected_member_id
 
     def test_that_all_members_can_be_retrieved(self) -> None:
-        expected_member1 = self.member_generator.create_member_entity()
-        expected_member2 = self.member_generator.create_member_entity()
+        expected_member1 = self.member_generator.create_member()
+        expected_member2 = self.member_generator.create_member()
         all_members = list(self.database_gateway.get_members())
-        assert expected_member1 in all_members
-        assert expected_member2 in all_members
+        assert expected_member1 in {m.id for m in all_members}
+        assert expected_member2 in {m.id for m in all_members}
 
     def test_that_number_of_returned_members_is_equal_to_number_of_created_members(
         self,
     ) -> None:
         expected_number_of_members = 3
         for i in range(expected_number_of_members):
-            self.member_generator.create_member_entity()
+            self.member_generator.create_member()
         member_count = len(self.database_gateway.get_members())
         assert member_count == expected_number_of_members
 

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 
-from arbeitszeit.entities import Company, Member
+from arbeitszeit.entities import Company
 from arbeitszeit.injector import Module
 from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
 from arbeitszeit_flask.token import FlaskTokenService
@@ -59,17 +59,17 @@ class ViewTestCase(FlaskTestCase):
 
     def login_member(
         self,
-        member: Optional[Member] = None,
+        member: Optional[UUID] = None,
         password: Optional[str] = None,
         email: Optional[str] = None,
         confirm_member: bool = True,
-    ) -> Member:
+    ) -> UUID:
         if password is None:
             password = "password123"
         if email is None:
             email = self.email_generator.get_random_email()
         if member is None:
-            member = self.member_generator.create_member_entity(
+            member = self.member_generator.create_member(
                 password=password, email=email, confirmed=False
             )
         response = self.client.post(
@@ -83,11 +83,7 @@ class ViewTestCase(FlaskTestCase):
         assert response.status_code < 400
         if confirm_member:
             self._confirm_member(email)
-        updated_member = (
-            self.database_gateway.get_members().with_email_address(email).first()
-        )
-        assert updated_member
-        return updated_member
+        return member
 
     def _confirm_member(
         self,

--- a/tests/flask_integration/test_company_work_invite_view.py
+++ b/tests/flask_integration/test_company_work_invite_view.py
@@ -38,7 +38,7 @@ class AuthenticatedTests(ViewTestCase):
         response = self.invite_use_case(
             InviteWorkerToCompanyUseCase.Request(
                 company.id,
-                self.member.id,
+                self.member,
             )
         )
         assert response.invite_id

--- a/tests/flask_integration/test_get_member_account_details_view.py
+++ b/tests/flask_integration/test_get_member_account_details_view.py
@@ -12,6 +12,6 @@ class GetMemberAccountDetailsViewTests(ViewTestCase):
         assert response.status_code == 200
 
     def test_that_response_contains_user_id(self) -> None:
-        member = str(self.login_member().id)
+        member = self.login_member()
         response = self.client.get(self.url)
-        assert member in response.text
+        assert str(member) in response.text

--- a/tests/flask_integration/test_invite_worker_to_company_view.py
+++ b/tests/flask_integration/test_invite_worker_to_company_view.py
@@ -21,8 +21,8 @@ class InviteWorkerToCompanyTests(ViewTestCase):
 
     def test_that_get_response_contains_worker_names(self) -> None:
         expected_member_name = "test member 123"
-        worker = self.member_generator.create_member_entity(name=expected_member_name)
-        self.company_manager.add_worker_to_company(self.company.id, worker.id)
+        worker = self.member_generator.create_member(name=expected_member_name)
+        self.company_manager.add_worker_to_company(self.company.id, worker)
         response = self.client.get("/company/invite_worker_to_company")
         self.assertIn(expected_member_name, response.data.decode("utf-8"))
 
@@ -31,9 +31,9 @@ class InviteWorkerToCompanyTests(ViewTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_post_yields_200_if_correct_data_was_provided(self) -> None:
-        member = self.member_generator.create_member_entity()
+        member = self.member_generator.create_member()
         response = self.client.post(
-            "/company/invite_worker_to_company", data={"member_id": str(member.id)}
+            "/company/invite_worker_to_company", data={"member_id": str(member)}
         )
         self.assertEqual(response.status_code, 200)
 

--- a/tests/flask_integration/test_pay_consumer_product_view.py
+++ b/tests/flask_integration/test_pay_consumer_product_view.py
@@ -32,8 +32,12 @@ class AuthenticatedMemberTests(ViewTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_posting_with_valid_form_data_results_in_302(self) -> None:
+        account = (
+            self.database_gateway.get_accounts().owned_by_member(self.member).first()
+        )
+        assert account
         self.transaction_generator.create_transaction(
-            receiving_account=self.member.account, amount_received=Decimal(100)
+            receiving_account=account.id, amount_received=Decimal(100)
         )
         plan = self.plan_generator.create_plan()
         response = self.client.post(

--- a/tests/flask_integration/test_register_hours_worked_view.py
+++ b/tests/flask_integration/test_register_hours_worked_view.py
@@ -30,20 +30,20 @@ class AuthenticatedCompanyTests(ViewTestCase):
     def test_company_gets_404_when_posting_incorrect_data_with_worker_not_in_company(
         self,
     ) -> None:
-        worker = self.member_generator.create_member_entity()
+        worker = self.member_generator.create_member()
         response = self.client.post(
             self.url,
-            data=dict(member_id=str(worker.id), amount="10"),
+            data=dict(member_id=str(worker), amount="10"),
         )
         self.assertEqual(response.status_code, 404)
 
     def test_company_gets_400_when_posting_incorrect_data_with_negative_amount(
         self,
     ) -> None:
-        worker = self.member_generator.create_member_entity()
-        self.company_manager.add_worker_to_company(self.company.id, worker.id)
+        worker = self.member_generator.create_member()
+        self.company_manager.add_worker_to_company(self.company.id, worker)
         response = self.client.post(
             self.url,
-            data=dict(member_id=str(worker.id), amount="-10"),
+            data=dict(member_id=str(worker), amount="-10"),
         )
         self.assertEqual(response.status_code, 400)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -123,7 +123,7 @@ class GeneralUrlIndexTests(ViewTestCase):
         self,
     ) -> None:
         member = self.login_member()
-        invite_id = self._create_invite(member.id)
+        invite_id = self._create_invite(member)
         url = self.url_index.get_work_invite_url(invite_id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
@@ -132,7 +132,7 @@ class GeneralUrlIndexTests(ViewTestCase):
         self,
     ) -> None:
         member = self.login_member()
-        invite_id = self._create_invite(member.id)
+        invite_id = self._create_invite(member)
         url = self.url_index.get_answer_company_work_invite_url(invite_id=invite_id)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_user_address_book.py
+++ b/tests/flask_integration/test_user_address_book.py
@@ -18,10 +18,11 @@ class UserAddressBookTests(FlaskTestCase):
         self.assertIsNone(self.repository.get_user_email_address(uuid4()))
 
     def test_that_associated_email_for_member_is_returned(self) -> None:
-        member = self.member_generator.create_member_entity()
+        expected_email = "test@test.test"
+        member = self.member_generator.create_member(email=expected_email)
         self.assertEqual(
-            member.email,
-            self.repository.get_user_email_address(member.id),
+            expected_email,
+            self.repository.get_user_email_address(member),
         )
 
     def test_that_associated_email_for_company_is_returned(self) -> None:


### PR DESCRIPTION
This refactoring aims to reduce the coupling between our DB strategy and the use case tests. This was done by changing our test code such that `create_member_entity` is replaced by `create_member` in our test cases. The former method returns a member "entity" to the caller which violates our abstractions boundaries. the `Member` "entity" models our DB structure which should not be touched by our business logic tests.

There are still some occurrences of `create_member_entity` which should be replaced in future PRs.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf