### PR TITLE
Update dependencies

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -29,7 +29,7 @@ Flask-Mail==0.9.1
 Flask-Migrate==4.0.4
 flask-restx==1.1.0
 Flask-SQLAlchemy==3.0.3
-flask-talisman==1.0.0
+flask-talisman==1.1.0
 Flask-WTF==1.1.1
 fonttools==4.38.0
 greenlet==2.0.2

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixos-23-05": {
       "locked": {
-        "lastModified": 1690558459,
-        "narHash": "sha256-5W7y1l2cLYPkpJGNlAja7XW2X2o9rjf0O1mo9nxS9jQ=",
+        "lastModified": 1691421349,
+        "narHash": "sha256-RRJyX0CUrs4uW4gMhd/X4rcDG8PTgaaCQM5rXEJOx6g=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "48e82fe1b1c863ee26a33ce9bd39621d2ada0a33",
+        "rev": "011567f35433879aae5024fc6ec53f2a0568a6c4",
         "type": "github"
       },
       "original": {
@@ -105,11 +105,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1690630721,
-        "narHash": "sha256-Y04onHyBQT4Erfr2fc82dbJTfXGYrf4V0ysLUYnPOP8=",
+        "lastModified": 1691464053,
+        "narHash": "sha256-D21ctOBjr2Y3vOFRXKRoFr6uNBvE8q5jC4RrMxRZXTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2b52322f35597c62abf56de91b0236746b2a03d",
+        "rev": "844ffa82bbe2a2779c86ab3a72ff1b4176cec467",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
There was a version bump of flask-talisman. There was only one change from the previous version 1.0.0 to 1.1.0 which is that X-XSS-Protection is now disabled by default. I checked the mozilla developer resources about this HTTP header and they advise disabling this header anyway.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection 
https://github.com/wntrblm/flask-talisman/compare/v1.0.0...v1.1.0

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf