### PR TITLE
Disable mypy error about using abstract types

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -90,21 +90,21 @@ from arbeitszeit_web.www.presenters.registration_email_presenter import (
 class AccountantModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[TemplateIndex] = AliasProvider(AccountantTemplateIndex)  # type: ignore
+        binder[TemplateIndex] = AliasProvider(AccountantTemplateIndex)
 
 
 class MemberModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[TemplateIndex] = AliasProvider(MemberTemplateIndex)  # type: ignore
+        binder[TemplateIndex] = AliasProvider(MemberTemplateIndex)
 
 
 class CompanyModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[RenewPlanUrlIndex] = AliasProvider(CompanyUrlIndex)  # type: ignore
-        binder[HidePlanUrlIndex] = AliasProvider(CompanyUrlIndex)  # type: ignore
-        binder[TemplateIndex] = AliasProvider(CompanyTemplateIndex)  # type: ignore
+        binder[RenewPlanUrlIndex] = AliasProvider(CompanyUrlIndex)
+        binder[HidePlanUrlIndex] = AliasProvider(CompanyUrlIndex)
+        binder[TemplateIndex] = AliasProvider(CompanyTemplateIndex)
 
 
 class FlaskModule(Module):
@@ -115,59 +115,61 @@ class FlaskModule(Module):
             to=CallableProvider(get_social_accounting),
         )
         binder.bind(
-            DatetimeService,  # type: ignore
+            DatetimeService,
             to=AliasProvider(RealtimeDatetimeService),
         )
         binder.bind(
             SQLAlchemy,
             to=CallableProvider(self.provide_sqlalchemy, is_singleton=True),
         )
-        binder.bind(UserAddressBook, to=AliasProvider(UserAddressBookImpl))  # type: ignore
-        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
-        binder[InviteWorkerPresenter] = AliasProvider(InviteWorkerPresenterImpl)  # type: ignore
-        binder[TextRenderer] = AliasProvider(TextRendererImpl)  # type: ignore
-        binder[Request] = AliasProvider(FlaskRequest)  # type: ignore
-        binder[UrlIndex] = AliasProvider(GeneralUrlIndex)  # type: ignore
-        binder[interfaces.LanguageRepository] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
-        binder[LanguageService] = AliasProvider(LanguageRepositoryImpl)  # type: ignore
-        binder[EmailConfiguration] = AliasProvider(FlaskEmailConfiguration)  # type: ignore
+        binder.bind(UserAddressBook, to=AliasProvider(UserAddressBookImpl))
+        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(
+            NotifyAccountantsAboutNewPlanPresenterImpl
+        )
+        binder[InviteWorkerPresenter] = AliasProvider(InviteWorkerPresenterImpl)
+        binder[TextRenderer] = AliasProvider(TextRendererImpl)
+        binder[Request] = AliasProvider(FlaskRequest)
+        binder[UrlIndex] = AliasProvider(GeneralUrlIndex)
+        binder[interfaces.LanguageRepository] = AliasProvider(LanguageRepositoryImpl)
+        binder[LanguageService] = AliasProvider(LanguageRepositoryImpl)
+        binder[EmailConfiguration] = AliasProvider(FlaskEmailConfiguration)
         binder.bind(
-            interfaces.DatabaseGateway,  # type: ignore
+            interfaces.DatabaseGateway,
             to=AliasProvider(DatabaseGatewayImpl),
         )
-        binder[TemplateRenderer] = AliasProvider(FlaskTemplateRenderer)  # type: ignore
-        binder[Session] = AliasProvider(FlaskSession)  # type: ignore
-        binder[Notifier] = AliasProvider(FlaskFlashNotifier)  # type: ignore
-        binder[MailService] = CallableProvider(get_mail_service)  # type: ignore
-        binder[Translator] = AliasProvider(FlaskTranslator)  # type: ignore
-        binder[Plotter] = AliasProvider(FlaskPlotter)  # type: ignore
-        binder[Colors] = AliasProvider(FlaskColors)  # type: ignore
-        binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)  # type: ignore
-        binder[LanguageChangerUrlIndex] = AliasProvider(GeneralUrlIndex)  # type: ignore
-        binder[CompanyRegistrationMessagePresenter] = AliasProvider(  # type: ignore
+        binder[TemplateRenderer] = AliasProvider(FlaskTemplateRenderer)
+        binder[Session] = AliasProvider(FlaskSession)
+        binder[Notifier] = AliasProvider(FlaskFlashNotifier)
+        binder[MailService] = CallableProvider(get_mail_service)
+        binder[Translator] = AliasProvider(FlaskTranslator)
+        binder[Plotter] = AliasProvider(FlaskPlotter)
+        binder[Colors] = AliasProvider(FlaskColors)
+        binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)
+        binder[LanguageChangerUrlIndex] = AliasProvider(GeneralUrlIndex)
+        binder[CompanyRegistrationMessagePresenter] = AliasProvider(
             RegistrationEmailPresenter
         )
-        binder[MemberRegistrationMessagePresenter] = AliasProvider(  # type: ignore
+        binder[MemberRegistrationMessagePresenter] = AliasProvider(
             RegistrationEmailPresenter
         )
         binder.bind(
-            AccountantInvitationPresenter,  # type: ignore
+            AccountantInvitationPresenter,
             to=AliasProvider(AccountantInvitationEmailPresenter),
         )
         binder.bind(
-            AccountantInvitationEmailView,  # type: ignore
+            AccountantInvitationEmailView,
             to=AliasProvider(AccountantInvitationEmailViewImpl),
         )
         binder.bind(
-            AccountantInvitationUrlIndex,  # type: ignore
+            AccountantInvitationUrlIndex,
             to=AliasProvider(GeneralUrlIndex),
         )
         binder.bind(
-            PasswordHasher,  # type: ignore
+            PasswordHasher,
             to=AliasProvider(PasswordHasherImpl),
         )
         binder.bind(
-            TokenService,  # type: ignore
+            TokenService,
             to=AliasProvider(FlaskTokenService),
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ mypy_path = "type_stubs"
 exclude = '''
     migrations/
 '''
+disable_error_code = "type-abstract"
 
 [[tool.mypy.overrides]]
 module = [

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -27,22 +27,18 @@ from tests.www.presenters.test_colors import ColorsTestImpl
 class TestingModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[CompanyRegistrationMessagePresenter] = AliasProvider(  # type: ignore
+        binder[CompanyRegistrationMessagePresenter] = AliasProvider(
             TokenDeliveryService
         )
-        binder[MemberRegistrationMessagePresenter] = AliasProvider(  # type: ignore
-            TokenDeliveryService
-        )
-        binder[TextRenderer] = AliasProvider(TextRendererImpl)  # type: ignore
-        binder[Colors] = AliasProvider(ColorsTestImpl)  # type: ignore
-        binder[Plotter] = AliasProvider(FakePlotter)  # type: ignore
-        binder[ControlThresholds] = AliasProvider(  # type: ignore
-            ControlThresholdsTestImpl
-        )
-        binder[Translator] = AliasProvider(FakeTranslator)  # type: ignore
-        binder[AccountantInvitationPresenter] = AliasProvider(  # type: ignore
+        binder[MemberRegistrationMessagePresenter] = AliasProvider(TokenDeliveryService)
+        binder[TextRenderer] = AliasProvider(TextRendererImpl)
+        binder[Colors] = AliasProvider(ColorsTestImpl)
+        binder[Plotter] = AliasProvider(FakePlotter)
+        binder[ControlThresholds] = AliasProvider(ControlThresholdsTestImpl)
+        binder[Translator] = AliasProvider(FakeTranslator)
+        binder[AccountantInvitationPresenter] = AliasProvider(
             AccountantInvitationPresenterTestImpl
         )
-        binder[DatetimeService] = AliasProvider(FakeDatetimeService)  # type: ignore
-        binder[UserAddressBook] = AliasProvider(FakeAddressBook)  # type: ignore
-        binder[Request] = AliasProvider(FakeRequest)  # type: ignore
+        binder[DatetimeService] = AliasProvider(FakeDatetimeService)
+        binder[UserAddressBook] = AliasProvider(FakeAddressBook)
+        binder[Request] = AliasProvider(FakeRequest)

--- a/tests/use_cases/dependency_injection.py
+++ b/tests/use_cases/dependency_injection.py
@@ -41,14 +41,16 @@ def provide_social_accounting_instance(
 class InMemoryModule(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(NotifyAccountantsAboutNewPlanPresenterImpl)  # type: ignore
-        binder[interfaces.LanguageRepository] = AliasProvider(  # type: ignore
+        binder[NotifyAccountantsAboutNewPlanPresenter] = AliasProvider(
+            NotifyAccountantsAboutNewPlanPresenterImpl
+        )
+        binder[interfaces.LanguageRepository] = AliasProvider(
             repositories.FakeLanguageRepository
         )
-        binder[AccountantInvitationPresenter] = AliasProvider(  # type: ignore
+        binder[AccountantInvitationPresenter] = AliasProvider(
             AccountantInvitationPresenterTestImpl
         )
-        binder[InviteWorkerPresenter] = AliasProvider(InviteWorkerPresenterImpl)  # type: ignore
+        binder[InviteWorkerPresenter] = AliasProvider(InviteWorkerPresenterImpl)
         binder[records.SocialAccounting] = CallableProvider(
             provide_social_accounting_instance
         )
@@ -57,15 +59,15 @@ class InMemoryModule(Module):
             to=AliasProvider(ChangeUserEmailAddressPresenterMock),
         )
         binder.bind(
-            interfaces.DatabaseGateway,  # type: ignore
+            interfaces.DatabaseGateway,
             to=AliasProvider(repositories.MockDatabase),
         )
         binder.bind(
-            PasswordHasher,  # type: ignore
+            PasswordHasher,
             to=AliasProvider(PasswordHasherImpl),
         )
         binder.bind(
-            TokenService,  # type: ignore
+            TokenService,
             to=AliasProvider(FakeTokenService),
         )
 

--- a/tests/www/dependency_injection.py
+++ b/tests/www/dependency_injection.py
@@ -37,20 +37,22 @@ from .presenters.url_index import (
 class WwwTestsInjector(Module):
     def configure(self, binder: Binder) -> None:
         super().configure(binder)
-        binder[AccountantInvitationEmailView] = AliasProvider(  # type: ignore
+        binder[AccountantInvitationEmailView] = AliasProvider(
             AccountantInvitationEmailViewImpl
         )
-        binder[EmailConfiguration] = AliasProvider(FakeEmailConfiguration)  # type: ignore
-        binder[AccountantInvitationUrlIndex] = AliasProvider(AccountantInvitationUrlIndexImpl)  # type: ignore
-        binder[Notifier] = AliasProvider(NotifierTestImpl)  # type: ignore
+        binder[EmailConfiguration] = AliasProvider(FakeEmailConfiguration)
+        binder[AccountantInvitationUrlIndex] = AliasProvider(
+            AccountantInvitationUrlIndexImpl
+        )
+        binder[Notifier] = AliasProvider(NotifierTestImpl)
         binder[UrlIndex] = AliasProvider(UrlIndexTestImpl)
-        binder[Session] = AliasProvider(FakeSession)  # type: ignore
-        binder[Request] = AliasProvider(FakeRequest)  # type: ignore
-        binder[LanguageChangerUrlIndex] = AliasProvider(LanguageChangerUrlIndexImpl)  # type: ignore
-        binder[LanguageService] = AliasProvider(FakeLanguageService)  # type: ignore
-        binder[MailService] = AliasProvider(FakeEmailSender)  # type: ignore
-        binder[RenewPlanUrlIndex] = AliasProvider(RenewPlanUrlIndexTestImpl)  # type: ignore
-        binder[HidePlanUrlIndex] = AliasProvider(HidePlanUrlIndexTestImpl)  # type: ignore
+        binder[Session] = AliasProvider(FakeSession)
+        binder[Request] = AliasProvider(FakeRequest)
+        binder[LanguageChangerUrlIndex] = AliasProvider(LanguageChangerUrlIndexImpl)
+        binder[LanguageService] = AliasProvider(FakeLanguageService)
+        binder[MailService] = AliasProvider(FakeEmailSender)
+        binder[RenewPlanUrlIndex] = AliasProvider(RenewPlanUrlIndexTestImpl)
+        binder[HidePlanUrlIndex] = AliasProvider(HidePlanUrlIndexTestImpl)
 
 
 def get_dependency_injector() -> Injector:


### PR DESCRIPTION
Before this change it was not really possible to use our dependency injection system in conjuntion with mypys type checking. The main reason for this was that mypy would complain if we specified abstract types as concrete values. Here is an example:

```python
class Interface(Protocol):
    def method(self) -> None:
        ...

instance = injector.get(Interface)  # mypy considers this illegal
```

This change disables these kinds of errors.  The main benefit of this is that we can delete lots of comments that would disable mypy because of this error.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf