### PR TITLE
Changes to type annotations + imports in repositories.py

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -10,17 +10,16 @@ from typing_extensions import Self
 from arbeitszeit import records
 
 T = TypeVar("T", covariant=True)
-QueryResultT = TypeVar("QueryResultT", bound="QueryResult")
 
 
 class QueryResult(Protocol, Generic[T]):
     def __iter__(self) -> Iterator[T]:
         ...
 
-    def limit(self: QueryResultT, n: int) -> QueryResultT:
+    def limit(self, n: int) -> Self:
         ...
 
-    def offset(self: QueryResultT, n: int) -> QueryResultT:
+    def offset(self, n: int) -> Self:
         ...
 
     def first(self) -> Optional[T]:
@@ -38,22 +37,22 @@ class DatabaseUpdate(Protocol):
 
 
 class PlanResult(QueryResult[records.Plan], Protocol):
-    def ordered_by_creation_date(self, ascending: bool = ...) -> PlanResult:
+    def ordered_by_creation_date(self, ascending: bool = ...) -> Self:
         ...
 
-    def ordered_by_activation_date(self, ascending: bool = ...) -> PlanResult:
+    def ordered_by_activation_date(self, ascending: bool = ...) -> Self:
         ...
 
-    def ordered_by_planner_name(self, ascending: bool = ...) -> PlanResult:
+    def ordered_by_planner_name(self, ascending: bool = ...) -> Self:
         ...
 
-    def with_id_containing(self, query: str) -> PlanResult:
+    def with_id_containing(self, query: str) -> Self:
         ...
 
-    def with_product_name_containing(self, query: str) -> PlanResult:
+    def with_product_name_containing(self, query: str) -> Self:
         ...
 
-    def that_are_approved(self) -> PlanResult:
+    def that_are_approved(self) -> Self:
         ...
 
     def that_were_activated_before(self, timestamp: datetime) -> Self:
@@ -69,38 +68,38 @@ class PlanResult(QueryResult[records.Plan], Protocol):
     def that_are_expired_as_of(self, timestamp: datetime) -> Self:
         """Plans that will be expired by a given timestamp."""
 
-    def that_are_productive(self) -> PlanResult:
+    def that_are_productive(self) -> Self:
         ...
 
-    def that_are_public(self) -> PlanResult:
+    def that_are_public(self) -> Self:
         ...
 
-    def that_are_cooperating(self) -> PlanResult:
+    def that_are_cooperating(self) -> Self:
         ...
 
-    def planned_by(self, *company: UUID) -> PlanResult:
+    def planned_by(self, *company: UUID) -> Self:
         ...
 
-    def with_id(self, *id_: UUID) -> PlanResult:
+    def with_id(self, *id_: UUID) -> Self:
         ...
 
-    def without_completed_review(self) -> PlanResult:
+    def without_completed_review(self) -> Self:
         ...
 
     def with_open_cooperation_request(
         self, *, cooperation: Optional[UUID] = ...
-    ) -> PlanResult:
+    ) -> Self:
         ...
 
-    def that_are_in_same_cooperation_as(self, plan: UUID) -> PlanResult:
+    def that_are_in_same_cooperation_as(self, plan: UUID) -> Self:
         ...
 
-    def that_are_part_of_cooperation(self, *cooperation: UUID) -> PlanResult:
+    def that_are_part_of_cooperation(self, *cooperation: UUID) -> Self:
         """If no cooperations are specified, then all the repository
         should return plans that are part of any cooperation.
         """
 
-    def that_request_cooperation_with_coordinator(self, *company: UUID) -> PlanResult:
+    def that_request_cooperation_with_coordinator(self, *company: UUID) -> Self:
         """If no companies are specified then the repository should
         return all plans that request cooperation with any
         coordinator.
@@ -138,14 +137,14 @@ class PlanUpdate(DatabaseUpdate, Protocol):
     the DB and execute them all in one.
     """
 
-    def set_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_cooperation(self, cooperation: Optional[UUID]) -> Self:
         """Set the associated cooperation of all matching plans to the
         one specified via the cooperation argument. Specifying `None`
         will unset the cooperation field. The return value counts all
         plans that were updated through this method.
         """
 
-    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> Self:
         """Set the `requested_cooperation` field of all matching plans
         to the specified value.  A value `None` means that these plans
         are marked as not requesting membership in any
@@ -155,10 +154,10 @@ class PlanUpdate(DatabaseUpdate, Protocol):
 
     def set_activation_timestamp(
         self, activation_timestamp: Optional[datetime]
-    ) -> PlanUpdate:
+    ) -> Self:
         """Set the `activation_date` field of all selected plans."""
 
-    def set_approval_date(self, approval_date: Optional[datetime]) -> PlanUpdate:
+    def set_approval_date(self, approval_date: Optional[datetime]) -> Self:
         """Set the approval date of all matching plans. The return
         value counts all the plans that were changed by this methods.
         """
@@ -230,13 +229,13 @@ class CooperationResult(QueryResult[records.Cooperation], Protocol):
 
 
 class MemberResult(QueryResult[records.Member], Protocol):
-    def working_at_company(self, company: UUID) -> MemberResult:
+    def working_at_company(self, company: UUID) -> Self:
         ...
 
-    def with_id(self, id_: UUID) -> MemberResult:
+    def with_id(self, id_: UUID) -> Self:
         ...
 
-    def with_email_address(self, email: str) -> MemberResult:
+    def with_email_address(self, email: str) -> Self:
         ...
 
     def joined_with_email_address(
@@ -246,12 +245,10 @@ class MemberResult(QueryResult[records.Member], Protocol):
 
 
 class PrivateConsumptionResult(QueryResult[records.PrivateConsumption], Protocol):
-    def ordered_by_creation_date(
-        self, *, ascending: bool = ...
-    ) -> PrivateConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = ...) -> Self:
         ...
 
-    def where_consumer_is_member(self, member: UUID) -> PrivateConsumptionResult:
+    def where_consumer_is_member(self, member: UUID) -> Self:
         ...
 
     def joined_with_transactions_and_plan(
@@ -263,12 +260,10 @@ class PrivateConsumptionResult(QueryResult[records.PrivateConsumption], Protocol
 
 
 class ProductiveConsumptionResult(QueryResult[records.ProductiveConsumption], Protocol):
-    def ordered_by_creation_date(
-        self, *, ascending: bool = ...
-    ) -> ProductiveConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = ...) -> Self:
         ...
 
-    def where_consumer_is_company(self, company: UUID) -> ProductiveConsumptionResult:
+    def where_consumer_is_company(self, company: UUID) -> Self:
         ...
 
     def joined_with_transactions_and_plan(
@@ -292,13 +287,13 @@ class ProductiveConsumptionResult(QueryResult[records.ProductiveConsumption], Pr
 
 
 class CompanyResult(QueryResult[records.Company], Protocol):
-    def with_id(self, id_: UUID) -> CompanyResult:
+    def with_id(self, id_: UUID) -> Self:
         ...
 
-    def with_email_address(self, email: str) -> CompanyResult:
+    def with_email_address(self, email: str) -> Self:
         ...
 
-    def that_are_workplace_of_member(self, member: UUID) -> CompanyResult:
+    def that_are_workplace_of_member(self, member: UUID) -> Self:
         ...
 
     def that_is_coordinating_cooperation(self, cooperation: UUID) -> Self:
@@ -307,10 +302,10 @@ class CompanyResult(QueryResult[records.Company], Protocol):
     def add_worker(self, member: UUID) -> int:
         ...
 
-    def with_name_containing(self, query: str) -> CompanyResult:
+    def with_name_containing(self, query: str) -> Self:
         ...
 
-    def with_email_containing(self, query: str) -> CompanyResult:
+    def with_email_containing(self, query: str) -> Self:
         ...
 
     def joined_with_email_address(
@@ -333,19 +328,19 @@ class AccountantResult(QueryResult[records.Accountant], Protocol):
 
 
 class TransactionResult(QueryResult[records.Transaction], Protocol):
-    def where_account_is_sender_or_receiver(self, *account: UUID) -> TransactionResult:
+    def where_account_is_sender_or_receiver(self, *account: UUID) -> Self:
         ...
 
-    def where_account_is_sender(self, *account: UUID) -> TransactionResult:
+    def where_account_is_sender(self, *account: UUID) -> Self:
         ...
 
-    def where_account_is_receiver(self, *account: UUID) -> TransactionResult:
+    def where_account_is_receiver(self, *account: UUID) -> Self:
         ...
 
-    def ordered_by_transaction_date(self, descending: bool = ...) -> TransactionResult:
+    def ordered_by_transaction_date(self, descending: bool = ...) -> Self:
         ...
 
-    def where_sender_is_social_accounting(self) -> TransactionResult:
+    def where_sender_is_social_accounting(self) -> Self:
         ...
 
     def that_were_a_sale_for_plan(self, *plan: UUID) -> Self:
@@ -372,7 +367,7 @@ class TransactionResult(QueryResult[records.Transaction], Protocol):
 
 
 class AccountResult(QueryResult[records.Account], Protocol):
-    def with_id(self, *id_: UUID) -> AccountResult:
+    def with_id(self, *id_: UUID) -> Self:
         ...
 
     def owned_by_member(self, *member: UUID) -> Self:

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -35,7 +35,6 @@ from arbeitszeit_flask.database.models import (
 )
 
 T = TypeVar("T", covariant=True)
-FlaskQueryResultT = TypeVar("FlaskQueryResultT", bound="FlaskQueryResult")
 
 
 class FlaskQueryResult(Generic[T]):
@@ -44,10 +43,10 @@ class FlaskQueryResult(Generic[T]):
         self.mapper = mapper
         self.db = db
 
-    def limit(self: FlaskQueryResultT, n: int) -> FlaskQueryResultT:
+    def limit(self, n: int) -> Self:
         return type(self)(query=self.query.limit(n), mapper=self.mapper, db=self.db)
 
-    def offset(self: FlaskQueryResultT, n: int) -> FlaskQueryResultT:
+    def offset(self, n: int) -> Self:
         return type(self)(query=self.query.offset(n), mapper=self.mapper, db=self.db)
 
     def first(self) -> Optional[T]:
@@ -69,19 +68,19 @@ class FlaskQueryResult(Generic[T]):
 
 
 class PlanQueryResult(FlaskQueryResult[records.Plan]):
-    def ordered_by_creation_date(self, ascending: bool = True) -> PlanQueryResult:
+    def ordered_by_creation_date(self, ascending: bool = True) -> Self:
         ordering = models.Plan.plan_creation_date
         if not ascending:
             ordering = ordering.desc()
         return self._with_modified_query(lambda query: query.order_by(ordering))
 
-    def ordered_by_activation_date(self, ascending: bool = True) -> PlanQueryResult:
+    def ordered_by_activation_date(self, ascending: bool = True) -> Self:
         ordering = models.Plan.activation_date
         if not ascending:
             ordering = ordering.desc()
         return self._with_modified_query(lambda query: query.order_by(ordering))
 
-    def ordered_by_planner_name(self, ascending: bool = True) -> PlanQueryResult:
+    def ordered_by_planner_name(self, ascending: bool = True) -> Self:
         ordering = models.Company.name
         if not ascending:
             ordering = ordering.desc()
@@ -89,17 +88,17 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
             lambda query: self.query.join(models.Company).order_by(func.lower(ordering))
         )
 
-    def with_id_containing(self, query: str) -> PlanQueryResult:
+    def with_id_containing(self, query: str) -> Self:
         return self._with_modified_query(
             lambda db_query: db_query.filter(models.Plan.id.contains(query))
         )
 
-    def with_product_name_containing(self, query: str) -> PlanQueryResult:
+    def with_product_name_containing(self, query: str) -> Self:
         return self._with_modified_query(
             lambda db_query: db_query.filter(models.Plan.prd_name.ilike(f"%{query}%"))
         )
 
-    def that_are_approved(self) -> PlanQueryResult:
+    def that_are_approved(self) -> Self:
         return self._with_modified_query(
             lambda query: self.query.join(models.PlanReview).filter(
                 models.PlanReview.approval_date != None
@@ -129,34 +128,34 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
             lambda query: query.filter(expiration_date <= timestamp)
         )
 
-    def that_are_productive(self) -> PlanQueryResult:
+    def that_are_productive(self) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Plan.is_public_service == False)
         )
 
-    def that_are_public(self) -> PlanQueryResult:
+    def that_are_public(self) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Plan.is_public_service == True)
         )
 
-    def that_are_cooperating(self) -> PlanQueryResult:
+    def that_are_cooperating(self) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Plan.cooperation != None)
         )
 
-    def planned_by(self, *company: UUID) -> PlanQueryResult:
+    def planned_by(self, *company: UUID) -> Self:
         companies = list(map(str, company))
         return self._with_modified_query(
             lambda query: query.filter(models.Plan.planner.in_(companies))
         )
 
-    def with_id(self, *id_: UUID) -> PlanQueryResult:
+    def with_id(self, *id_: UUID) -> Self:
         ids = list(map(str, id_))
         return self._with_modified_query(
             lambda query: query.filter(models.Plan.id.in_(ids))
         )
 
-    def without_completed_review(self) -> PlanQueryResult:
+    def without_completed_review(self) -> Self:
         return self._with_modified_query(
             lambda query: self.query.join(models.PlanReview).filter(
                 models.PlanReview.approval_date == None
@@ -165,7 +164,7 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
 
     def with_open_cooperation_request(
         self, *, cooperation: Optional[UUID] = None
-    ) -> PlanQueryResult:
+    ) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(
                 models.Plan.requested_cooperation == str(cooperation)
@@ -174,7 +173,7 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
             )
         )
 
-    def that_are_in_same_cooperation_as(self, plan: UUID) -> PlanQueryResult:
+    def that_are_in_same_cooperation_as(self, plan: UUID) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(
                 or_(
@@ -191,7 +190,7 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
             )
         )
 
-    def that_are_part_of_cooperation(self, *cooperation: UUID) -> PlanQueryResult:
+    def that_are_part_of_cooperation(self, *cooperation: UUID) -> Self:
         cooperations = list(map(str, cooperation))
         if not cooperation:
             return self._with_modified_query(
@@ -202,9 +201,7 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
                 lambda query: query.filter(models.Plan.cooperation.in_(cooperations))
             )
 
-    def that_request_cooperation_with_coordinator(
-        self, *company: UUID
-    ) -> PlanQueryResult:
+    def that_request_cooperation_with_coordinator(self, *company: UUID) -> Self:
         companies = list(map(str, company))
 
         cooperation = aliased(models.Cooperation)
@@ -399,7 +396,7 @@ class PlanUpdate:
             row_count = max(row_count, result.rowcount)  # type: ignore
         return row_count
 
-    def set_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_cooperation(self, cooperation: Optional[UUID]) -> Self:
         return replace(
             self,
             plan_update_values=dict(
@@ -408,7 +405,7 @@ class PlanUpdate:
             ),
         )
 
-    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> Self:
         return replace(
             self,
             plan_update_values=dict(
@@ -417,7 +414,7 @@ class PlanUpdate:
             ),
         )
 
-    def set_approval_date(self, approval_date: Optional[datetime]) -> PlanUpdate:
+    def set_approval_date(self, approval_date: Optional[datetime]) -> Self:
         return replace(
             self,
             review_update_values=dict(
@@ -427,7 +424,7 @@ class PlanUpdate:
 
     def set_activation_timestamp(
         self, activation_timestamp: Optional[datetime]
-    ) -> PlanUpdate:
+    ) -> Self:
         return replace(
             self,
             plan_update_values=dict(
@@ -528,17 +525,17 @@ class PlanDraftUpdate:
 
 
 class MemberQueryResult(FlaskQueryResult[records.Member]):
-    def working_at_company(self, company: UUID) -> MemberQueryResult:
+    def working_at_company(self, company: UUID) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Member.workplaces.any(id=str(company)))
         )
 
-    def with_id(self, member: UUID) -> MemberQueryResult:
+    def with_id(self, member: UUID) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Member.id == str(member))
         )
 
-    def with_email_address(self, email: str) -> MemberQueryResult:
+    def with_email_address(self, email: str) -> Self:
         user = aliased(models.User)
         return self._with_modified_query(
             lambda query: query.join(user).filter(
@@ -568,19 +565,19 @@ class MemberQueryResult(FlaskQueryResult[records.Member]):
 
 
 class CompanyQueryResult(FlaskQueryResult[records.Company]):
-    def with_id(self, id_: UUID) -> CompanyQueryResult:
+    def with_id(self, id_: UUID) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(models.Company.id == str(id_))
         )
 
-    def with_email_address(self, email: str) -> CompanyQueryResult:
+    def with_email_address(self, email: str) -> Self:
         return self._with_modified_query(
             lambda query: query.join(models.User).filter(
                 func.lower(models.User.email_address) == func.lower(email)
             )
         )
 
-    def that_are_workplace_of_member(self, member: UUID) -> CompanyQueryResult:
+    def that_are_workplace_of_member(self, member: UUID) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(
                 models.Company.workers.any(models.Member.id == str(member))
@@ -613,12 +610,12 @@ class CompanyQueryResult(FlaskQueryResult[records.Company]):
             company.workers.append(member)
         return companies_changed
 
-    def with_name_containing(self, query: str) -> CompanyQueryResult:
+    def with_name_containing(self, query: str) -> Self:
         return self._with_modified_query(
             lambda db_query: db_query.filter(models.Company.name.ilike(f"%{query}%"))
         )
 
-    def with_email_containing(self, query: str) -> CompanyQueryResult:
+    def with_email_containing(self, query: str) -> Self:
         return self._with_modified_query(
             lambda db_query: db_query.join(models.User).filter(
                 models.User.email_address.ilike(f"%{query}%")
@@ -685,9 +682,7 @@ class AccountantResult(FlaskQueryResult[records.Accountant]):
 
 
 class TransactionQueryResult(FlaskQueryResult[records.Transaction]):
-    def where_account_is_sender_or_receiver(
-        self, *account: UUID
-    ) -> TransactionQueryResult:
+    def where_account_is_sender_or_receiver(self, *account: UUID) -> Self:
         accounts = list(map(str, account))
         return self._with_modified_query(
             lambda query: query.filter(
@@ -698,7 +693,7 @@ class TransactionQueryResult(FlaskQueryResult[records.Transaction]):
             )
         )
 
-    def where_account_is_sender(self, *account: UUID) -> TransactionQueryResult:
+    def where_account_is_sender(self, *account: UUID) -> Self:
         accounts = map(str, account)
         return self._with_modified_query(
             lambda query: query.filter(
@@ -706,7 +701,7 @@ class TransactionQueryResult(FlaskQueryResult[records.Transaction]):
             )
         )
 
-    def where_account_is_receiver(self, *account: UUID) -> TransactionQueryResult:
+    def where_account_is_receiver(self, *account: UUID) -> Self:
         accounts = map(str, account)
         return self._with_modified_query(
             lambda query: query.filter(
@@ -714,15 +709,13 @@ class TransactionQueryResult(FlaskQueryResult[records.Transaction]):
             )
         )
 
-    def ordered_by_transaction_date(
-        self, descending: bool = False
-    ) -> TransactionQueryResult:
+    def ordered_by_transaction_date(self, descending: bool = False) -> Self:
         ordering = models.Transaction.date
         if descending:
             ordering = ordering.desc()
         return self._with_modified_query(lambda query: self.query.order_by(ordering))
 
-    def where_sender_is_social_accounting(self) -> TransactionQueryResult:
+    def where_sender_is_social_accounting(self) -> Self:
         return self._with_modified_query(
             lambda query: self.query.join(
                 models.SocialAccounting,
@@ -866,7 +859,7 @@ class TransactionQueryResult(FlaskQueryResult[records.Transaction]):
 
 
 class AccountQueryResult(FlaskQueryResult[records.Account]):
-    def with_id(self, *id_: UUID) -> AccountQueryResult:
+    def with_id(self, *id_: UUID) -> Self:
         ids = list(map(str, id_))
         return self._with_modified_query(
             lambda query: query.filter(models.Account.id.in_(ids))
@@ -1004,7 +997,7 @@ class AccountQueryResult(FlaskQueryResult[records.Account]):
 
 
 class ProductiveConsumptionResult(FlaskQueryResult[records.ProductiveConsumption]):
-    def where_consumer_is_company(self, company: UUID) -> ProductiveConsumptionResult:
+    def where_consumer_is_company(self, company: UUID) -> Self:
         transaction = aliased(models.Transaction)
         account = aliased(models.Account)
         consuming_company = aliased(models.Company)
@@ -1021,9 +1014,7 @@ class ProductiveConsumptionResult(FlaskQueryResult[records.ProductiveConsumption
             .filter(consuming_company.id == str(company))
         )
 
-    def ordered_by_creation_date(
-        self, *, ascending: bool = True
-    ) -> ProductiveConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = True) -> Self:
         transaction = aliased(models.Transaction)
         ordering = transaction.date
         if not ascending:
@@ -1117,7 +1108,7 @@ class ProductiveConsumptionResult(FlaskQueryResult[records.ProductiveConsumption
 
 
 class PrivateConsumptionResult(FlaskQueryResult[records.PrivateConsumption]):
-    def where_consumer_is_member(self, member: UUID) -> PrivateConsumptionResult:
+    def where_consumer_is_member(self, member: UUID) -> Self:
         transaction = aliased(models.Transaction)
         account = aliased(models.Account)
         consuming_member = aliased(models.Member)
@@ -1131,9 +1122,7 @@ class PrivateConsumptionResult(FlaskQueryResult[records.PrivateConsumption]):
             .filter(consuming_member.id == str(member))
         )
 
-    def ordered_by_creation_date(
-        self, *, ascending: bool = True
-    ) -> PrivateConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = True) -> Self:
         transaction = aliased(models.Transaction)
         ordering = transaction.date
         if not ascending:
@@ -1185,7 +1174,7 @@ class CooperationResult(FlaskQueryResult[records.Cooperation]):
             )
         )
 
-    def coordinated_by_company(self, company_id: UUID) -> FlaskQueryResult:
+    def coordinated_by_company(self, company_id: UUID) -> Self:
         most_recent_tenure_holder = (
             models.CoordinationTenure.query.filter(
                 models.CoordinationTenure.cooperation == models.Cooperation.id
@@ -1196,11 +1185,7 @@ class CooperationResult(FlaskQueryResult[records.Cooperation]):
             .scalar_subquery()
         )
         query = self.query.filter(most_recent_tenure_holder == str(company_id))
-        return FlaskQueryResult(
-            db=self.db,
-            query=query,
-            mapper=self.mapper,
-        )
+        return self._with_modified_query(lambda _: query)
 
     def joined_with_current_coordinator(
         self,

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -48,8 +48,6 @@ T_Hash = TypeVar("T_Hash", bound=Hashable)
 Key = TypeVar("Key", bound=Hashable)
 Value = TypeVar("Value", bound=Hashable)
 
-QueryResultT = TypeVar("QueryResultT", bound="QueryResultImpl")
-
 
 @dataclass
 class QueryResultImpl(Generic[T]):
@@ -89,7 +87,7 @@ class QueryResultImpl(Generic[T]):
 
 
 class PlanResult(QueryResultImpl[Plan]):
-    def ordered_by_creation_date(self, ascending: bool = True) -> PlanResult:
+    def ordered_by_creation_date(self, ascending: bool = True) -> Self:
         return replace(
             self,
             items=lambda: sorted(
@@ -99,7 +97,7 @@ class PlanResult(QueryResultImpl[Plan]):
             ),
         )
 
-    def ordered_by_activation_date(self, ascending: bool = True) -> PlanResult:
+    def ordered_by_activation_date(self, ascending: bool = True) -> Self:
         return replace(
             self,
             items=lambda: sorted(
@@ -111,7 +109,7 @@ class PlanResult(QueryResultImpl[Plan]):
             ),
         )
 
-    def ordered_by_planner_name(self, ascending: bool = True) -> PlanResult:
+    def ordered_by_planner_name(self, ascending: bool = True) -> Self:
         def get_company_name(planner_id: UUID) -> str:
             planner = self.database.get_company_by_id(planner_id)
             assert planner
@@ -127,15 +125,15 @@ class PlanResult(QueryResultImpl[Plan]):
             ),
         )
 
-    def with_id_containing(self, query: str) -> PlanResult:
+    def with_id_containing(self, query: str) -> Self:
         return self._filter_elements(lambda plan: query in str(plan.id))
 
-    def with_product_name_containing(self, query: str) -> PlanResult:
+    def with_product_name_containing(self, query: str) -> Self:
         return self._filter_elements(
             lambda plan: query.lower() in plan.prd_name.lower()
         )
 
-    def that_are_approved(self) -> PlanResult:
+    def that_are_approved(self) -> Self:
         return self._filter_elements(lambda plan: plan.approval_date is not None)
 
     def that_were_activated_before(self, timestamp: datetime) -> Self:
@@ -156,34 +154,34 @@ class PlanResult(QueryResultImpl[Plan]):
             and plan.approval_date + timedelta(days=plan.timeframe) <= timestamp
         )
 
-    def that_are_productive(self) -> PlanResult:
+    def that_are_productive(self) -> Self:
         return self._filter_elements(lambda plan: not plan.is_public_service)
 
-    def that_are_public(self) -> PlanResult:
+    def that_are_public(self) -> Self:
         return self._filter_elements(lambda plan: plan.is_public_service)
 
-    def that_are_cooperating(self) -> PlanResult:
+    def that_are_cooperating(self) -> Self:
         return self._filter_elements(lambda plan: plan.cooperation is not None)
 
-    def planned_by(self, *company: UUID) -> PlanResult:
+    def planned_by(self, *company: UUID) -> Self:
         return self._filter_elements(lambda plan: plan.planner in company)
 
-    def with_id(self, *id_: UUID) -> PlanResult:
+    def with_id(self, *id_: UUID) -> Self:
         return self._filter_elements(lambda plan: plan.id in id_)
 
-    def without_completed_review(self) -> PlanResult:
+    def without_completed_review(self) -> Self:
         return self._filter_elements(lambda plan: plan.approval_date is None)
 
     def with_open_cooperation_request(
         self, *, cooperation: Optional[UUID] = None
-    ) -> PlanResult:
+    ) -> Self:
         return self._filter_elements(
             lambda plan: plan.requested_cooperation == cooperation
             if cooperation
             else plan.requested_cooperation is not None
         )
 
-    def that_are_in_same_cooperation_as(self, plan: UUID) -> PlanResult:
+    def that_are_in_same_cooperation_as(self, plan: UUID) -> Self:
         def items_generator() -> Iterator[records.Plan]:
             plan_record = self.database.plans.get(plan)
             if not plan_record:
@@ -204,14 +202,14 @@ class PlanResult(QueryResultImpl[Plan]):
             items=items_generator,
         )
 
-    def that_are_part_of_cooperation(self, *cooperation: UUID) -> PlanResult:
+    def that_are_part_of_cooperation(self, *cooperation: UUID) -> Self:
         return self._filter_elements(
             (lambda plan: plan.cooperation in cooperation)
             if cooperation
             else (lambda plan: plan.cooperation is not None)
         )
 
-    def that_request_cooperation_with_coordinator(self, *company: UUID) -> PlanResult:
+    def that_request_cooperation_with_coordinator(self, *company: UUID) -> Self:
         def new_items() -> Iterator[Plan]:
             cooperations: Set[UUID] = {
                 coop.id
@@ -325,7 +323,7 @@ class PlanUpdate:
     update_functions: List[Callable[[Plan], None]]
     records: MockDatabase
 
-    def set_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_cooperation(self, cooperation: Optional[UUID]) -> Self:
         def update(plan: Plan) -> None:
             if plan.cooperation:
                 self.records.indices.plan_by_cooperation.remove(
@@ -337,13 +335,13 @@ class PlanUpdate:
 
         return self._add_update(update)
 
-    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> PlanUpdate:
+    def set_requested_cooperation(self, cooperation: Optional[UUID]) -> Self:
         def update(plan: Plan) -> None:
             plan.requested_cooperation = cooperation
 
         return self._add_update(update)
 
-    def set_approval_date(self, approval_date: Optional[datetime]) -> PlanUpdate:
+    def set_approval_date(self, approval_date: Optional[datetime]) -> Self:
         def update(plan: Plan) -> None:
             plan.approval_date = approval_date
 
@@ -351,7 +349,7 @@ class PlanUpdate:
 
     def set_activation_timestamp(
         self, activation_timestamp: Optional[datetime]
-    ) -> PlanUpdate:
+    ) -> Self:
         def update(plan: Plan) -> None:
             plan.activation_date = activation_timestamp
 
@@ -563,16 +561,16 @@ class CooperationResult(QueryResultImpl[Cooperation]):
 
 
 class MemberResult(QueryResultImpl[Member]):
-    def working_at_company(self, company: UUID) -> MemberResult:
+    def working_at_company(self, company: UUID) -> Self:
         return self._filter_elements(
             lambda member: member.id
             in self.database.relationships.company_to_workers.get_right_values(company),
         )
 
-    def with_id(self, member: UUID) -> MemberResult:
+    def with_id(self, member: UUID) -> Self:
         return self._filter_elements(lambda model: model.id == member)
 
-    def with_email_address(self, email: str) -> MemberResult:
+    def with_email_address(self, email: str) -> Self:
         def items() -> Iterable[records.Member]:
             for member in self.items():
                 account_id = self.database.relationships.account_credentials_to_member.get_left_value(
@@ -608,13 +606,13 @@ class MemberResult(QueryResultImpl[Member]):
 
 
 class CompanyResult(QueryResultImpl[Company]):
-    def with_id(self, id_: UUID) -> CompanyResult:
+    def with_id(self, id_: UUID) -> Self:
         return replace(
             self,
             items=lambda: filter(lambda company: company.id == id_, self.items()),
         )
 
-    def with_email_address(self, email: str) -> CompanyResult:
+    def with_email_address(self, email: str) -> Self:
         def items() -> Iterable[records.Company]:
             for company in self.items():
                 credentials_id = self.database.relationships.account_credentials_to_company.get_left_value(
@@ -627,7 +625,7 @@ class CompanyResult(QueryResultImpl[Company]):
 
         return replace(self, items=items)
 
-    def that_are_workplace_of_member(self, member: UUID) -> CompanyResult:
+    def that_are_workplace_of_member(self, member: UUID) -> Self:
         def items() -> Iterable[records.Company]:
             for company in self.items():
                 workers = (
@@ -671,12 +669,12 @@ class CompanyResult(QueryResultImpl[Company]):
             self.database.relationships.company_to_workers.relate(company.id, member)
         return companies_changed
 
-    def with_name_containing(self, query: str) -> CompanyResult:
+    def with_name_containing(self, query: str) -> Self:
         return self._filter_elements(
             lambda company: query.lower() in company.name.lower()
         )
 
-    def with_email_containing(self, query: str) -> CompanyResult:
+    def with_email_containing(self, query: str) -> Self:
         def items() -> Iterable[records.Company]:
             for company in self.items():
                 credentials_id = self.database.relationships.account_credentials_to_company.get_left_value(
@@ -744,7 +742,7 @@ class AccountantResult(QueryResultImpl[Accountant]):
 
 
 class TransactionResult(QueryResultImpl[Transaction]):
-    def where_account_is_sender_or_receiver(self, *account: UUID) -> TransactionResult:
+    def where_account_is_sender_or_receiver(self, *account: UUID) -> Self:
         return replace(
             self,
             items=lambda: filter(
@@ -754,7 +752,7 @@ class TransactionResult(QueryResultImpl[Transaction]):
             ),
         )
 
-    def where_account_is_sender(self, *account: UUID) -> TransactionResult:
+    def where_account_is_sender(self, *account: UUID) -> Self:
         return replace(
             self,
             items=lambda: filter(
@@ -763,7 +761,7 @@ class TransactionResult(QueryResultImpl[Transaction]):
             ),
         )
 
-    def where_account_is_receiver(self, *account: UUID) -> TransactionResult:
+    def where_account_is_receiver(self, *account: UUID) -> Self:
         return replace(
             self,
             items=lambda: filter(
@@ -772,9 +770,7 @@ class TransactionResult(QueryResultImpl[Transaction]):
             ),
         )
 
-    def ordered_by_transaction_date(
-        self, descending: bool = False
-    ) -> TransactionResult:
+    def ordered_by_transaction_date(self, descending: bool = False) -> Self:
         return replace(
             self,
             items=lambda: sorted(
@@ -784,7 +780,7 @@ class TransactionResult(QueryResultImpl[Transaction]):
             ),
         )
 
-    def where_sender_is_social_accounting(self) -> TransactionResult:
+    def where_sender_is_social_accounting(self) -> Self:
         return replace(
             self,
             items=lambda: filter(
@@ -856,9 +852,7 @@ class TransactionResult(QueryResultImpl[Transaction]):
 
 
 class PrivateConsumptionResult(QueryResultImpl[records.PrivateConsumption]):
-    def ordered_by_creation_date(
-        self, *, ascending: bool = True
-    ) -> PrivateConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = True) -> Self:
         def consumption_sorting_key(
             consumption: records.PrivateConsumption,
         ) -> datetime:
@@ -874,7 +868,7 @@ class PrivateConsumptionResult(QueryResultImpl[records.PrivateConsumption]):
             ),
         )
 
-    def where_consumer_is_member(self, member: UUID) -> PrivateConsumptionResult:
+    def where_consumer_is_member(self, member: UUID) -> Self:
         def filtered_items() -> Iterator[records.PrivateConsumption]:
             member_account = self.database.members[member].account
             for consumption in self.items():
@@ -905,9 +899,7 @@ class PrivateConsumptionResult(QueryResultImpl[records.PrivateConsumption]):
 
 
 class ProductiveConsumptionResult(QueryResultImpl[records.ProductiveConsumption]):
-    def ordered_by_creation_date(
-        self, *, ascending: bool = True
-    ) -> ProductiveConsumptionResult:
+    def ordered_by_creation_date(self, *, ascending: bool = True) -> Self:
         def consumption_sorting_key(
             consumption: records.ProductiveConsumption,
         ) -> datetime:
@@ -923,7 +915,7 @@ class ProductiveConsumptionResult(QueryResultImpl[records.ProductiveConsumption]
             ),
         )
 
-    def where_consumer_is_company(self, company: UUID) -> ProductiveConsumptionResult:
+    def where_consumer_is_company(self, company: UUID) -> Self:
         def filtered_items() -> Iterator[records.ProductiveConsumption]:
             company_record = self.database.get_company_by_id(company)
             if company_record is None:
@@ -992,7 +984,7 @@ class ProductiveConsumptionResult(QueryResultImpl[records.ProductiveConsumption]
 
 
 class AccountResult(QueryResultImpl[Account]):
-    def with_id(self, *id_: UUID) -> AccountResult:
+    def with_id(self, *id_: UUID) -> Self:
         return replace(
             self,
             items=lambda: filter(lambda account: account.id in id_, self.items()),


### PR DESCRIPTION
# Reorganize imports in arbeitszeit.repositories

Before this commit the imports in `arbeitszeit.repositories` were a
little unorganized and inconsitent, especially the the imports from
`arbeitszeit.records`. This change unifies all imports from that
module such that only the module `arbeitszeit.records` is brought into
scope and the individual type definitions are accessed via the dot
operator.

Before:
```python
def create_member(...) -> Member:
    ...
```

Now:
```python
def create_member(...) -> records.Member:
    ...
```

# Simplify type signatures on DatabaseGateway et al

Before this change we made use of a crutch when it comes to type
signatures. This change uses the new `Self` typing feature of python
in all `*Result` types for database interfacing.  The type signatures
should be easier to understand and reproduce with this change. This
simplification does come with a cost though.  After this change we
generally disallow that a specific subtype of `QueryResult` may yield
another subtype of QueryResult that is not a subtype of itself. The
author considers this trade off worthwhile since he believes that
something in the design process must have gone horribly wrong if the
need for such a monstrosity ever arises.

_Registration not needed_