### PR TITLE
Rework user record handling

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -35,10 +35,8 @@ class SocialAccounting:
 class Member:
     id: UUID
     name: str
-    email: str
     account: UUID
     registered_on: datetime
-    password_hash: str
 
     def accounts(self) -> List[UUID]:
         return [self.account]
@@ -60,22 +58,16 @@ class Member:
     def is_member(self) -> bool:
         return True
 
-    @property
-    def email_address(self) -> str:
-        return self.email
-
 
 @dataclass
 class Company:
     id: UUID
-    email: str
     name: str
     means_account: UUID
     raw_material_account: UUID
     work_account: UUID
     product_account: UUID
     registered_on: datetime
-    password_hash: str
 
     def _accounts_by_type(self) -> Dict[AccountTypes, UUID]:
         return {
@@ -105,10 +97,6 @@ class Company:
 
     def is_member(self) -> bool:
         return False
-
-    @property
-    def email_address(self) -> str:
-        return self.email
 
 
 class AccountTypes(Enum):
@@ -305,9 +293,7 @@ class CompanyWorkInvite:
 @dataclass
 class Accountant:
     id: UUID
-    email_address: str
     name: str
-    password_hash: str
 
 
 @dataclass
@@ -333,6 +319,13 @@ class CompanyPurchase:
 
 
 AccountOwner = Union[Member, Company, SocialAccounting]
+
+
+@dataclass
+class AccountCredentials:
+    id: UUID
+    email_address: str
+    password_hash: str
 
 
 @dataclass

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -257,9 +257,6 @@ class MemberResult(QueryResult[Member], Protocol):
     def joined_with_email_address(self) -> QueryResult[Tuple[Member, EmailAddress]]:
         ...
 
-    def that_are_confirmed(self) -> MemberResult:
-        ...
-
 
 class PrivateConsumptionResult(QueryResult[PrivateConsumption], Protocol):
     def ordered_by_creation_date(
@@ -311,6 +308,9 @@ class CompanyResult(QueryResult[Company], Protocol):
     def that_are_workplace_of_member(self, member: UUID) -> CompanyResult:
         ...
 
+    def that_is_coordinating_cooperation(self, cooperation: UUID) -> Self:
+        ...
+
     def add_worker(self, member: UUID) -> int:
         ...
 
@@ -318,9 +318,6 @@ class CompanyResult(QueryResult[Company], Protocol):
         ...
 
     def with_email_containing(self, query: str) -> CompanyResult:
-        ...
-
-    def that_are_confirmed(self) -> Self:
         ...
 
     def joined_with_email_address(self) -> QueryResult[Tuple[Company, EmailAddress]]:
@@ -332,6 +329,9 @@ class AccountantResult(QueryResult[Accountant], Protocol):
         ...
 
     def with_id(self, id_: UUID) -> Self:
+        ...
+
+    def joined_with_email_address(self) -> QueryResult[Tuple[Accountant, EmailAddress]]:
         ...
 
 
@@ -416,12 +416,71 @@ class EmailAddressResult(QueryResult[EmailAddress], Protocol):
     def with_address(self, *addresses: str) -> Self:
         ...
 
+    def that_belong_to_member(self, member: UUID) -> Self:
+        ...
+
+    def that_belong_to_company(self, company: UUID) -> Self:
+        ...
+
     def update(self) -> EmailAddressUpdate:
         ...
 
 
 class EmailAddressUpdate(DatabaseUpdate, Protocol):
     def set_confirmation_timestamp(self, timestamp: Optional[datetime]) -> Self:
+        ...
+
+
+class AccountCredentialsResult(QueryResult[records.AccountCredentials], Protocol):
+    def with_email_address(self, address: str) -> Self:
+        ...
+
+    def joined_with_accountant(
+        self,
+    ) -> QueryResult[Tuple[records.AccountCredentials, Optional[records.Accountant]]]:
+        ...
+
+    def joined_with_email_address_and_accountant(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.AccountCredentials,
+            records.EmailAddress,
+            Optional[records.Accountant],
+        ]
+    ]:
+        ...
+
+    def joined_with_member(
+        self,
+    ) -> QueryResult[Tuple[records.AccountCredentials, Optional[records.Member]]]:
+        ...
+
+    def joined_with_email_address_and_member(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.AccountCredentials,
+            records.EmailAddress,
+            Optional[records.Member],
+        ]
+    ]:
+        ...
+
+    def joined_with_company(
+        self,
+    ) -> QueryResult[Tuple[records.AccountCredentials, Optional[records.Company]]]:
+        ...
+
+    def joined_with_email_address_and_company(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.AccountCredentials,
+            records.EmailAddress,
+            Optional[records.Company],
+        ]
+    ]:
         ...
 
 
@@ -505,9 +564,8 @@ class DatabaseGateway(Protocol):
     def create_member(
         self,
         *,
-        email: str,
+        account_credentials: UUID,
         name: str,
-        password_hash: str,
         account: Account,
         registered_on: datetime,
     ) -> Member:
@@ -518,9 +576,8 @@ class DatabaseGateway(Protocol):
 
     def create_company(
         self,
-        email: str,
+        account_credentials: UUID,
         name: str,
-        password_hash: str,
         means_account: Account,
         labour_account: Account,
         resource_account: Account,
@@ -532,7 +589,9 @@ class DatabaseGateway(Protocol):
     def get_companies(self) -> CompanyResult:
         ...
 
-    def create_accountant(self, email: str, name: str, password_hash: str) -> UUID:
+    def create_accountant(
+        self, account_credentials: UUID, name: str
+    ) -> records.Accountant:
         ...
 
     def get_accountants(self) -> AccountantResult:
@@ -567,4 +626,12 @@ class DatabaseGateway(Protocol):
         ...
 
     def get_accounts(self) -> AccountResult:
+        ...
+
+    def create_account_credentials(
+        self, email_address: str, password_hash: str
+    ) -> records.AccountCredentials:
+        ...
+
+    def get_account_credentials(self) -> AccountCredentialsResult:
         ...

--- a/arbeitszeit/use_cases/get_accountant_dashboard.py
+++ b/arbeitszeit/use_cases/get_accountant_dashboard.py
@@ -18,9 +18,15 @@ class GetAccountantDashboardUseCase:
     database: DatabaseGateway
 
     def get_dashboard(self, user: UUID) -> Response:
-        accountant = self.database.get_accountants().with_id(user).first()
-        if not accountant:
+        record = (
+            self.database.get_accountants()
+            .with_id(user)
+            .joined_with_email_address()
+            .first()
+        )
+        if not record:
             raise self.Failure()
+        accountant, email = record
         return self.Response(
-            accountant_id=user, name=accountant.name, email=accountant.email_address
+            accountant_id=user, name=accountant.name, email=email.address
         )

--- a/arbeitszeit/use_cases/get_company_dashboard.py
+++ b/arbeitszeit/use_cases/get_company_dashboard.py
@@ -36,11 +36,17 @@ class GetCompanyDashboardUseCase:
     datetime_service: DatetimeService
 
     def get_dashboard(self, company_id: UUID) -> Response:
-        company = self.database_gateway.get_companies().with_id(company_id).first()
-        if company is None:
+        record = (
+            self.database_gateway.get_companies()
+            .with_id(company_id)
+            .joined_with_email_address()
+            .first()
+        )
+        if record is None:
             raise self.Failure()
+        company, email = record
         company_info = self.Response.CompanyInfo(
-            id=company.id, name=company.name, email=company.email
+            id=company.id, name=company.name, email=email.address
         )
         has_workers = bool(
             self.database_gateway.get_members().working_at_company(company_id)

--- a/arbeitszeit/use_cases/get_company_summary.py
+++ b/arbeitszeit/use_cases/get_company_summary.py
@@ -67,9 +67,15 @@ class GetCompanySummary:
     datetime_service: DatetimeService
 
     def __call__(self, company_id: UUID) -> GetCompanySummaryResponse:
-        company = self.database_gateway.get_companies().with_id(company_id).first()
-        if company is None:
+        record = (
+            self.database_gateway.get_companies()
+            .with_id(company_id)
+            .joined_with_email_address()
+            .first()
+        )
+        if not record:
             return None
+        company, email = record
         plans = (
             self.database_gateway.get_plans()
             .planned_by(company.id)
@@ -86,7 +92,7 @@ class GetCompanySummary:
         return GetCompanySummarySuccess(
             id=company.id,
             name=company.name,
-            email=company.email,
+            email=email.address,
             registered_on=company.registered_on,
             expectations=expectations,
             account_balances=account_balances,

--- a/arbeitszeit/use_cases/get_user_account_details.py
+++ b/arbeitszeit/use_cases/get_user_account_details.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Optional, Tuple, Union
 from uuid import UUID
 
 from arbeitszeit import records
@@ -13,16 +13,31 @@ class GetUserAccountDetailsUseCase:
     database: DatabaseGateway
 
     def get_user_account_details(self, request: Request) -> Response:
-        user: Union[records.Member, records.Company, records.Accountant, None] = (
-            self.database.get_members().with_id(request.user_id).first()
-            or self.database.get_companies().with_id(request.user_id).first()
-            or self.database.get_accountants().with_id(request.user_id).first()
+        record: Optional[
+            Tuple[
+                Union[records.Member, records.Company, records.Accountant],
+                records.EmailAddress,
+            ],
+        ] = (
+            (
+                self.database.get_members().with_id(request.user_id)
+                or self.database.get_companies().with_id(request.user_id)
+                or self.database.get_accountants().with_id(request.user_id)
+            )
+            .joined_with_email_address()
+            .first()
         )
-        return Response(
-            user_info=UserInfo(id=user.id, email_address=user.email_address)
-            if user
-            else None
-        )
+        if not record:
+            return self._create_failure_model()
+        else:
+            user, mail = record
+            return self._create_success_model(user.id, mail.address)
+
+    def _create_success_model(self, user_id: UUID, email_address: str) -> Response:
+        return Response(user_info=UserInfo(id=user_id, email_address=email_address))
+
+    def _create_failure_model(self) -> Response:
+        return Response(user_info=None)
 
 
 @dataclass

--- a/arbeitszeit/use_cases/list_workers.py
+++ b/arbeitszeit/use_cases/list_workers.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import List
 from uuid import UUID
 
-from arbeitszeit.records import Member
+from arbeitszeit.records import EmailAddress, Member
 from arbeitszeit.repositories import DatabaseGateway
 
 
@@ -32,12 +32,17 @@ class ListWorkers:
             return ListWorkersResponse(workers=[])
         members = self.database.get_members().working_at_company(request.company)
         return ListWorkersResponse(
-            workers=[self._create_worker_response_model(member) for member in members]
+            workers=[
+                self._create_worker_response_model(member, mail)
+                for member, mail in members.joined_with_email_address()
+            ]
         )
 
-    def _create_worker_response_model(self, member: Member) -> ListedWorker:
+    def _create_worker_response_model(
+        self, member: Member, email: EmailAddress
+    ) -> ListedWorker:
         return ListedWorker(
             id=member.id,
             name=member.name,
-            email=member.email,
+            email=email.address,
         )

--- a/arbeitszeit/use_cases/log_in_accountant.py
+++ b/arbeitszeit/use_cases/log_in_accountant.py
@@ -30,17 +30,23 @@ class LogInAccountantUseCase:
     password_hasher: PasswordHasher
 
     def log_in_accountant(self, request: Request) -> Response:
-        accountant = (
-            self.database.get_accountants()
+        record = (
+            self.database.get_account_credentials()
             .with_email_address(request.email_address.strip())
+            .joined_with_accountant()
             .first()
         )
-        if accountant is None:
+        if record is None or record[1] is None:
             return self.Response(
                 rejection_reason=self.RejectionReason.email_is_not_accountant
             )
-        elif not self.password_hasher.is_password_matching_hash(
-            password=request.password, password_hash=accountant.password_hash
-        ):
-            return self.Response(rejection_reason=self.RejectionReason.wrong_password)
-        return self.Response(user_id=accountant.id)
+        else:
+            credentials, accountant = record
+            assert accountant
+            if not self.password_hasher.is_password_matching_hash(
+                password=request.password, password_hash=credentials.password_hash
+            ):
+                return self.Response(
+                    rejection_reason=self.RejectionReason.wrong_password
+                )
+            return self.Response(user_id=accountant.id)

--- a/arbeitszeit/use_cases/log_in_member.py
+++ b/arbeitszeit/use_cases/log_in_member.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import Optional
 from uuid import UUID
 
+from arbeitszeit import records
 from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.repositories import DatabaseGateway
 
@@ -32,27 +33,35 @@ class LogInMemberUseCase:
     password_hasher: PasswordHasher
 
     def log_in_member(self, request: Request) -> Response:
-        member = (
-            self.database.get_members()
+        credentials: records.AccountCredentials
+        member: Optional[records.Member]
+        record = (
+            self.database.get_account_credentials()
             .with_email_address(request.email.strip())
+            .joined_with_member()
             .first()
         )
-        if not member:
-            reason = self.RejectionReason.unknown_email_address
-        elif not self.password_hasher.is_password_matching_hash(
-            password=request.password, password_hash=member.password_hash
-        ):
-            reason = self.RejectionReason.invalid_password
-        else:
+        if not record or not record[1]:
             return self.Response(
-                is_logged_in=True,
-                rejection_reason=None,
+                is_logged_in=False,
+                rejection_reason=self.RejectionReason.unknown_email_address,
                 email=request.email,
-                user_id=member.id,
+                user_id=None,
+            )
+        credentials, member = record
+        assert member
+        if not self.password_hasher.is_password_matching_hash(
+            password=request.password, password_hash=credentials.password_hash
+        ):
+            return self.Response(
+                is_logged_in=False,
+                rejection_reason=self.RejectionReason.invalid_password,
+                email=request.email,
+                user_id=None,
             )
         return self.Response(
-            is_logged_in=False,
-            rejection_reason=reason,
+            is_logged_in=True,
+            rejection_reason=None,
             email=request.email,
-            user_id=None,
+            user_id=member.id,
         )

--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -140,10 +140,6 @@ def login_member(
 @with_injection(modules=[MemberModule()])
 @login_required
 def resend_confirmation_member(use_case: ResendConfirmationMailUseCase):
-    assert (
-        current_user.user.email_address
-    )  # current user object must have email because it is logged in
-
     request = use_case.Request(user=UUID(current_user.id))
     response = use_case.resend_confirmation_mail(request)
     if response.is_token_sent:
@@ -230,10 +226,6 @@ def confirm_email_company(
 @with_injection(modules=[CompanyModule()])
 @login_required
 def resend_confirmation_company(use_case: ResendConfirmationMailUseCase):
-    assert (
-        current_user.user.email_address
-    )  # current user object must have email because it is logged in
-
     request = use_case.Request(user=UUID(current_user.id))
     response = use_case.resend_confirmation_mail(request)
     if response.is_token_sent:

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -50,12 +50,6 @@ class Member(UserMixin, db.Model):
     registered_on = db.Column(db.DateTime, nullable=False)
     account = db.Column(db.ForeignKey("account.id"), nullable=False)
 
-    user = db.relationship(
-        "User",
-        lazy=True,
-        uselist=False,
-        backref=db.backref("member"),
-    )
     workplaces = db.relationship(
         "Company",
         secondary=jobs,
@@ -74,13 +68,6 @@ class Company(UserMixin, db.Model):
     a_account = db.Column(db.ForeignKey("account.id"), nullable=False)
     prd_account = db.Column(db.ForeignKey("account.id"), nullable=False)
 
-    user = db.relationship(
-        "User",
-        lazy=True,
-        uselist=False,
-        backref=db.backref("company"),
-    )
-
     def __repr__(self):
         return "<Company(name='%s')>" % (self.name,)
 
@@ -89,13 +76,6 @@ class Accountant(UserMixin, db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     user_id = db.Column(db.ForeignKey("user.id"), nullable=False, unique=True)
     name = db.Column(db.String(1000), nullable=False)
-
-    user = db.relationship(
-        "User",
-        lazy=True,
-        uselist=False,
-        backref=db.backref("accountant"),
-    )
 
 
 class PlanDraft(db.Model):

--- a/tests/flask_integration/database_gateway_impl/test_account_credentials_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_credentials_result.py
@@ -1,0 +1,308 @@
+from parameterized import parameterized
+
+from arbeitszeit import records
+from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
+
+from ..flask import FlaskTestCase
+
+
+class AccountCredentialsResultTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.accountant_generator = self.injector.get(AccountantGenerator)
+        self.member_generator = self.injector.get(MemberGenerator)
+        self.company_generator = self.injector.get(CompanyGenerator)
+
+    def create_account_credentials(
+        self, *, email_address: str = "test@cp.org", password_hash: str = ""
+    ) -> records.AccountCredentials:
+        self.database_gateway.create_email_address(
+            address=email_address, confirmed_on=None
+        )
+        return self.database_gateway.create_account_credentials(
+            email_address=email_address, password_hash=password_hash
+        )
+
+    def create_members(self, *, n: int) -> None:
+        for _ in range(n):
+            self.member_generator.create_member()
+
+    def create_accountants(self, *, n: int) -> None:
+        for _ in range(n):
+            self.accountant_generator.create_accountant()
+
+    def create_companies(self, *, n: int) -> None:
+        for _ in range(n):
+            self.company_generator.create_company()
+
+
+class CreateAccountCredentialsTests(AccountCredentialsResultTests):
+    @parameterized.expand(["test@test.test", "", "ABC@123.fg"])
+    def test_account_credentials_created_has_correct_email_address_set(
+        self, expected_email_address: str
+    ) -> None:
+        credentials = self.create_account_credentials(
+            email_address=expected_email_address
+        )
+        assert credentials.email_address == expected_email_address
+
+    @parameterized.expand(["abc", "\n\t", ""])
+    def test_account_credentials_created_has_correct_password_hash_set(
+        self, expected_password_hash: str
+    ) -> None:
+        credentials = self.create_account_credentials(
+            password_hash=expected_password_hash
+        )
+        assert credentials.password_hash == expected_password_hash
+
+    @parameterized.expand(["test@test.test", "", "ABC@123.fg"])
+    def test_account_credentials_retrieved_from_db_have_original_email_address(
+        self, expected_email_address: str
+    ) -> None:
+        self.create_account_credentials(email_address=expected_email_address)
+        credentials = self.database_gateway.get_account_credentials().first()
+        assert credentials
+        assert credentials.email_address == expected_email_address
+
+    @parameterized.expand(["abc", "\n\t", ""])
+    def test_account_credentials_retrieved_from_db_have_original_password_hash(
+        self, expected_password_hash: str
+    ) -> None:
+        self.create_account_credentials(password_hash=expected_password_hash)
+        credentials = self.database_gateway.get_account_credentials().first()
+        assert credentials
+        assert credentials.password_hash == expected_password_hash
+
+
+class JoinedWithEmailAddressAndCompanyTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_companies_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(
+                self.database_gateway.get_account_credentials().joined_with_email_address_and_company()
+            )
+            == companies + members + accountants
+        )
+
+    @parameterized.expand(["name1", "test name 2"])
+    def test_that_companies_yielded_have_their_correct_name(
+        self, expected_name: str
+    ) -> None:
+        self.company_generator.create_company(name=expected_name)
+        assert all(
+            result[2] is not None and result[2].name == expected_name
+            for result in self.database_gateway.get_account_credentials().joined_with_email_address_and_company()
+        )
+
+
+class JoinedWithEmailAddressAndMemberTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_members_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(
+                self.database_gateway.get_account_credentials().joined_with_email_address_and_member()
+            )
+            == companies + members + accountants
+        )
+
+    @parameterized.expand(["name1", "test name 2"])
+    def test_that_companies_yielded_have_their_correct_name(
+        self, expected_name: str
+    ) -> None:
+        self.member_generator.create_member(name=expected_name)
+        assert all(
+            result[2] is not None and result[2].name == expected_name
+            for result in self.database_gateway.get_account_credentials().joined_with_email_address_and_member()
+        )
+
+
+class JoinedWithEmailAddressAndAccountantTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_accountants_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(
+                self.database_gateway.get_account_credentials().joined_with_email_address_and_accountant()
+            )
+            == companies + members + accountants
+        )
+
+    @parameterized.expand(["name1", "test name 2"])
+    def test_that_companies_yielded_have_their_correct_name(
+        self, expected_name: str
+    ) -> None:
+        self.accountant_generator.create_accountant(name=expected_name)
+        assert all(
+            result[2] is not None and result[2].name == expected_name
+            for result in self.database_gateway.get_account_credentials().joined_with_email_address_and_accountant()
+        )
+
+
+class JoinedWithAccountantTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_accountants_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(
+                self.database_gateway.get_account_credentials().joined_with_accountant()
+            )
+            == companies + members + accountants
+        )
+
+    def test_that_credentials_with_accountant_return_accountant_in_result_set(
+        self,
+    ) -> None:
+        self.accountant_generator.create_accountant()
+        assert all(
+            result[1] is not None
+            for result in self.database_gateway.get_account_credentials().joined_with_accountant()
+        )
+
+
+class JoinedWithMemberTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_members_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(self.database_gateway.get_account_credentials().joined_with_member())
+            == companies + members + accountants
+        )
+
+    def test_that_credentials_with_member_return_member_in_result_set(self) -> None:
+        self.member_generator.create_member()
+        assert all(
+            result[1] is not None
+            for result in self.database_gateway.get_account_credentials().joined_with_member()
+        )
+
+
+class JoinedWithCompanyTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            (0, 0, 0),
+            (1, 0, 0),
+            (0, 1, 0),
+            (0, 0, 1),
+            (2, 2, 2),
+        ]
+    )
+    def test_that_credentials_without_companies_are_also_included_in_result_set(
+        self, companies: int, members: int, accountants: int
+    ) -> None:
+        self.create_companies(n=companies)
+        self.create_members(n=members)
+        self.create_accountants(n=accountants)
+        assert (
+            len(self.database_gateway.get_account_credentials().joined_with_company())
+            == companies + members + accountants
+        )
+
+    def test_that_credentials_with_company_return_company_in_result_set(self) -> None:
+        self.company_generator.create_company()
+        assert all(
+            result[1] is not None
+            for result in self.database_gateway.get_account_credentials().joined_with_company()
+        )
+
+
+class WithEmailAddressTests(AccountCredentialsResultTests):
+    @parameterized.expand(
+        [
+            "test@test.test",
+            "TEST@TEST.TEST",
+        ]
+    )
+    def test_that_filtering_ignores_casing(self, address: str) -> None:
+        self.database_gateway.create_email_address(address=address, confirmed_on=None)
+        self.database_gateway.create_account_credentials(
+            email_address=address, password_hash=""
+        )
+        assert self.database_gateway.get_account_credentials().with_email_address(
+            address
+        )
+        assert self.database_gateway.get_account_credentials().with_email_address(
+            address.lower()
+        )
+        assert self.database_gateway.get_account_credentials().with_email_address(
+            address.upper()
+        )
+
+    @parameterized.expand(
+        [
+            ("test@test.test", "test@test.test1"),
+            ("TEST@TEST.TEST", ""),
+            ("test@test.test", "test@test.tes"),
+        ]
+    )
+    def test_that_emails_that_dont_match_are_filtered(
+        self, address: str, filter_text: str
+    ) -> None:
+        self.database_gateway.create_email_address(address=address, confirmed_on=None)
+        self.database_gateway.create_account_credentials(
+            email_address=address, password_hash=""
+        )
+        assert not self.database_gateway.get_account_credentials().with_email_address(
+            filter_text
+        )

--- a/tests/flask_integration/database_gateway_impl/test_account_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_result.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from parameterized import parameterized
 
+from arbeitszeit import records
 from arbeitszeit.records import SocialAccounting
 from tests.data_generators import (
     AccountGenerator,
@@ -48,10 +49,10 @@ class AccountResultTests(FlaskTestCase):
 
     def test_that_account_joined_with_owner_yields_original_member(self) -> None:
         account = self.database_gateway.create_account()
+        credentials = self.create_account_credentials()
         member = self.database_gateway.create_member(
-            email="test@test.test",
+            account_credentials=credentials.id,
             name="test name",
-            password_hash="password",
             account=account,
             registered_on=datetime(2000, 1, 1),
         )
@@ -144,10 +145,10 @@ class AccountResultTests(FlaskTestCase):
         self,
     ) -> None:
         expected_account = self.database_gateway.create_account()
+        credentials = self.create_account_credentials()
         self.database_gateway.create_company(
-            email="",
+            account_credentials=credentials.id,
             name="",
-            password_hash="",
             means_account=self.database_gateway.create_account(),
             resource_account=self.database_gateway.create_account(),
             labour_account=self.database_gateway.create_account(),
@@ -170,10 +171,10 @@ class AccountResultTests(FlaskTestCase):
         self,
     ) -> None:
         expected_account = self.database_gateway.create_account()
+        credentials = self.create_account_credentials()
         self.database_gateway.create_company(
-            email="",
+            account_credentials=credentials.id,
             name="",
-            password_hash="",
             means_account=self.database_gateway.create_account(),
             resource_account=self.database_gateway.create_account(),
             labour_account=expected_account,
@@ -265,3 +266,12 @@ class AccountResultTests(FlaskTestCase):
     ) -> None:
         company = self.company_generator.create_company()
         assert len(self.database_gateway.get_accounts().owned_by_company(company)) == 4
+
+    def create_account_credentials(
+        self, address: str = "test@test.test"
+    ) -> records.AccountCredentials:
+        self.database_gateway.create_email_address(address=address, confirmed_on=None)
+        return self.database_gateway.create_account_credentials(
+            email_address=address,
+            password_hash="",
+        )

--- a/tests/flask_integration/database_gateway_impl/test_accountant_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_accountant_result.py
@@ -1,153 +1,107 @@
 from uuid import uuid4
 
 from flask_sqlalchemy import SQLAlchemy
-from sqlalchemy.exc import IntegrityError
+from parameterized import parameterized
 
-from tests.data_generators import MemberGenerator
+from arbeitszeit import records
+from tests.data_generators import AccountantGenerator, MemberGenerator
 
 from ..flask import FlaskTestCase
 from .utility import Utility
 
 
-class CreateAccountantTests(FlaskTestCase):
+class AccountantResultTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.accountant_generator = self.injector.get(AccountantGenerator)
+
+    def create_accountant(
+        self, *, email_address: str = "test@test.test", name: str = "test name"
+    ) -> records.Accountant:
+        self.database_gateway.create_email_address(
+            address=email_address, confirmed_on=None
+        )
+        credentials = self.database_gateway.create_account_credentials(
+            email_address=email_address,
+            password_hash="1234",
+        )
+        return self.database_gateway.create_accountant(
+            name=name,
+            account_credentials=credentials.id,
+        )
+
+
+class CreateAccountantTests(AccountantResultTests):
     def setUp(self) -> None:
         super().setUp()
         self.expected_email = "test@test.test"
         self.expected_name = "test name"
-        self.expected_password = "test password"
-        self.uuid = self.database_gateway.create_accountant(
-            email=self.expected_email,
-            name=self.expected_name,
-            password_hash=self.expected_password,
+        self.accountant = self.create_accountant(
+            email_address=self.expected_email, name=self.expected_name
         )
-
-    def test_repository_stores_email_address_correctly(self) -> None:
-        accountant = self.database_gateway.get_accountants().with_id(self.uuid).first()
-        assert accountant
-        self.assertEqual(accountant.email_address, self.expected_email)
+        self.uuid = self.accountant.id
 
     def test_repository_stores_name_correctly(self) -> None:
         accountant = self.database_gateway.get_accountants().with_id(self.uuid).first()
         assert accountant
         self.assertEqual(accountant.name, self.expected_name)
 
-    def test_cannot_create_accountant_with_same_email_twice(self) -> None:
-        with self.assertRaises(IntegrityError):
-            self.uuid = self.database_gateway.create_accountant(
-                email=self.expected_email,
-                name=self.expected_name,
-                password_hash=self.expected_password,
-            )
-            self.db.session.flush()
 
-    def test_cannot_create_accountant_with_similar_email_case_insensitive(self) -> None:
-        with self.assertRaises(IntegrityError):
-            altered_email = Utility.mangle_case(self.expected_email)
-            self.uuid = self.database_gateway.create_accountant(
-                email=altered_email,
-                name=self.expected_name,
-                password_hash=self.expected_password,
-            )
-            self.db.session.flush()
-
-
-class CreateAccountantWithExistingMemberEmailTests(FlaskTestCase):
+class CreateAccountantWithExistingMemberEmailTests(AccountantResultTests):
     def setUp(self) -> None:
         super().setUp()
         self.db = self.injector.get(SQLAlchemy)
         self.member_generator = self.injector.get(MemberGenerator)
         self.expected_email = "test@test.test"
-        self.expected_name = "test name"
-        self.expected_password = "test password"
 
     def test_can_create_accountant_with_same_email_address_as_member(self) -> None:
         self.member_generator.create_member(email=self.expected_email)
+        account_credentials = (
+            self.database_gateway.get_account_credentials()
+            .with_email_address(self.expected_email)
+            .first()
+        )
+        assert account_credentials
         self.database_gateway.create_accountant(
-            email=self.expected_email,
-            name=self.expected_name,
-            password_hash=self.expected_password,
-        )
-        self.db.session.flush()
-
-    def test_can_create_accountant_with_similar_email_address_as_member_case_insensitive(
-        self,
-    ) -> None:
-        self.member_generator.create_member(email=self.expected_email)
-        altered_email = Utility.mangle_case(self.expected_email)
-        new_accountant_id = self.database_gateway.create_accountant(
-            email=altered_email,
-            name=self.expected_name,
-            password_hash=self.expected_password,
-        )
-        self.db.session.flush()
-        new_accountant = (
-            self.database_gateway.get_accountants().with_id(new_accountant_id).first()
-        )
-        self.db.session.flush()
-        assert new_accountant and new_accountant.email_address == self.expected_email
-
-
-class ValidationTests(FlaskTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.expected_email = "test@test.test"
-        self.expected_password = "test password"
-        self.uuid = self.database_gateway.create_accountant(
-            email=self.expected_email,
+            account_credentials=account_credentials.id,
             name="test name",
-            password_hash=self.expected_password,
         )
+        self.db.session.flush()
 
 
-class GetAccountantsTests(FlaskTestCase):
+class GetAccountantsTests(AccountantResultTests):
     def test_that_by_default_there_are_no_accountants_in_db(self) -> None:
         assert not self.database_gateway.get_accountants()
 
     def test_that_one_item_is_shown_after_accountant_was_created(self) -> None:
-        self.database_gateway.create_accountant(
-            email="test@test.test", name="test accountant", password_hash="1234"
-        )
+        self.create_accountant()
         assert len(self.database_gateway.get_accountants()) == 1
-
-    def test_that_correct_email_address_is_retrieved(self) -> None:
-        expected_email_address = "test@email.com"
-        self.database_gateway.create_accountant(
-            email=expected_email_address, name="test accountant", password_hash="1234"
-        )
-        item = list(self.database_gateway.get_accountants())[0]
-        assert item.email_address == expected_email_address
 
     def test_that_correct_name_is_retrieved(self) -> None:
         expected_name = "test name 123"
-        self.database_gateway.create_accountant(
-            email="test@test.test", name=expected_name, password_hash="1234"
-        )
+        self.create_accountant(name=expected_name)
         item = list(self.database_gateway.get_accountants())[0]
         assert item.name == expected_name
 
 
-class WithIdTests(FlaskTestCase):
+class WithIdTests(AccountantResultTests):
     def test_with_any_accountants_in_db_that_result_set_is_empty(self) -> None:
         assert not self.database_gateway.get_accountants().with_id(uuid4())
 
     def test_result_set_is_empty_with_with_unknown_id_and_one_accountant_in_db(
         self,
     ) -> None:
-        self.database_gateway.create_accountant(
-            email="test@test.test", name="test name", password_hash="1234"
-        )
+        self.create_accountant()
         assert not self.database_gateway.get_accountants().with_id(uuid4())
 
     def test_result_set_contains_1_entry_with_id_for_previously_created_accountant(
         self,
     ) -> None:
-        accountant_id = self.database_gateway.create_accountant(
-            email="test@test.test", name="test name", password_hash="1234"
-        )
-        assert len(self.database_gateway.get_accountants().with_id(accountant_id)) == 1
+        accountant = self.create_accountant()
+        assert len(self.database_gateway.get_accountants().with_id(accountant.id)) == 1
 
 
-class WithEmailAddressTests(FlaskTestCase):
+class WithEmailAddressTests(AccountantResultTests):
     def test_result_set_is_empty_with_empty_db(self) -> None:
         assert not self.database_gateway.get_accountants().with_email_address(
             "fake@mail.test"
@@ -156,9 +110,7 @@ class WithEmailAddressTests(FlaskTestCase):
     def test_result_set_is_empty_with_unknown_email_address_and_one_accountant_in_db(
         self,
     ) -> None:
-        self.database_gateway.create_accountant(
-            email="test@test.test", name="test name", password_hash="1234"
-        )
+        self.create_accountant(email_address="test@test.test")
         assert not self.database_gateway.get_accountants().with_email_address(
             "fake@mail.test"
         )
@@ -166,13 +118,12 @@ class WithEmailAddressTests(FlaskTestCase):
     def test_result_set_contains_one_record_with_known_email_address_of_existing_accountant(
         self,
     ) -> None:
-        self.database_gateway.create_accountant(
-            email="test@test.test", name="test name", password_hash="1234"
-        )
+        expected_email_address = "test1@test.test"
+        self.create_accountant(email_address=expected_email_address)
         assert (
             len(
                 self.database_gateway.get_accountants().with_email_address(
-                    "test@test.test"
+                    expected_email_address
                 )
             )
             == 1
@@ -182,9 +133,7 @@ class WithEmailAddressTests(FlaskTestCase):
         self,
     ) -> None:
         email = "test@test.test"
-        self.database_gateway.create_accountant(
-            email=email, name="test name", password_hash="1234"
-        )
+        self.create_accountant(email_address=email)
         altered_email = Utility.mangle_case(email)
         assert (
             len(
@@ -193,4 +142,27 @@ class WithEmailAddressTests(FlaskTestCase):
                 )
             )
             == 1
+        )
+
+
+class JoinedWithEmailAddressTests(AccountantResultTests):
+    @parameterized.expand(["test@test.test"])
+    def test_that_email_address_is_the_one_that_accountant_was_created_with(
+        self, expected_address
+    ) -> None:
+        self.create_accountant(email_address=expected_address)
+        assert all(
+            result[1].address == expected_address
+            for result in self.database_gateway.get_accountants().joined_with_email_address()
+        )
+
+    @parameterized.expand([(0,), (1,), (2,)])
+    def test_that_result_has_length_equal_to_amount_of_created_accountants(
+        self, n: int
+    ) -> None:
+        for _ in range(n):
+            self.accountant_generator.create_accountant()
+        assert (
+            len(self.database_gateway.get_accountants().joined_with_email_address())
+            == n
         )

--- a/tests/flask_integration/database_gateway_impl/test_email_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_email_result.py
@@ -3,11 +3,20 @@ from datetime import datetime
 import pytest
 from sqlalchemy.exc import IntegrityError
 
+from tests.data_generators import CompanyGenerator, MemberGenerator
+
 from ..flask import FlaskTestCase
 from .utility import Utility
 
 
-class EmailResultTests(FlaskTestCase):
+class EmailAddressResultTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.member_generator = self.injector.get(MemberGenerator)
+        self.company_generator = self.injector.get(CompanyGenerator)
+
+
+class CreateEmailAddressTests(EmailAddressResultTests):
     def test_cannot_create_same_email_address_twice(self) -> None:
         address = "test@test.test"
         self.database_gateway.create_email_address(address=address, confirmed_on=None)
@@ -24,3 +33,29 @@ class EmailResultTests(FlaskTestCase):
             self.database_gateway.create_email_address(
                 address=altered_address, confirmed_on=datetime.min
             )
+
+
+class ThatBelongToMemberTests(EmailAddressResultTests):
+    def test_that_member_email_addresses_is_included(self) -> None:
+        member = self.member_generator.create_member()
+        assert self.database_gateway.get_email_addresses().that_belong_to_member(member)
+
+    def test_that_companies_are_not_included(self) -> None:
+        company = self.company_generator.create_company()
+        assert not self.database_gateway.get_email_addresses().that_belong_to_member(
+            company
+        )
+
+
+class ThatBelongToCompanyTests(EmailAddressResultTests):
+    def test_that_members_are_not_included(self) -> None:
+        member = self.member_generator.create_member()
+        assert not self.database_gateway.get_email_addresses().that_belong_to_company(
+            member
+        )
+
+    def test_that_companies_are_included(self) -> None:
+        company = self.company_generator.create_company()
+        assert self.database_gateway.get_email_addresses().that_belong_to_company(
+            company
+        )

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -38,11 +38,14 @@ class FlaskTestCase(TestCase):
         self.app = self.injector.get(Flask)
         self.app_context = self.app.app_context()
         self.app_context.push()
+        self.db.session.flush()
         self.db.drop_all()
         self.db.create_all()
+        self.db.session.flush()
         self.database_gateway = self.injector.get(DatabaseGatewayImpl)
 
     def tearDown(self) -> None:
+        self.db.session.flush()
         self.app_context.pop()
         super().tearDown()
 

--- a/tests/flask_integration/test_user_address_book.py
+++ b/tests/flask_integration/test_user_address_book.py
@@ -26,10 +26,11 @@ class UserAddressBookTests(FlaskTestCase):
         )
 
     def test_that_associated_email_for_company_is_returned(self) -> None:
-        company = self.company_generator.create_company_record()
+        expected_email = "test@test.test"
+        company = self.company_generator.create_company(email=expected_email)
         self.assertEqual(
-            company.email,
-            self.repository.get_user_email_address(company.id),
+            expected_email,
+            self.repository.get_user_email_address(company),
         )
 
     def test_that_associated_email_for_accountant_is_returned(self) -> None:

--- a/tests/use_cases/test_query_companies.py
+++ b/tests/use_cases/test_query_companies.py
@@ -18,13 +18,7 @@ class TestQueryCompanies(BaseTestCase):
     def company_in_results(
         self, company: Company, response: CompanyQueryResponse
     ) -> bool:
-        return any(
-            (
-                company.name == result.company_name
-                and company.email == result.company_email
-                for result in response.results
-            )
-        )
+        return any((result.company_id == company.id for result in response.results))
 
     def test_that_no_company_is_returned_when_searching_an_empty_repository(self):
         response = self.query_companies(make_request(None, CompanyFilter.by_name))


### PR DESCRIPTION
This change aims to make the user handling code more explicit. I tried to improve the test coverage for the DB code. This let to the tests taking longer to execute. I felt that this was warranted since for local development it is rarely necessary to execute all the DB tests.

# Remove login info from Member, Company, Accountant records

This change changes the API and data records for `Member`, `Company`
and `Accountant` user objects.  Those 3 classes no longer have login
information associated with them.  There is a new record type
`AccountCredentials` which holds information on password hashes and
email addresses. The database interface and implementations were
changed to accommodate this. For a birds eye view the behavior of the
application should not have changed.

# Implement explicit relationships in test DB implementation

Before this change in the test DB implementation we used indices to
model relationships between models.  Now there is an explicit
`Relationships` class that models implicit relationships between
records.  There are 3 kinds of relationships modeled in this change:
OneToOne, OneToMany and ManyToMany.  Those relationship types enforce
invariants via `assert` statements, for example the OneToOne
relationship enforces that one object can only ever be associated with
one other object.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (6x)