### PR TITLE
Remove MemberGenerator.create_member_entity from some tests

### DIFF
--- a/tests/use_cases/test_get_member_dashboard.py
+++ b/tests/use_cases/test_get_member_dashboard.py
@@ -15,14 +15,14 @@ class UseCaseTests(TestCase):
         self.company_generator = self.injector.get(CompanyGenerator)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.invite_worker_to_company = self.injector.get(InviteWorkerToCompanyUseCase)
-        self.member = self.member_generator.create_member_entity()
+        self.member = self.member_generator.create_member()
 
     def test_that_correct_workplace_email_is_shown(self):
         self.company_generator.create_company_entity(
             email="companyname@mail.com",
-            workers=[self.member.id],
+            workers=[self.member],
         )
-        member_info = self.get_member_dashboard(self.member.id)
+        member_info = self.get_member_dashboard(self.member)
         self.assertEqual(
             member_info.workplaces[0].workplace_email, "companyname@mail.com"
         )
@@ -30,56 +30,56 @@ class UseCaseTests(TestCase):
     def test_that_correct_workplace_name_is_shown(self):
         self.company_generator.create_company_entity(
             name="SomeCompanyNameXY",
-            workers=[self.member.id],
+            workers=[self.member],
         )
-        member_info = self.get_member_dashboard(self.member.id)
+        member_info = self.get_member_dashboard(self.member)
         self.assertEqual(member_info.workplaces[0].workplace_name, "SomeCompanyNameXY")
 
     def test_that_three_latest_plans_is_empty_if_there_are_no_plans(self):
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertFalse(response.three_latest_plans)
 
     def test_three_latest_plans_has_at_least_one_entry_if_there_is_one_active_plan(
         self,
     ):
         self.plan_generator.create_plan()
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertTrue(response.three_latest_plans)
 
     def test_no_invites_are_shown_when_none_was_sent(self):
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertFalse(response.invites)
 
     def test_invites_are_shown_when_worker_was_previously_invited(self):
         inviting_company = self.company_generator.create_company_entity()
         self.invite_worker_to_company(
-            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member.id)
+            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertTrue(response.invites)
 
     def test_show_id_of_company_that_sent_the_invite(self):
         inviting_company = self.company_generator.create_company_entity()
         self.invite_worker_to_company(
-            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member.id)
+            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertEqual(response.invites[0].company_id, inviting_company.id)
 
     def test_show_name_of_company_that_sent_the_invite(self):
         inviting_company = self.company_generator.create_company_entity()
         self.invite_worker_to_company(
-            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member.id)
+            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
-        response = self.get_member_dashboard(self.member.id)
+        response = self.get_member_dashboard(self.member)
         self.assertEqual(response.invites[0].company_name, inviting_company.name)
 
     def test_show_correct_invite_id(self):
         inviting_company = self.company_generator.create_company_entity()
         invite_response = self.invite_worker_to_company(
-            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member.id)
+            InviteWorkerToCompanyUseCase.Request(inviting_company.id, self.member)
         )
-        get_dashboard_response = self.get_member_dashboard(self.member.id)
+        get_dashboard_response = self.get_member_dashboard(self.member)
         self.assertEqual(
             get_dashboard_response.invites[0].invite_id, invite_response.invite_id
         )

--- a/tests/use_cases/test_invite_worker_to_company.py
+++ b/tests/use_cases/test_invite_worker_to_company.py
@@ -9,8 +9,8 @@ from .base_test_case import BaseTestCase
 class InviteWorkerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.company_generator.create_company_entity()
-        self.member = self.member_generator.create_member_entity()
+        self.company = self.company_generator.create_company()
+        self.member = self.member_generator.create_member()
         self.invite_worker_to_company = self.injector.get(InviteWorkerToCompanyUseCase)
 
     def test_can_successfully_invite_worker_which_was_not_previously_invited(
@@ -18,34 +18,34 @@ class InviteWorkerTests(BaseTestCase):
     ) -> None:
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=self.member.id,
+                company=self.company,
+                worker=self.member,
             )
         )
         self.assertTrue(response.is_success)
 
     def test_cannot_invite_worker_twices(self) -> None:
         request = InviteWorkerToCompanyUseCase.Request(
-            company=self.company.id,
-            worker=self.member.id,
+            company=self.company,
+            worker=self.member,
         )
         self.invite_worker_to_company(request)
         response = self.invite_worker_to_company(request)
         assert not response.is_success
 
     def test_can_invite_different_workers(self) -> None:
-        first_member = self.member_generator.create_member_entity()
-        second_member = self.member_generator.create_member_entity()
+        first_member = self.member_generator.create_member()
+        second_member = self.member_generator.create_member()
         self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=first_member.id,
+                company=self.company,
+                worker=first_member,
             )
         )
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=second_member.id,
+                company=self.company,
+                worker=second_member,
             )
         )
         self.assertTrue(response.is_success)
@@ -56,13 +56,13 @@ class InviteWorkerTests(BaseTestCase):
         self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
                 company=first_company.id,
-                worker=self.member.id,
+                worker=self.member,
             )
         )
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
                 company=second_company.id,
-                worker=self.member.id,
+                worker=self.member,
             )
         )
         self.assertTrue(response.is_success)
@@ -70,7 +70,7 @@ class InviteWorkerTests(BaseTestCase):
     def test_cannot_invite_worker_that_does_not_exist(self) -> None:
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
+                company=self.company,
                 worker=uuid4(),
             )
         )
@@ -80,7 +80,7 @@ class InviteWorkerTests(BaseTestCase):
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
                 company=uuid4(),
-                worker=self.member.id,
+                worker=self.member,
             )
         )
         self.assertFalse(response.is_success)
@@ -88,8 +88,8 @@ class InviteWorkerTests(BaseTestCase):
     def test_response_uuid_is_not_none_on_successful_invite(self) -> None:
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=self.member.id,
+                company=self.company,
+                worker=self.member,
             )
         )
         self.assertIsNotNone(response.invite_id)
@@ -98,15 +98,15 @@ class InviteWorkerTests(BaseTestCase):
 class NotificationTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.company = self.company_generator.create_company_entity()
-        self.member = self.member_generator.create_member_entity()
+        self.company = self.company_generator.create_company()
+        self.member = self.member_generator.create_member()
         self.invite_worker_presenter = self.injector.get(InviteWorkerPresenterImpl)
         self.invite_worker_to_company = self.injector.get(InviteWorkerToCompanyUseCase)
 
     def test_no_invite_gets_send_if_invite_was_not_successful(self) -> None:
         self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
+                company=self.company,
                 worker=uuid4(),
             )
         )
@@ -116,28 +116,31 @@ class NotificationTests(BaseTestCase):
     def test_one_worker_gets_notified_on_successful_invite(self) -> None:
         self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=self.member.id,
+                company=self.company,
+                worker=self.member,
             )
         )
         invites = self.invite_worker_presenter.invites
         self.assertEqual(len(invites), 1)
 
     def test_correct_worker_gets_notified_on_successful_invite(self) -> None:
+        expected_email = "test@test.test"
+        company = self.company_generator.create_company()
+        member = self.member_generator.create_member(email=expected_email)
         self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=self.member.id,
+                company=company,
+                worker=member,
             )
         )
         invites = self.invite_worker_presenter.invites
-        self.assertEqual(invites[0].worker_email, self.member.email)
+        self.assertEqual(invites[0].worker_email, expected_email)
 
     def test_worker_gets_notified_about_correct_invite(self) -> None:
         response = self.invite_worker_to_company(
             InviteWorkerToCompanyUseCase.Request(
-                company=self.company.id,
-                worker=self.member.id,
+                company=self.company,
+                worker=self.member,
             )
         )
         invites = self.invite_worker_presenter.invites

--- a/tests/use_cases/test_list_workers.py
+++ b/tests/use_cases/test_list_workers.py
@@ -1,6 +1,7 @@
+from typing import Union
 from uuid import UUID, uuid4
 
-from arbeitszeit.entities import Company, Member
+from arbeitszeit.entities import Member
 from arbeitszeit.use_cases.list_workers import (
     ListWorkers,
     ListWorkersRequest,
@@ -15,21 +16,18 @@ def make_request(company: UUID) -> ListWorkersRequest:
     return ListWorkersRequest(company)
 
 
-def worker_in_results(worker: Member, response: ListWorkersResponse) -> bool:
-    return any(
-        (
-            worker.id == result.id
-            and worker.name == result.name
-            and worker.email == result.email
-            for result in response.workers
-        )
-    )
+def worker_in_results(
+    worker: Union[Member, UUID], response: ListWorkersResponse
+) -> bool:
+    if isinstance(worker, Member):
+        worker = worker.id
+    return any(w.id == worker for w in response.workers)
 
 
 @injection_test
 def test_list_workers_response_is_empty_for_nonexisting_company(
     list_workers: ListWorkers,
-):
+) -> None:
     response: ListWorkersResponse = list_workers(make_request(company=uuid4()))
     assert not response.workers
 
@@ -38,9 +36,9 @@ def test_list_workers_response_is_empty_for_nonexisting_company(
 def test_list_workers_response_is_empty_for_company_without_worker(
     list_workers: ListWorkers,
     company_generator: CompanyGenerator,
-):
-    company: Company = company_generator.create_company_entity()
-    response: ListWorkersResponse = list_workers(make_request(company=company.id))
+) -> None:
+    company = company_generator.create_company()
+    response = list_workers(make_request(company=company))
     assert not response.workers
 
 
@@ -49,10 +47,10 @@ def test_list_workers_response_includes_single_company_worker(
     list_workers: ListWorkers,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-):
-    worker: Member = member_generator.create_member_entity()
-    company: Company = company_generator.create_company_entity(workers=[worker.id])
-    response: ListWorkersResponse = list_workers(make_request(company=company.id))
+) -> None:
+    worker = member_generator.create_member()
+    company = company_generator.create_company(workers=[worker])
+    response = list_workers(make_request(company=company))
     assert worker_in_results(worker, response)
 
 
@@ -61,11 +59,9 @@ def test_list_workers_response_includes_multiple_company_workers(
     list_workers: ListWorkers,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-):
-    worker1: Member = member_generator.create_member_entity()
-    worker2: Member = member_generator.create_member_entity()
-    company: Company = company_generator.create_company_entity(
-        workers=[worker1.id, worker2.id]
-    )
+) -> None:
+    worker1 = member_generator.create_member()
+    worker2 = member_generator.create_member()
+    company = company_generator.create_company_entity(workers=[worker1, worker2])
     response: ListWorkersResponse = list_workers(make_request(company=company.id))
     assert worker_in_results(worker1, response) and worker_in_results(worker2, response)

--- a/tests/use_cases/test_register_hours_worked.py
+++ b/tests/use_cases/test_register_hours_worked.py
@@ -46,19 +46,17 @@ class UseCaseTester(BaseTestCase):
     def test_with_no_public_plans_that_certificates_received_equal_hours_worked(
         self,
     ) -> None:
-        worker = self.member_generator.create_member_entity()
-        company = self.company_generator.create_company_entity(workers=[worker.id])
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company_entity(workers=[worker])
         hours_worked = Decimal(50)
         self.register_hours_worked(
-            RegisterHoursWorkedRequest(company.id, worker.id, hours_worked=hours_worked)
+            RegisterHoursWorkedRequest(company.id, worker, hours_worked=hours_worked)
         )
         assert (
             self.balance_checker.get_company_account_balances(company.id).a_account
             == -hours_worked
         )
-        assert (
-            self.balance_checker.get_member_account_balance(worker.id) == hours_worked
-        )
+        assert self.balance_checker.get_member_account_balance(worker) == hours_worked
 
     def test_that_request_with_negative_hours_worked_is_rejected(self) -> None:
         worker = self.member_generator.create_member()
@@ -92,8 +90,8 @@ class UseCaseTester(BaseTestCase):
     def test_that_with_all_public_plans_that_worker_receives_no_certificates(
         self,
     ) -> None:
-        worker = self.member_generator.create_member_entity()
-        company = self.company_generator.create_company_entity(workers=[worker.id])
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company_entity(workers=[worker])
         self.plan_generator.create_plan(
             is_public_service=True,
             costs=ProductionCosts(
@@ -104,12 +102,10 @@ class UseCaseTester(BaseTestCase):
         )
         hours_worked = Decimal(10)
         self.register_hours_worked(
-            RegisterHoursWorkedRequest(company.id, worker.id, hours_worked=hours_worked)
+            RegisterHoursWorkedRequest(company.id, worker, hours_worked=hours_worked)
         )
         assert (
             self.balance_checker.get_company_account_balances(company.id).a_account
             == -hours_worked
         )
-        assert self.balance_checker.get_member_account_balance(worker.id) == Decimal(
-            "0"
-        )
+        assert self.balance_checker.get_member_account_balance(worker) == Decimal("0")

--- a/tests/use_cases/test_register_member.py
+++ b/tests/use_cases/test_register_member.py
@@ -59,7 +59,7 @@ class RegisterMemberTests(BaseTestCase):
         assert dashboard_response.name == DEFAULT["name"]
 
     def test_that_correct_error_is_raised_when_user_with_mail_exists(self) -> None:
-        self.member_generator.create_member_entity(email="test@cp.org")
+        self.member_generator.create_member(email="test@cp.org")
         request = RegisterMemberUseCase.Request(**DEFAULT)
         response = self.use_case.register_member(request)
         self.assertTrue(response.is_rejected)
@@ -71,7 +71,7 @@ class RegisterMemberTests(BaseTestCase):
     def test_no_confirmation_is_required_if_member_already_existed_pre_registration(
         self,
     ) -> None:
-        self.member_generator.create_member_entity(email="test@cp.org")
+        self.member_generator.create_member(email="test@cp.org")
         request = RegisterMemberUseCase.Request(**DEFAULT)
         response = self.use_case.register_member(request)
         assert not response.is_confirmation_required

--- a/tests/use_cases/test_send_accountant_registration_token.py
+++ b/tests/use_cases/test_send_accountant_registration_token.py
@@ -24,7 +24,7 @@ class UseCaseTests(TestCase):
         self,
     ) -> None:
         member_email = "test@test.test"
-        self.member_generator.create_member_entity(email=member_email)
+        self.member_generator.create_member(email=member_email)
         self.use_case.send_accountant_registration_token(
             request=SendAccountantRegistrationTokenUseCase.Request(
                 email=member_email,

--- a/tests/use_cases/test_show_a_account_details.py
+++ b/tests/use_cases/test_show_a_account_details.py
@@ -1,14 +1,22 @@
+from __future__ import annotations
+
 from datetime import datetime
 from decimal import Decimal
 
-from arbeitszeit.entities import SocialAccounting
+from arbeitszeit.entities import ProductionCosts
 from arbeitszeit.transactions import TransactionTypes
+from arbeitszeit.use_cases.register_hours_worked import (
+    RegisterHoursWorked,
+    RegisterHoursWorkedRequest,
+)
 from arbeitszeit.use_cases.show_a_account_details import ShowAAccountDetailsUseCase
 from tests.data_generators import (
     CompanyGenerator,
     MemberGenerator,
-    TransactionGenerator,
+    PlanGenerator,
+    PurchaseGenerator,
 )
+from tests.datetime_service import FakeDatetimeService
 
 from .dependency_injection import injection_test
 
@@ -19,7 +27,7 @@ def test_no_transactions_returned_when_no_transactions_took_place(
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
 ):
-    member_generator.create_member_entity()
+    member_generator.create_member()
     company = company_generator.create_company_entity()
 
     response = show_a_account_details(company.id)
@@ -32,7 +40,7 @@ def test_balance_is_zero_when_no_transactions_took_place(
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
 ):
-    member_generator.create_member_entity()
+    member_generator.create_member()
     company = company_generator.create_company_entity()
 
     response = show_a_account_details(company.id)
@@ -45,7 +53,7 @@ def test_company_id_is_returned(
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
 ):
-    member_generator.create_member_entity()
+    member_generator.create_member()
     company = company_generator.create_company_entity()
 
     response = show_p_account_details(company.id)
@@ -57,79 +65,62 @@ def test_that_no_info_is_generated_after_selling_of_consumer_product(
     show_a_account_details: ShowAAccountDetailsUseCase,
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
+    purchase_generator: PurchaseGenerator,
+    plan_generator: PlanGenerator,
 ):
-    member = member_generator.create_member_entity()
-    company = company_generator.create_company_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=member.account,
-        receiving_account=company.product_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    response = show_a_account_details(company.id)
-    assert len(response.transactions) == 0
+    company = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=company)
+    response = show_a_account_details(company)
+    transactions_before_purchase = len(response.transactions)
+    purchase_generator.create_purchase_by_member(plan=plan.id)
+    response = show_a_account_details(company)
+    assert len(response.transactions) == transactions_before_purchase
 
 
 @injection_test
 def test_that_no_info_is_generated_when_company_sells_p(
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
+    plan_generator: PlanGenerator,
+    purchase_generator: PurchaseGenerator,
 ):
-    company1 = company_generator.create_company_entity()
-    company2 = company_generator.create_company_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=company1.means_account,
-        receiving_account=company2.product_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    response = show_a_account_details(company2.id)
-    assert not response.transactions
+    company = company_generator.create_company()
+    plan = plan_generator.create_plan(planner=company)
+    response = show_a_account_details(company)
+    transactions_before_purchase = len(response.transactions)
+    purchase_generator.create_fixed_means_purchase(plan=plan.id)
+    response = show_a_account_details(company)
+    assert len(response.transactions) == transactions_before_purchase
 
 
 @injection_test
-def test_that_no_info_is_generated_when_credit_for_r_is_granted(
+def test_after_approving_a_plan_one_transaction_is_recorded(
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
+    plan_generator: PlanGenerator,
 ):
-    company = company_generator.create_company_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.raw_material_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
-    )
-
-    response = show_a_account_details(company.id)
-    assert len(response.transactions) == 0
+    company = company_generator.create_company()
+    plan_generator.create_plan(planner=company)
+    response = show_a_account_details(company)
+    assert len(response.transactions) == 1
 
 
 @injection_test
 def test_that_correct_info_is_generated_when_credit_for_wages_is_granted(
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
+    plan_generator: PlanGenerator,
 ):
-    company = company_generator.create_company_entity()
-
-    transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.work_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
+    company = company_generator.create_company()
+    plan_generator.create_plan(
+        planner=company,
+        costs=ProductionCosts(
+            labour_cost=Decimal(8.5),
+            means_cost=Decimal(0),
+            resource_cost=Decimal(0),
+        ),
     )
-
-    response = show_a_account_details(company.id)
+    response = show_a_account_details(company)
     assert len(response.transactions) == 1
     assert response.transactions[0].transaction_volume == Decimal(8.5)
     assert response.transactions[0].purpose is not None
@@ -145,23 +136,23 @@ def test_that_correct_info_is_generated_after_company_transfering_work_certifica
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-    transaction_generator: TransactionGenerator,
+    register_hours_worked: RegisterHoursWorked,
 ):
-    company1 = company_generator.create_company_entity()
-    member = member_generator.create_member_entity()
-
-    trans = transaction_generator.create_transaction(
-        sending_account=company1.work_account,
-        receiving_account=member.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
+    hours_worked = Decimal("8.5")
+    member = member_generator.create_member()
+    company = company_generator.create_company(workers=[member])
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=company,
+            worker_id=member,
+            hours_worked=hours_worked,
+        )
     )
-
-    response = show_a_account_details(company1.id)
+    response = show_a_account_details(company)
     transaction = response.transactions[0]
     assert transaction.transaction_type == TransactionTypes.payment_of_wages
-    assert transaction.transaction_volume == -trans.amount_sent
-    assert response.account_balance == -trans.amount_sent
+    assert transaction.transaction_volume == -hours_worked
+    assert response.account_balance == -hours_worked
 
 
 @injection_test
@@ -170,7 +161,7 @@ def test_that_plotting_info_is_empty_when_no_transactions_occurred(
     member_generator: MemberGenerator,
     company_generator: CompanyGenerator,
 ):
-    member_generator.create_member_entity()
+    member_generator.create_member()
     company = company_generator.create_company_entity()
 
     response = show_a_account_details(company.id)
@@ -183,19 +174,19 @@ def test_that_plotting_info_is_generated_after_transfer_of_work_certificates(
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-    transaction_generator: TransactionGenerator,
+    register_hours_worked: RegisterHoursWorked,
 ):
-    worker = member_generator.create_member_entity()
-    own_company = company_generator.create_company_entity(workers=[worker.id])
-
-    transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
+    hours_worked = Decimal("8.5")
+    worker = member_generator.create_member()
+    own_company = company_generator.create_company(workers=[worker])
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company,
+            worker_id=worker,
+            hours_worked=hours_worked,
+        )
     )
-
-    response = show_a_account_details(own_company.id)
+    response = show_a_account_details(own_company)
     assert response.plot.timestamps
     assert response.plot.accumulated_volumes
 
@@ -205,39 +196,40 @@ def test_that_correct_plotting_info_is_generated_after_transferring_of_work_cert
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-    transaction_generator: TransactionGenerator,
+    register_hours_worked: RegisterHoursWorked,
+    datetime_service: FakeDatetimeService,
 ):
-    worker1 = member_generator.create_member_entity()
-    worker2 = member_generator.create_member_entity()
-    own_company = company_generator.create_company_entity(
-        workers=[worker1.id, worker2.id]
+    datetime_service.freeze_time(datetime(2000, 1, 1))
+    worker1 = member_generator.create_member()
+    worker2 = member_generator.create_member()
+    own_company = company_generator.create_company(workers=[worker1, worker2])
+    expected_transaction_1_timestamp = datetime(2000, 1, 2)
+    datetime_service.freeze_time(expected_transaction_1_timestamp)
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company,
+            worker_id=worker1,
+            hours_worked=Decimal("10"),
+        )
     )
-
-    trans1 = transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker1.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(5),
+    expected_transaction_2_timestamp = datetime(2000, 1, 3)
+    datetime_service.freeze_time(expected_transaction_2_timestamp)
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company,
+            worker_id=worker2,
+            hours_worked=Decimal("10"),
+        )
     )
-
-    trans2 = transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker2.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(10),
-    )
-
-    response = show_a_account_details(own_company.id)
+    response = show_a_account_details(own_company)
     assert len(response.plot.timestamps) == 2
     assert len(response.plot.accumulated_volumes) == 2
 
-    assert trans1.date in response.plot.timestamps
-    assert trans2.date in response.plot.timestamps
+    assert expected_transaction_1_timestamp in response.plot.timestamps
+    assert expected_transaction_2_timestamp in response.plot.timestamps
 
-    assert trans1.amount_sent * (-1) in response.plot.accumulated_volumes
-    assert (
-        trans1.amount_sent * (-1) + trans2.amount_sent * (-1)
-    ) in response.plot.accumulated_volumes
+    assert Decimal("-10") in response.plot.accumulated_volumes
+    assert Decimal("-20") in response.plot.accumulated_volumes
 
 
 @injection_test
@@ -245,69 +237,78 @@ def test_that_plotting_info_is_generated_in_the_correct_order_after_transfer_of_
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
     member_generator: MemberGenerator,
-    transaction_generator: TransactionGenerator,
+    register_hours_worked: RegisterHoursWorked,
+    datetime_service: FakeDatetimeService,
 ):
-    worker1 = member_generator.create_member_entity()
-    worker2 = member_generator.create_member_entity()
-    worker3 = member_generator.create_member_entity()
+    worker1 = member_generator.create_member()
+    worker2 = member_generator.create_member()
+    worker3 = member_generator.create_member()
     own_company = company_generator.create_company_entity(
-        workers=[worker1.id, worker2.id, worker3.id]
+        workers=[worker1, worker2, worker3]
     )
 
-    trans1 = transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker1.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(1),
+    first_transaction_timestamp = datetime(2000, 1, 1)
+    datetime_service.freeze_time(first_transaction_timestamp)
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company.id,
+            worker_id=worker1,
+            hours_worked=Decimal("10"),
+        )
     )
-
-    trans2 = transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker2.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(2),
+    seconds_transaction_timestamp = datetime(2000, 1, 2)
+    datetime_service.freeze_time(seconds_transaction_timestamp)
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company.id,
+            worker_id=worker2,
+            hours_worked=Decimal("10"),
+        )
     )
-
-    trans3 = transaction_generator.create_transaction(
-        sending_account=own_company.work_account,
-        receiving_account=worker3.account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(3),
+    third_transaction_timestamp = datetime(2000, 1, 3)
+    datetime_service.freeze_time(third_transaction_timestamp)
+    register_hours_worked(
+        RegisterHoursWorkedRequest(
+            company_id=own_company.id,
+            worker_id=worker3,
+            hours_worked=Decimal("10"),
+        )
     )
 
     response = show_a_account_details(own_company.id)
-    assert response.plot.timestamps[0] == trans1.date
-    assert response.plot.timestamps[2] == trans3.date
+    assert response.plot.timestamps[0] == first_transaction_timestamp
+    assert response.plot.timestamps[2] == third_transaction_timestamp
 
-    assert response.plot.accumulated_volumes[0] == trans1.amount_sent * (-1)
-    assert response.plot.accumulated_volumes[2] == (
-        trans1.amount_sent * (-1)
-        + trans2.amount_sent * (-1)
-        + trans3.amount_sent * (-1)
-    )
+    assert response.plot.accumulated_volumes[0] == Decimal(-10)
+    assert response.plot.accumulated_volumes[2] == Decimal(-30)
 
 
 @injection_test
 def test_that_correct_plotting_info_is_generated_after_receiving_of_work_certificates_from_social_accounting(
     show_a_account_details: ShowAAccountDetailsUseCase,
     company_generator: CompanyGenerator,
-    transaction_generator: TransactionGenerator,
-    social_accounting: SocialAccounting,
+    plan_generator: PlanGenerator,
+    datetime_service: FakeDatetimeService,
 ):
-    company = company_generator.create_company_entity()
-    trans = transaction_generator.create_transaction(
-        sending_account=social_accounting.account,
-        receiving_account=company.work_account,
-        amount_sent=Decimal(10),
-        amount_received=Decimal(8.5),
+    transaction_timestamp = datetime(2030, 1, 1)
+    expected_labour_time = Decimal(123)
+    datetime_service.freeze_time(transaction_timestamp)
+    company = company_generator.create_company()
+    plan_generator.create_plan(
+        planner=company,
+        costs=ProductionCosts(
+            labour_cost=expected_labour_time,
+            means_cost=Decimal(0),
+            resource_cost=Decimal(0),
+        ),
     )
+    response = show_a_account_details(company)
 
-    response = show_a_account_details(company.id)
     assert response.plot.timestamps
     assert response.plot.accumulated_volumes
 
     assert len(response.plot.timestamps) == 1
     assert len(response.plot.accumulated_volumes) == 1
 
-    assert trans.date in response.plot.timestamps
-    assert trans.amount_received in response.plot.accumulated_volumes
+    assert transaction_timestamp in response.plot.timestamps
+    assert expected_labour_time in response.plot.accumulated_volumes


### PR DESCRIPTION
This change aims to remove some instances of create_member_entity in our test, specifically our use case tests. In the process I also removed the usage of the TransactionGenerator since it does not conform to the business logic of arbeitszeitapp and exposes implemenation details.

Three use case tests were completely removed since they would test implementation details instead of observable results.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)