### PR TITLE
arbeitszeit_benchmark: Commit to DB and flush session on start up

### DIFF
--- a/arbeitszeit_benchmark/get_company_summary_benchmark.py
+++ b/arbeitszeit_benchmark/get_company_summary_benchmark.py
@@ -40,6 +40,8 @@ class GetCompanySummaryBenchmark:
                 )
         for _ in range(1000):
             self.plan_generator.create_plan(planner=self.company)
+        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/get_company_transactions.py
+++ b/arbeitszeit_benchmark/get_company_transactions.py
@@ -33,6 +33,8 @@ class GetCompanyTransactionsBenchmark:
                 self.purchase_generator.create_resource_purchase_by_company(
                     buyer=self.buyer, plan=plan.id
                 )
+        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/get_statistics.py
+++ b/arbeitszeit_benchmark/get_statistics.py
@@ -30,6 +30,8 @@ class GetStatisticsBenchmark:
             plan_generator.create_plan(
                 is_public_service=False, costs=self.random_production_costs()
             )
+        db.session.commit()
+        db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
+++ b/arbeitszeit_benchmark/query_plans_sorted_by_activation_date_benchmark.py
@@ -44,6 +44,8 @@ class QueryPlansSortedByActivationDateBenchmark:
             limit=None,
             offset=None,
         )
+        db.session.commit()
+        db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()

--- a/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
+++ b/arbeitszeit_benchmark/show_prd_account_details_benchmark.py
@@ -34,6 +34,8 @@ class ShowPrdAccountDetailsBenchmark:
         for _ in range(1000):
             self.purchase_generator.create_resource_purchase_by_company(plan=plan.id)
         self.use_case = self.injector.get(ShowPRDAccountDetailsUseCase)
+        self.db.session.commit()
+        self.db.session.flush()
 
     def tear_down(self) -> None:
         self.app_context.pop()


### PR DESCRIPTION
With this change all currently existing benchmark tests will commit any pending changes from the benchmark setup to the DB and flush the database session before running the benchmarks. This is done to ensure that behavior similar to the production environment. Without committing and flushing we might actually not test the database but rather the `sqlalchemy` session cache, which is pointless.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf