### PR TITLE
Implement RequestEmailAddressChangeController for the web

### DIFF
--- a/arbeitszeit_web/forms.py
+++ b/arbeitszeit_web/forms.py
@@ -4,6 +4,12 @@ from typing import Protocol
 from arbeitszeit_web.fields import FormField
 
 
+class RequestEmailAddressChangeForm(Protocol):
+    @property
+    def new_email_field(self) -> FormField[str]:
+        ...
+
+
 class LoginMemberForm(Protocol):
     def email_field(self) -> FormField[str]:
         ...

--- a/arbeitszeit_web/www/controllers/request_email_address_change_controller.py
+++ b/arbeitszeit_web/www/controllers/request_email_address_change_controller.py
@@ -1,0 +1,44 @@
+from dataclasses import dataclass
+
+from arbeitszeit.repositories import DatabaseGateway
+from arbeitszeit.use_cases import request_email_address_change as use_case
+from arbeitszeit_web.forms import RequestEmailAddressChangeForm
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class RequestEmailAddressChangeController:
+    database: DatabaseGateway
+    session: Session
+
+    def process_email_address_change_request(
+        self, form: RequestEmailAddressChangeForm
+    ) -> use_case.Request:
+        current_user_id = self.session.get_current_user()
+        assert current_user_id
+        if self.session.get_user_role() == UserRole.member:
+            email_address = (
+                self.database.get_email_addresses()
+                .that_belong_to_member(current_user_id)
+                .first()
+            )
+        elif self.session.get_user_role() == UserRole.company:
+            email_address = (
+                self.database.get_email_addresses()
+                .that_belong_to_company(current_user_id)
+                .first()
+            )
+        elif self.session.get_user_role() == UserRole.accountant:
+            query = (
+                self.database.get_accountants()
+                .with_id(current_user_id)
+                .joined_with_email_address()
+                .first()
+            )
+            assert query
+            email_address = query[1]
+        assert email_address
+        return use_case.Request(
+            current_email_address=email_address.address,
+            new_email_address=form.new_email_field.get_value(),
+        )

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -5,6 +5,8 @@ from decimal import Decimal
 from typing import Generic, List, Optional, TypeVar
 from uuid import uuid4
 
+from typing_extensions import Self
+
 T = TypeVar("T")
 
 
@@ -171,3 +173,12 @@ class RegisterFormImpl:
             + self.password_field.errors
             + self.name_field.errors
         )
+
+
+@dataclass
+class RequestEmailAddressChangeFormImpl:
+    new_email_field: FormFieldImpl[str]
+
+    @classmethod
+    def from_values(cls, new_email_address: str) -> Self:
+        return cls(new_email_field=FormFieldImpl(value=new_email_address))

--- a/tests/www/base_test_case.py
+++ b/tests/www/base_test_case.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generic, Type, TypeVar
 from unittest import TestCase
 
+from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
 from tests.session import FakeSession
 
 from .dependency_injection import get_dependency_injector
@@ -48,4 +49,7 @@ class BaseTestCase(TestCase):
 
     # It would be nice to have the following list sorted
     # alphabetically
+    accountant_generator = _lazy_property(AccountantGenerator)
+    company_generator = _lazy_property(CompanyGenerator)
+    member_generator = _lazy_property(MemberGenerator)
     session = _lazy_property(FakeSession)

--- a/tests/www/controllers/test_request_email_address_change_controller.py
+++ b/tests/www/controllers/test_request_email_address_change_controller.py
@@ -1,0 +1,108 @@
+from parameterized import parameterized
+
+from arbeitszeit_web.www.controllers.request_email_address_change_controller import (
+    RequestEmailAddressChangeController,
+)
+from tests.forms import RequestEmailAddressChangeFormImpl as Form
+
+from ..base_test_case import BaseTestCase
+
+
+class RequestEmailAddressChangeControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(RequestEmailAddressChangeController)
+
+    @parameterized.expand(
+        [
+            ("old@test.test", "new@test.test"),
+            ("member@test.test", "new@test.test"),
+            ("member@test.test", "new2@test.test"),
+        ]
+    )
+    def test_that_for_authenticated_member_use_the_current_email_address_and_supplied_new_email_address_in_request(
+        self, current_address: str, new_address: str
+    ) -> None:
+        member = self.member_generator.create_member(email=current_address)
+        self.session.login_member(member=member)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address
+
+    def test_that_for_authenticated_member_use_the_current_email_address_and_supplied_new_email_address_in_request_even_as_another_member_registered_before_them(
+        self,
+    ) -> None:
+        current_address = "member@test.test"
+        new_address = "new@test.test"
+        self.member_generator.create_member(email="other@test.test")
+        member = self.member_generator.create_member(email=current_address)
+        self.session.login_member(member=member)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address
+
+    @parameterized.expand(
+        [
+            ("old@test.test", "new@test.test"),
+            ("company@test.test", "new@test.test"),
+            ("company@test.test", "new2@test.test"),
+        ]
+    )
+    def test_that_for_authenticated_company_use_the_current_email_address_and_supplied_new_email_address_in_request(
+        self, current_address: str, new_address: str
+    ) -> None:
+        company = self.company_generator.create_company(email=current_address)
+        self.session.login_company(company=company)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address
+
+    def test_that_for_authenticated_company_use_the_current_email_address_and_supplied_new_email_address_in_request_even_as_another_company_registered_before_them(
+        self,
+    ) -> None:
+        current_address = "company@test.test"
+        new_address = "new@test.test"
+        self.company_generator.create_company(email="other@test.test")
+        company = self.company_generator.create_company(email=current_address)
+        self.session.login_company(company=company)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address
+
+    @parameterized.expand(
+        [
+            ("old@test.test", "new@test.test"),
+            ("accountant@test.test", "new@test.test"),
+            ("accountant@test.test", "new2@test.test"),
+        ]
+    )
+    def test_that_for_authenticated_accountant_use_the_current_email_address_and_supplied_new_email_address_in_request(
+        self, current_address: str, new_address: str
+    ) -> None:
+        accountant = self.accountant_generator.create_accountant(
+            email_address=current_address
+        )
+        self.session.login_accountant(accountant=accountant)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address
+
+    def test_that_for_authenticated_accountant_use_the_current_email_address_and_supplied_new_email_address_in_request_even_as_another_accountant_registered_before_them(
+        self,
+    ) -> None:
+        current_address = "accountant@test.test"
+        new_address = "new@test.test"
+        self.accountant_generator.create_accountant(email_address="other@test.test")
+        accountant = self.accountant_generator.create_accountant(
+            email_address=current_address
+        )
+        self.session.login_accountant(accountant=accountant)
+        form = Form.from_values(new_email_address=new_address)
+        use_case_request = self.controller.process_email_address_change_request(form)
+        assert use_case_request.current_email_address == current_address
+        assert use_case_request.new_email_address == new_address

--- a/tests/www/presenters/test_company_consumptions_presenter.py
+++ b/tests/www/presenters/test_company_consumptions_presenter.py
@@ -11,7 +11,7 @@ from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
     CompanyConsumptionsPresenter,
     ViewModel,
 )
-from tests.data_generators import CompanyGenerator, ConsumptionGenerator
+from tests.data_generators import ConsumptionGenerator
 from tests.datetime_service import FakeDatetimeService
 from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
@@ -22,7 +22,6 @@ class TestPresenter(BaseTestCase):
         super().setUp()
         self.query_consumptions = self.injector.get(QueryCompanyConsumptions)
         self.consumption_generator = self.injector.get(ConsumptionGenerator)
-        self.company_generator = self.injector.get(CompanyGenerator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(CompanyConsumptionsPresenter)

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -11,7 +11,7 @@ from arbeitszeit.use_cases.show_my_plans import (
 )
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPresenter
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.data_generators import CooperationGenerator, PlanGenerator
 from tests.datetime_service import FakeDatetimeService
 from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
@@ -38,7 +38,6 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.notifier = self.injector.get(NotifierTestImpl)
         self.session.login_company(uuid4())
         self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
-        self.company_generator = self.injector.get(CompanyGenerator)
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
 
     def test_show_correct_notification_when_user_has_no_plans(self) -> None:


### PR DESCRIPTION
The implemented controller is intended for taking a web request from a user and constructing the appropriate use case request for the RequestEmailAddressChangeUseCase from it. It does so by taking the user id and role and retrieving their email address from the database. The new email address is parsed from a form field passed into the controller.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf