### PR TITLE
Implement RequestEmailAddressChange use case

### DIFF
--- a/arbeitszeit/email.py
+++ b/arbeitszeit/email.py
@@ -1,0 +1,2 @@
+def is_possibly_an_email_address(text: str) -> bool:
+    return "@" in text and not text.startswith("@") and not text.endswith("@")

--- a/arbeitszeit/presenters.py
+++ b/arbeitszeit/presenters.py
@@ -35,3 +35,15 @@ class AccountantInvitationPresenter(Protocol):
 class InviteWorkerPresenter(Protocol):
     def show_invite_worker_message(self, worker_email: str, invite: UUID) -> None:
         ...
+
+
+class ChangeUserEmailAddressPresenter(Protocol):
+    @dataclass
+    class Notification:
+        old_email_address: str
+        new_email_address: str
+
+    def present_email_change_confirmation_message(
+        self, notification: Notification
+    ) -> None:
+        ...

--- a/arbeitszeit/use_cases/request_email_address_change.py
+++ b/arbeitszeit/use_cases/request_email_address_change.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from arbeitszeit.email import is_possibly_an_email_address
+from arbeitszeit.presenters import ChangeUserEmailAddressPresenter
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class RequestEmailAddressChangeUseCase:
+    database: DatabaseGateway
+    email_presenter: ChangeUserEmailAddressPresenter
+
+    def request_email_address_change(self, request: Request) -> Response:
+        if self._is_valid_request(request):
+            self.email_presenter.present_email_change_confirmation_message(
+                ChangeUserEmailAddressPresenter.Notification(
+                    old_email_address=request.current_email_address,
+                    new_email_address=request.new_email_address,
+                )
+            )
+            return Response(is_rejected=False)
+        return Response(is_rejected=True)
+
+    def _is_valid_request(self, request: Request) -> bool:
+        return (
+            is_possibly_an_email_address(request.new_email_address)
+            and bool(
+                self.database.get_email_addresses().with_address(
+                    request.current_email_address
+                )
+            )
+            and not self.database.get_email_addresses().with_address(
+                request.new_email_address
+            )
+        )
+
+
+@dataclass
+class Request:
+    current_email_address: str
+    new_email_address: str
+
+
+@dataclass
+class Response:
+    is_rejected: bool

--- a/tests/use_cases/change_user_email_address_presenter_mock.py
+++ b/tests/use_cases/change_user_email_address_presenter_mock.py
@@ -1,0 +1,20 @@
+from arbeitszeit.injector import singleton
+from arbeitszeit.presenters import ChangeUserEmailAddressPresenter as Interface
+
+
+@singleton
+class ChangeUserEmailAddressPresenterMock:
+    def __init__(self) -> None:
+        self._notifications: list[Interface.Notification] = list()
+
+    def present_email_change_confirmation_message(
+        self, notification: Interface.Notification
+    ) -> None:
+        self._notifications.append(notification)
+
+    def has_notifications_delivered(self) -> bool:
+        return bool(self._notifications)
+
+    def get_latest_notification_delivered(self) -> Interface.Notification:
+        assert self._notifications
+        return self._notifications[-1]

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -12,6 +12,7 @@ from arbeitszeit.injector import (
 from arbeitszeit.password_hasher import PasswordHasher
 from arbeitszeit.presenters import (
     AccountantInvitationPresenter,
+    ChangeUserEmailAddressPresenter,
     InviteWorkerPresenter,
     NotifyAccountantsAboutNewPlanPresenter,
 )
@@ -23,6 +24,9 @@ from tests.token import FakeTokenService
 from tests.work_invitation_presenter import InviteWorkerPresenterImpl
 
 from . import repositories
+from .change_user_email_address_presenter_mock import (
+    ChangeUserEmailAddressPresenterMock,
+)
 from .notify_accountant_about_new_plan_presenter import (
     NotifyAccountantsAboutNewPlanPresenterImpl,
 )
@@ -47,6 +51,10 @@ class InMemoryModule(Module):
         binder[InviteWorkerPresenter] = AliasProvider(InviteWorkerPresenterImpl)  # type: ignore
         binder[records.SocialAccounting] = CallableProvider(
             provide_social_accounting_instance
+        )
+        binder.bind(
+            ChangeUserEmailAddressPresenter,
+            to=AliasProvider(ChangeUserEmailAddressPresenterMock),
         )
         binder.bind(
             interfaces.DatabaseGateway,  # type: ignore

--- a/tests/use_cases/test_request_email_address_change.py
+++ b/tests/use_cases/test_request_email_address_change.py
@@ -1,0 +1,161 @@
+from parameterized import parameterized
+
+from arbeitszeit.use_cases import request_email_address_change as use_case
+
+from .base_test_case import BaseTestCase
+from .change_user_email_address_presenter_mock import (
+    ChangeUserEmailAddressPresenterMock,
+)
+
+
+class RequestEmailAddressChangeTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(use_case.RequestEmailAddressChangeUseCase)
+        self.presenter = self.injector.get(ChangeUserEmailAddressPresenterMock)
+
+    @parameterized.expand(
+        [
+            ("test@test.test", "new@test.test"),
+            ("a@b.c", "d@b.c"),
+        ]
+    )
+    def test_that_request_is_rejected_for_unknown_email_address(
+        self, current: str, new: str
+    ) -> None:
+        request = use_case.Request(
+            current_email_address=current,
+            new_email_address=new,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert response.is_rejected
+
+    def test_that_confirmed_members_requests_are_accepted(self) -> None:
+        member_email_address = "test@test.test"
+        new_email_address = "new@test.test"
+        self.member_generator.create_member(email=member_email_address, confirmed=True)
+        request = use_case.Request(
+            current_email_address=member_email_address,
+            new_email_address=new_email_address,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert not response.is_rejected
+
+    def test_that_confirmed_companies_requests_are_accepted(self) -> None:
+        company_email_address = "test@test.test"
+        new_email_address = "new@test.test"
+        self.company_generator.create_company(
+            email=company_email_address, confirmed=True
+        )
+        request = use_case.Request(
+            current_email_address=company_email_address,
+            new_email_address=new_email_address,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert not response.is_rejected
+
+    def test_that_accountants_requests_are_accepted(self) -> None:
+        accountant_email_address = "test@test.test"
+        new_email_address = "new@test.test"
+        self.accountant_generator.create_accountant(
+            email_address=accountant_email_address
+        )
+        request = use_case.Request(
+            current_email_address=accountant_email_address,
+            new_email_address=new_email_address,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert not response.is_rejected
+
+    def test_that_requests_are_rejected_if_new_email_address_is_already_taken_by_member(
+        self,
+    ) -> None:
+        old_email_address = "test@test.test"
+        new_email_address = "new@test.test"
+        self.member_generator.create_member(email=old_email_address)
+        self.member_generator.create_member(email=new_email_address)
+        request = use_case.Request(
+            current_email_address=old_email_address,
+            new_email_address=new_email_address,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert response.is_rejected
+
+    @parameterized.expand(
+        [
+            ("",),
+            ("word",),
+            ("a@",),
+            ("@b",),
+        ]
+    )
+    def test_that_email_addresses_that_are_definityly_not_valid_are_rejected_as_new_addresses(
+        self, invalid: str
+    ) -> None:
+        original_email_address = "test@test.test"
+        self.member_generator.create_member(email=original_email_address)
+        request = use_case.Request(
+            current_email_address=original_email_address,
+            new_email_address=invalid,
+        )
+        response = self.use_case.request_email_address_change(request)
+        assert response.is_rejected
+
+    def test_that_change_confirmation_was_presented_after_successful_request_of_member(
+        self,
+    ) -> None:
+        original_address = "test@test.test"
+        new_address = "new@test.test"
+        self.member_generator.create_member(email=original_address)
+        request = use_case.Request(
+            current_email_address=original_address,
+            new_email_address=new_address,
+        )
+        self.use_case.request_email_address_change(request)
+        assert self.presenter.has_notifications_delivered()
+
+    @parameterized.expand(
+        [
+            ("test@test.test",),
+            ("other@test.test",),
+        ]
+    )
+    def test_that_delivered_notification_contains_current_email_address_as_requested(
+        self, original_address: str
+    ) -> None:
+        self.member_generator.create_member(email=original_address)
+        new_address = "new@test.test"
+        request = use_case.Request(
+            current_email_address=original_address,
+            new_email_address=new_address,
+        )
+        self.use_case.request_email_address_change(request)
+        notification = self.presenter.get_latest_notification_delivered()
+        assert notification.old_email_address == original_address
+
+    @parameterized.expand(
+        [
+            ("test@test.test",),
+            ("other@test.test",),
+        ]
+    )
+    def test_that_delivered_notification_contains_new_email_address_as_requested(
+        self, new_address: str
+    ) -> None:
+        original_address = "origional@test.test"
+        self.member_generator.create_member(email=original_address)
+        request = use_case.Request(
+            current_email_address=original_address,
+            new_email_address=new_address,
+        )
+        self.use_case.request_email_address_change(request)
+        notification = self.presenter.get_latest_notification_delivered()
+        assert notification.new_email_address == new_address
+
+    def test_that_no_notifiation_is_delivered_if_email_address_is_unkown(self) -> None:
+        request = use_case.Request(
+            current_email_address="test@test.test",
+            new_email_address="new@test.test",
+        )
+        self.use_case.request_email_address_change(request)
+        assert not self.presenter.has_notifications_delivered()


### PR DESCRIPTION
The use case RequestEmailAddressChange implemented with this change should allow users to request changing their email address. The change request is only granted if the new email address is not already taken by another account in the system. The use case does deliberately not check for authorization since it is very likely that we want to enable admins to do this for other users in the future.  On success the use case will send a notification that the email address change is requested. The actual change must be implemented in a separate use case.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)