### PR TITLE
Drop support for nixos-22.11

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -112,43 +112,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-  nixos-22-11:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v18
-      with:
-        install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-    - uses: cachix/cachix-action@v12
-      with:
-        name: arbeitszeit
-        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    # One might be tempted to run all the tests from `./run-checks`
-    # but this could be a bad idea.  The python packages used with
-    # nixos-22-11 are older then nixos-unstable.  This means that
-    # there might be incompatibilities between different versions of
-    # the tools used, e.g. mypy, flake8, black and so on. To avoid
-    # running into these incompatibilities we simply don't run
-    # them. As long as all the tests from `pytest` run successfully we
-    # should be okay.
-    - run: nix develop .#nixos-22-11 --command pytest
-      env:
-        ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
   nixos-23-05:
     runs-on: ubuntu-latest
     steps:

--- a/flake.lock
+++ b/flake.lock
@@ -55,22 +55,6 @@
         "type": "github"
       }
     },
-    "nixos-22-11": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-23-05": {
       "locked": {
         "lastModified": 1691693223,
@@ -123,7 +107,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-22-11": "nixos-22-11",
         "nixos-23-05": "nixos-23-05",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,17 @@
   description = "Arbeitszeitapp";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-22-11.url = "github:NixOS/nixpkgs/nixos-22.11";
     nixos-23-05.url = "github:NixOS/nixpkgs/nixos-23.05";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
 
-  outputs =
-    { self, nixpkgs, flake-utils, flask-profiler, nixos-22-11, nixos-23-05 }:
+  outputs = { self, nixpkgs, flake-utils, flask-profiler, nixos-23-05 }:
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
       systemDependent = flake-utils.lib.eachSystem supportedSystems (system:
         let
           pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ self.overlays.default ];
-          };
-          pkgs-22-11 = import nixos-22-11 {
             inherit system;
             overlays = [ self.overlays.default ];
           };
@@ -29,7 +23,6 @@
         in {
           devShells = {
             default = pkgs.callPackage nix/devShell.nix { };
-            nixos-22-11 = pkgs-22-11.callPackage nix/devShell.nix { };
             nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
           };
           packages = {


### PR DESCRIPTION
The build instructions for nixos-22.11 were removed from flake.nix and associated tests were dropped from the github pipeline.