### PR TITLE
Fix bug in routes /member/unconfirmed and /company/unconfirmed

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -11,7 +11,6 @@ from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
 from arbeitszeit.use_cases.resend_confirmation_mail import ResendConfirmationMailUseCase
 from arbeitszeit.use_cases.start_page import StartPageUseCase
 from arbeitszeit_flask.database import commit_changes
-from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
 from arbeitszeit_flask.dependency_injection import (
     CompanyModule,
     MemberModule,
@@ -24,6 +23,7 @@ from arbeitszeit_flask.types import Response
 from arbeitszeit_flask.views.signup_accountant_view import SignupAccountantView
 from arbeitszeit_flask.views.signup_company_view import SignupCompanyView
 from arbeitszeit_flask.views.signup_member_view import SignupMemberView
+from arbeitszeit_web.www.authentication import CompanyAuthenticator, MemberAuthenticator
 from arbeitszeit_web.www.controllers.confirm_company_controller import (
     ConfirmCompanyController,
 )
@@ -75,10 +75,10 @@ def set_language(language=None):
 @auth.route("/member/unconfirmed")
 @with_injection()
 @login_required
-def unconfirmed_member(database: DatabaseGatewayImpl):
-    if database.get_members().with_id(UUID(current_user.id)).that_are_confirmed():
-        return redirect(url_for("auth.start"))
-    return render_template("auth/unconfirmed_member.html")
+def unconfirmed_member(authenticator: MemberAuthenticator):
+    if authenticator.is_unconfirmed_member():
+        return render_template("auth/unconfirmed_member.html")
+    return redirect(url_for("auth.start"))
 
 
 @auth.route("/member/signup", methods=["GET", "POST"])
@@ -157,10 +157,10 @@ def resend_confirmation_member(use_case: ResendConfirmationMailUseCase):
 @auth.route("/company/unconfirmed")
 @with_injection()
 @login_required
-def unconfirmed_company(database: DatabaseGatewayImpl):
-    if database.get_companies().with_id(UUID(current_user.id)).that_are_confirmed():
-        return redirect(url_for("auth.start"))
-    return render_template("auth/unconfirmed_company.html")
+def unconfirmed_company(authenticator: CompanyAuthenticator):
+    if authenticator.is_unconfirmed_company():
+        return render_template("auth/unconfirmed_company.html")
+    return redirect(url_for("auth.start"))
 
 
 @auth.route("/company/login", methods=["GET", "POST"])

--- a/arbeitszeit_web/www/authentication.py
+++ b/arbeitszeit_web/www/authentication.py
@@ -18,6 +18,21 @@ class MemberAuthenticator:
     request: Request
     url_index: UrlIndex
 
+    def is_unconfirmed_member(self) -> bool:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            return False
+        record = (
+            self.database.get_members()
+            .with_id(user_id)
+            .joined_with_email_address()
+            .first()
+        )
+        if not record:
+            return False
+        _, email = record
+        return email.confirmed_on is None
+
     def redirect_user_to_member_login(self) -> Optional[str]:
         user_id = self.session.get_current_user()
         if not user_id:
@@ -50,6 +65,21 @@ class CompanyAuthenticator:
     notifier: Notifier
     request: Request
     url_index: UrlIndex
+
+    def is_unconfirmed_company(self) -> bool:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            return False
+        record = (
+            self.database.get_companies()
+            .with_id(user_id)
+            .joined_with_email_address()
+            .first()
+        )
+        if not record:
+            return False
+        _, email = record
+        return email.confirmed_on is None
 
     def redirect_user_to_company_login(self) -> Optional[str]:
         user_id = self.session.get_current_user()

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -23,7 +23,9 @@ from .dependency_injection import get_dependency_injector
 
 class LogInUser(Enum):
     member = auto()
+    unconfirmed_member = auto()
     company = auto()
+    unconfirmed_company = auto()
     accountant = auto()
 
 
@@ -163,15 +165,8 @@ class ViewTestCase(FlaskTestCase):
         login: Optional[LogInUser],
         data: Optional[dict[Any, Any]] = None,
     ) -> None:
-        if login is None:
-            pass
-        elif login == LogInUser.member:
-            self.login_member()
-        elif login == LogInUser.company:
-            self.login_company()
-        else:
-            self.login_accountant()
-
+        if login:
+            self._conduct_login(login)
         if method.lower() == "get":
             response = self.client.get(url, query_string=data)
         elif method.lower() == "post":
@@ -179,4 +174,18 @@ class ViewTestCase(FlaskTestCase):
         else:
             raise ValueError(f"Unknown {method=}")
 
-        assert response.status_code == expected_code
+        assert (
+            response.status_code == expected_code
+        ), f"Expected status code {expected_code} but got {response.status_code}"
+
+    def _conduct_login(self, login: LogInUser) -> None:
+        if login == LogInUser.member:
+            self.login_member()
+        elif login == LogInUser.unconfirmed_member:
+            self.login_member(confirm_member=False)
+        elif login == LogInUser.company:
+            self.login_company()
+        elif login == LogInUser.unconfirmed_company:
+            self.login_company(confirm_company=False)
+        elif login == LogInUser.accountant:
+            self.login_accountant()

--- a/tests/flask_integration/test_unconfirmed_company_view.py
+++ b/tests/flask_integration/test_unconfirmed_company_view.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from parameterized import parameterized
+
+from .flask import LogInUser, ViewTestCase
+
+
+class RedirectionTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/company/unconfirmed"
+
+    @parameterized.expand(
+        [
+            (LogInUser.unconfirmed_company, 200),
+            # any other case should result in a redirect
+            (LogInUser.member, 302),
+            (LogInUser.company, 302),
+            (LogInUser.unconfirmed_member, 302),
+            (LogInUser.accountant, 302),
+            (None, 302),
+        ]
+    )
+    def test_that_only_unconfirmed_companies_can_access_this_view(
+        self, login: Optional[LogInUser], expected_code: int
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=self.url, method="GET", expected_code=expected_code, login=login
+        )

--- a/tests/flask_integration/test_unconfirmed_member_view.py
+++ b/tests/flask_integration/test_unconfirmed_member_view.py
@@ -1,0 +1,29 @@
+from typing import Optional
+
+from parameterized import parameterized
+
+from .flask import LogInUser, ViewTestCase
+
+
+class RedirectionTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/member/unconfirmed"
+
+    @parameterized.expand(
+        [
+            (LogInUser.unconfirmed_member, 200),
+            # any other case should result in a redirect
+            (LogInUser.member, 302),
+            (LogInUser.company, 302),
+            (LogInUser.unconfirmed_company, 302),
+            (LogInUser.accountant, 302),
+            (None, 302),
+        ]
+    )
+    def test_that_only_unconfirmed_members_can_access_this_view(
+        self, login: Optional[LogInUser], expected_code: int
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=self.url, method="GET", expected_code=expected_code, login=login
+        )


### PR DESCRIPTION
This commit addresses a bug in two views from the `auth` blueprint, namely `/member/unconfirmed` and `/company/unconfirmed`.  The root cause for the issue (apart from not having proper tests) is that previously we would check if a member/company is confirmed and then redirect them to the start page if that's the case. Now the logic is that we check explicitly if the current user is an unconfirmed member/company and redirect them otherwise.

Also tests were written to check for this behavior.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf