### PR TITLE
Implement basic presenter for RequestEmailAddressChange use case

### DIFF
--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -208,6 +208,15 @@ class GeneralUrlIndex:
     def get_start_page_url(self) -> str:
         return url_for(endpoint="auth.start")
 
+    def get_member_account_details_url(self) -> str:
+        return url_for("main_member.get_member_account_details")
+
+    def get_company_account_details_url(self) -> str:
+        return url_for("main_company.get_company_account_details")
+
+    def get_accountant_account_details_url(self) -> str:
+        return url_for("main_accountant.get_accountant_account_details")
+
 
 class CompanyUrlIndex:
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -147,6 +147,15 @@ class UrlIndex(Protocol):
     def get_start_page_url(self) -> str:
         ...
 
+    def get_member_account_details_url(self) -> str:
+        ...
+
+    def get_company_account_details_url(self) -> str:
+        ...
+
+    def get_accountant_account_details_url(self) -> str:
+        ...
+
 
 class RenewPlanUrlIndex(Protocol):
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
+++ b/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
@@ -1,0 +1,38 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from arbeitszeit.use_cases import request_email_address_change as use_case
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.session import Session, UserRole
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirect_url: Optional[str]
+
+
+@dataclass
+class RequestEmailAddressChangePresenter:
+    url_index: UrlIndex
+    session: Session
+    notifier: Notifier
+    translator: Translator
+
+    def render_response(self, uc_response: use_case.Response) -> ViewModel:
+        redirect_url: Optional[str]
+        if uc_response.is_rejected:
+            redirect_url = None
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "Your request for an email address change was rejected."
+                )
+            )
+        elif self.session.get_user_role() == UserRole.member:
+            redirect_url = self.url_index.get_member_account_details_url()
+        elif self.session.get_user_role() == UserRole.accountant:
+            redirect_url = self.url_index.get_accountant_account_details_url()
+        else:
+            redirect_url = self.url_index.get_company_account_details_url()
+        return ViewModel(redirect_url=redirect_url)

--- a/tests/www/base_test_case.py
+++ b/tests/www/base_test_case.py
@@ -3,6 +3,9 @@ from unittest import TestCase
 
 from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
 from tests.session import FakeSession
+from tests.translator import FakeTranslator
+from tests.www.presenters.notifier import NotifierTestImpl
+from tests.www.presenters.url_index import UrlIndexTestImpl
 
 from .dependency_injection import get_dependency_injector
 
@@ -52,4 +55,7 @@ class BaseTestCase(TestCase):
     accountant_generator = _lazy_property(AccountantGenerator)
     company_generator = _lazy_property(CompanyGenerator)
     member_generator = _lazy_property(MemberGenerator)
+    notifier = _lazy_property(NotifierTestImpl)
     session = _lazy_property(FakeSession)
+    url_index = _lazy_property(UrlIndexTestImpl)
+    translator = _lazy_property(FakeTranslator)

--- a/tests/www/controllers/test_register_private_consumption_controller.py
+++ b/tests/www/controllers/test_register_private_consumption_controller.py
@@ -8,7 +8,6 @@ from arbeitszeit_web.www.controllers.register_private_consumption_controller imp
     RegisterPrivateConsumptionController,
 )
 from tests.forms import RegisterPrivateConsumptionFakeForm
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 ControllerResult = Optional[RegisterPrivateConsumptionRequest]
@@ -17,7 +16,6 @@ ControllerResult = Optional[RegisterPrivateConsumptionRequest]
 class RegisterPrivateConsumptionControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.controller = self.injector.get(RegisterPrivateConsumptionController)
         self.form = RegisterPrivateConsumptionFakeForm()
 

--- a/tests/www/controllers/test_register_productive_consumption_controller.py
+++ b/tests/www/controllers/test_register_productive_consumption_controller.py
@@ -8,14 +8,12 @@ from arbeitszeit_web.www.controllers.register_productive_consumption_controller 
     RegisterProductiveConsumptionController,
 )
 from tests.forms import RegisterProductiveConsumptionFakeForm
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
 class AuthenticatedCompanyTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.expected_user_id = uuid4()
         self.session.login_company(self.expected_user_id)
         self.controller = RegisterProductiveConsumptionController(

--- a/tests/www/controllers/test_request_cooperation_controller.py
+++ b/tests/www/controllers/test_request_cooperation_controller.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.malformed_input_data import MalformedInputData
 from arbeitszeit_web.www.controllers.request_cooperation_controller import (
     RequestCooperationController,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -30,7 +29,6 @@ fake_form = FakeRequestCooperationForm(
 class RequestCooperationControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.controller = self.injector.get(RequestCooperationController)
 
     def test_when_user_is_not_authenticated_then_we_cannot_get_a_use_case_request(

--- a/tests/www/presenters/test_accountant_invitation_presenter.py
+++ b/tests/www/presenters/test_accountant_invitation_presenter.py
@@ -8,7 +8,6 @@ from arbeitszeit_web.www.presenters.accountant_invitation_presenter import (
 from tests.datetime_service import FakeDatetimeService
 from tests.email import FakeEmailConfiguration
 from tests.token import FakeTokenService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 from .accountant_invitation_email_view import AccountantInvitationEmailViewImpl
@@ -20,9 +19,10 @@ class PresenterTests(BaseTestCase):
         super().setUp()
         self.view = self.injector.get(AccountantInvitationEmailViewImpl)
         self.presenter = self.injector.get(AccountantInvitationEmailPresenter)
-        self.translator = self.injector.get(FakeTranslator)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
-        self.url_index = self.injector.get(AccountantInvitationUrlIndexImpl)
+        self.accountant_invitation_url_index = self.injector.get(
+            AccountantInvitationUrlIndexImpl
+        )
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.token_service = self.injector.get(FakeTokenService)
 
@@ -54,7 +54,9 @@ class PresenterTests(BaseTestCase):
         self.presenter.send_accountant_invitation(email="test@test.test")
         self.assertViewModel(
             lambda model: model.registration_link_url
-            == self.url_index.get_accountant_invitation_url(expected_token)
+            == self.accountant_invitation_url_index.get_accountant_invitation_url(
+                expected_token
+            )
         )
 
     def assertViewModel(self, condition: Callable[[ViewModel], bool]) -> None:

--- a/tests/www/presenters/test_answer_company_work_invite.py
+++ b/tests/www/presenters/test_answer_company_work_invite.py
@@ -6,11 +6,7 @@ from arbeitszeit.use_cases.answer_company_work_invite import (
 from arbeitszeit_web.www.presenters.answer_company_work_invite_presenter import (
     AnswerCompanyWorkInvitePresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
 
 COMPANY_NAME = "test company"
 
@@ -41,9 +37,6 @@ def get_response(
 class SuccessfulResponseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(AnswerCompanyWorkInvitePresenter)
 
     def test_info_notification_is_displayed_on_success(self) -> None:
@@ -96,9 +89,6 @@ class SuccessfulResponseTests(BaseTestCase):
 class UnsuccessfulResponseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(AnswerCompanyWorkInvitePresenter)
 
     def test_warning_notification_is_displayed_on_failure(self) -> None:

--- a/tests/www/presenters/test_approve_plan_presenter.py
+++ b/tests/www/presenters/test_approve_plan_presenter.py
@@ -1,19 +1,12 @@
 from arbeitszeit.use_cases.approve_plan import ApprovePlanUseCase as UseCase
 from arbeitszeit_web.www.presenters.approve_plan_presenter import ApprovePlanPresenter
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.notifier import NotifierTestImpl
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ApprovePlanPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
 
     def test_that_view_model_redirects_to_list_view_for_unreviewed_plans(self) -> None:
         response = UseCase.Response(is_approved=True)

--- a/tests/www/presenters/test_company_consumptions_presenter.py
+++ b/tests/www/presenters/test_company_consumptions_presenter.py
@@ -13,7 +13,6 @@ from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
 )
 from tests.data_generators import ConsumptionGenerator
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -23,7 +22,6 @@ class TestPresenter(BaseTestCase):
         self.query_consumptions = self.injector.get(QueryCompanyConsumptions)
         self.consumption_generator = self.injector.get(ConsumptionGenerator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(CompanyConsumptionsPresenter)
 
     def test_show_consumptions_from_company(self) -> None:

--- a/tests/www/presenters/test_create_cooperation_presenter.py
+++ b/tests/www/presenters/test_create_cooperation_presenter.py
@@ -5,10 +5,7 @@ from arbeitszeit.use_cases.create_cooperation import CreateCooperationResponse
 from arbeitszeit_web.www.presenters.create_cooperation_presenter import (
     CreateCooperationPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
 
 SUCCESSFUL_CREATE_RESPONSE = CreateCooperationResponse(
     rejection_reason=None, cooperation_id=uuid4()
@@ -28,8 +25,6 @@ REJECTED_RESPONSE_COORDINATOR_NOT_FOUND = CreateCooperationResponse(
 class CreateCooperationPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(CreateCooperationPresenter)
 
     def test_notification_returned_when_creation_was_successful(self):

--- a/tests/www/presenters/test_create_draft_presenter.py
+++ b/tests/www/presenters/test_create_draft_presenter.py
@@ -2,19 +2,13 @@ from uuid import uuid4
 
 from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraftResponse
 from arbeitszeit_web.www.presenters.create_draft_presenter import CreateDraftPresenter
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.notifier import NotifierTestImpl
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(CreateDraftPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
 
     def test_on_successful_draft_creation_redirect_to_my_drafts_page(self) -> None:
         draft_id = uuid4()

--- a/tests/www/presenters/test_delete_draft_presenter.py
+++ b/tests/www/presenters/test_delete_draft_presenter.py
@@ -1,19 +1,12 @@
 from arbeitszeit.use_cases.delete_draft import DeleteDraftUseCase
 from arbeitszeit_web.www.presenters.delete_draft_presenter import DeleteDraftPresenter
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(DeleteDraftPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
 
     def test_that_user_gets_redirected_to_my_plans(self) -> None:
         response = self.get_response()

--- a/tests/www/presenters/test_end_cooperation_presenter.py
+++ b/tests/www/presenters/test_end_cooperation_presenter.py
@@ -7,11 +7,7 @@ from arbeitszeit_web.www.presenters.end_cooperation_presenter import (
     EndCooperationPresenter,
 )
 from tests.request import FakeRequest
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
 
 SUCCESSFUL_RESPONSE = EndCooperationResponse(rejection_reason=None)
 
@@ -28,9 +24,6 @@ class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.request = self.injector.get(FakeRequest)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(EndCooperationPresenter)
         self.session.login_company(company=uuid4())
 

--- a/tests/www/presenters/test_file_plan_with_accounting_presenter.py
+++ b/tests/www/presenters/test_file_plan_with_accounting_presenter.py
@@ -6,20 +6,13 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.file_plan_with_accounting_presenter import (
     FilePlanWithAccountingPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
 
 
 class Tests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(FilePlanWithAccountingPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.session.login_company(company=uuid4())
 
     def test_view_model_has_redirect_url_with_successful_responses(self) -> None:

--- a/tests/www/presenters/test_get_accountant_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_accountant_dashboard_presenter.py
@@ -6,14 +6,11 @@ from arbeitszeit_web.www.presenters.get_accountant_dashboard_presenter import (
 )
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import UrlIndexTestImpl
-
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetAccountantDashboardPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_that_view_model_contains_url_to_unreviewed_plans_list_view(self) -> None:
         response = self.get_use_case_response()

--- a/tests/www/presenters/test_get_company_summary_presenter.py
+++ b/tests/www/presenters/test_get_company_summary_presenter.py
@@ -16,10 +16,7 @@ from arbeitszeit_web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
 )
 from tests.control_thresholds import ControlThresholdsTestImpl
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 RESPONSE_WITH_2_PLANS = GetCompanySummarySuccess(
     id=uuid4(),
@@ -64,7 +61,6 @@ class GetCompanySummaryPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetCompanySummarySuccessPresenter)
-        self.translator = self.injector.get(FakeTranslator)
         self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
         self.session.login_company(uuid4())
 
@@ -113,8 +109,6 @@ class PlansOfCompanyTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetCompanySummarySuccessPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
         self.session.login_company(uuid4())
 

--- a/tests/www/presenters/test_get_company_transactions.py
+++ b/tests/www/presenters/test_get_company_transactions.py
@@ -14,14 +14,12 @@ from arbeitszeit_web.www.presenters.get_company_transactions_presenter import (
     GetCompanyTransactionsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(GetCompanyTransactionsPresenter)
         self.datetime_service = self.injector.get(FakeDatetimeService)
 

--- a/tests/www/presenters/test_get_coop_summary_presenter.py
+++ b/tests/www/presenters/test_get_coop_summary_presenter.py
@@ -9,8 +9,6 @@ from arbeitszeit_web.www.presenters.get_coop_summary_presenter import (
 )
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import UrlIndexTestImpl
-
 TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
     requester_is_coordinator=True,
     coop_id=uuid4(),
@@ -32,7 +30,6 @@ TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
 class GetCoopSummarySuccessPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(GetCoopSummarySuccessPresenter)
         self.session.login_company(company=uuid4())
 

--- a/tests/www/presenters/test_get_member_account_presenter.py
+++ b/tests/www/presenters/test_get_member_account_presenter.py
@@ -11,7 +11,6 @@ from arbeitszeit_web.www.presenters.get_member_account_presenter import (
     GetMemberAccountPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -19,7 +18,6 @@ class TestPresenter(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.datetime_service = self.injector.get(FakeDatetimeService)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(GetMemberAccountPresenter)
 
     def test_that_empty_transaction_list_is_shown_if_no_transactions_took_place(

--- a/tests/www/presenters/test_get_member_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_member_dashboard_presenter.py
@@ -10,17 +10,13 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.get_member_dashboard_presenter import (
     GetMemberDashboardPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 
 class GetMemberDashboardPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(GetMemberDashboardPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_that_welcome_line_is_correctly_translated(self) -> None:
         view_model = self.presenter.present(self.get_response())

--- a/tests/www/presenters/test_get_plan_details_company_presenter.py
+++ b/tests/www/presenters/test_get_plan_details_company_presenter.py
@@ -11,15 +11,12 @@ from arbeitszeit_web.www.presenters.get_plan_details_company_presenter import (
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
 
-from .url_index import UrlIndexTestImpl
-
 UseCaseResponse = GetPlanDetailsUseCase.Response
 
 
 class TestPresenterForPlanner(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(GetPlanDetailsCompanyPresenter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.expected_planner = uuid4()
@@ -132,7 +129,6 @@ class TestPresenterForPlanner(BaseTestCase):
 class TestPresenterForNonPlanningCompany(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(GetPlanDetailsCompanyPresenter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.session.login_company(uuid4())

--- a/tests/www/presenters/test_get_plan_details_member_presenter.py
+++ b/tests/www/presenters/test_get_plan_details_member_presenter.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.www.presenters.get_plan_details_member_presenter import (
 )
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
@@ -16,7 +15,6 @@ class PresenterTests(BaseTestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(GetPlanDetailsMemberMemberPresenter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
 

--- a/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
@@ -8,7 +8,6 @@ from arbeitszeit_web.www.presenters.create_draft_presenter import (
 from tests.forms import DraftForm
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 TEST_DRAFT_SUMMARY_SUCCESS = DraftDetailsSuccess(
     draft_id=uuid4(),
@@ -29,7 +28,6 @@ class PlanDetailsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetPrefilledDraftDataPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.plan_details = self.plan_details_generator.create_plan_details()
 
@@ -72,7 +70,6 @@ class DraftDetailsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetPrefilledDraftDataPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_correct_form_data_is_returned_for_draft_details(self) -> None:
         form = DraftForm()

--- a/tests/www/presenters/test_get_statistics_presenter.py
+++ b/tests/www/presenters/test_get_statistics_presenter.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.www.presenters.get_statistics_presenter import (
     GetStatisticsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 TESTING_RESPONSE_MODEL = StatisticsResponse(
@@ -29,7 +28,6 @@ class GetStatisticsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.datetime_service = self.injector.get(FakeDatetimeService)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(GetStatisticsPresenter)
 
     def test_planned_resources_hours_are_truncated_at_2_digits_after_comma(

--- a/tests/www/presenters/test_hide_plan_presenter.py
+++ b/tests/www/presenters/test_hide_plan_presenter.py
@@ -4,8 +4,6 @@ from arbeitszeit.use_cases.hide_plan import HidePlanResponse
 from arbeitszeit_web.www.presenters.hide_plan_presenter import HidePlanPresenter
 from tests.www.base_test_case import BaseTestCase
 
-from .notifier import NotifierTestImpl
-
 SUCCESSFUL_DELETE_RESPONSE = HidePlanResponse(
     plan_id=uuid4(),
     is_success=True,
@@ -19,7 +17,6 @@ FAILED_DELETE_RESPONSE = HidePlanResponse(
 class HidePlanPresenterTests(BaseTestCase):
     def setUp(self):
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
         self.presenter = self.injector.get(HidePlanPresenter)
 
     def test_that_a_notification_is_shown_when_deletion_was_successful(self):

--- a/tests/www/presenters/test_invite_worker_mail_presenter.py
+++ b/tests/www/presenters/test_invite_worker_mail_presenter.py
@@ -3,9 +3,7 @@ from uuid import uuid4
 from arbeitszeit_web.invite_worker_presenter import InviteWorkerPresenterImpl
 from tests.email import FakeEmailConfiguration, FakeEmailSender
 from tests.text_renderer import TextRendererImpl
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 
 class SendMailTests(BaseTestCase):
@@ -14,9 +12,7 @@ class SendMailTests(BaseTestCase):
         self.presenter = self.injector.get(InviteWorkerPresenterImpl)
         self.email_service = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
-        self.translator = self.injector.get(FakeTranslator)
         self.text_renderer = self.injector.get(TextRendererImpl)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_one_mail_gets_send(self) -> None:
         self.presenter.show_invite_worker_message(

--- a/tests/www/presenters/test_invite_worker_to_company.py
+++ b/tests/www/presenters/test_invite_worker_to_company.py
@@ -2,14 +2,12 @@ from arbeitszeit.use_cases.invite_worker_to_company import InviteWorkerToCompany
 from arbeitszeit_web.www.presenters.invite_worker_to_company_presenter import (
     InviteWorkerToCompanyPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 
 class InviteWorkerToCompanyPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(InviteWorkerToCompanyPresenter)
 
     def test_successfule_invitation_response_displays_proper_notification(self) -> None:

--- a/tests/www/presenters/test_list_all_cooperations.py
+++ b/tests/www/presenters/test_list_all_cooperations.py
@@ -11,13 +11,10 @@ from arbeitszeit_web.www.presenters.list_all_cooperations_presenter import (
 )
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import UrlIndexTestImpl
-
 
 class ListMessagesPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(ListAllCooperationsPresenter)
         self.session.login_company(company=uuid4())
 

--- a/tests/www/presenters/test_list_plans_with_pending_review_presenter.py
+++ b/tests/www/presenters/test_list_plans_with_pending_review_presenter.py
@@ -10,14 +10,11 @@ from arbeitszeit_web.www.presenters.list_plans_with_pending_review_presenter imp
 )
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import UrlIndexTestImpl
-
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ListPlansWithPendingReviewPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_that_plan_overview_is_not_shown_when_there_are_no_plans_in_response(
         self,

--- a/tests/www/presenters/test_log_in_accountant_presenter.py
+++ b/tests/www/presenters/test_log_in_accountant_presenter.py
@@ -7,18 +7,13 @@ from arbeitszeit_web.www.presenters.log_in_accountant_presenter import (
     LogInAccountantPresenter,
 )
 from tests.forms import LoginForm
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTester(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(LogInAccountantPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
 
     def test_user_gets_redirected_when_login_was_successful(self) -> None:
         response = self._create_success_response()

--- a/tests/www/presenters/test_login_in_company_presenter.py
+++ b/tests/www/presenters/test_login_in_company_presenter.py
@@ -9,18 +9,13 @@ from arbeitszeit_web.www.presenters.log_in_company_presenter import (
     LogInCompanyPresenter,
 )
 from tests.forms import LoginForm
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.presenter = self.injector.get(LogInCompanyPresenter)
-        self.translator = self.injector.get(FakeTranslator)
         self.form = LoginForm()
 
     def test_that_user_is_logged_into_session_on_successful_login(self) -> None:

--- a/tests/www/presenters/test_login_in_member_presenter.py
+++ b/tests/www/presenters/test_login_in_member_presenter.py
@@ -5,18 +5,13 @@ from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.log_in_member_presenter import LogInMemberPresenter
 from tests.forms import LoginForm
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(LogInMemberPresenter)
-        self.translator = self.injector.get(FakeTranslator)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.form = LoginForm()
 
     def test_that_user_is_logged_into_session_on_success(self) -> None:

--- a/tests/www/presenters/test_notify_accountant_about_new_plan_presenter.py
+++ b/tests/www/presenters/test_notify_accountant_about_new_plan_presenter.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.www.presenters.notify_accountant_about_new_plan_presenter i
 )
 from tests.email import FakeAddressBook, FakeEmailConfiguration, FakeEmailSender
 from tests.text_renderer import TextRendererImpl
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 Notification = Interface.Notification
@@ -18,7 +17,6 @@ class PresenterTests(BaseTestCase):
         self.presenter = self.injector.get(NotifyAccountantsAboutNewPlanPresenterImpl)
         self.email_sender = self.injector.get(FakeEmailSender)
         self.address_book = self.injector.get(FakeAddressBook)
-        self.translator = self.injector.get(FakeTranslator)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
         self.text_renderer = self.injector.get(TextRendererImpl)
 

--- a/tests/www/presenters/test_plan_details_formatter.py
+++ b/tests/www/presenters/test_plan_details_formatter.py
@@ -4,18 +4,13 @@ from uuid import uuid4
 from arbeitszeit_web.formatters.plan_details_formatter import PlanDetailsFormatter
 from arbeitszeit_web.session import UserRole
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
-
-from .url_index import UrlIndexTestImpl
 
 
 class PlanDetailsFormatterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.formatter = self.injector.get(PlanDetailsFormatter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.plan_details = self.plan_details_generator.create_plan_details()

--- a/tests/www/presenters/test_query_companies_presenter.py
+++ b/tests/www/presenters/test_query_companies_presenter.py
@@ -7,18 +7,13 @@ from arbeitszeit_web.www.presenters.query_companies_presenter import (
 )
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import QueriedCompanyGenerator
-from tests.www.presenters.url_index import UrlIndexTestImpl
-
-from .notifier import NotifierTestImpl
 
 
 class QueryCompaniesPresenterTests(BaseTestCase):
     def setUp(self):
         super().setUp()
         self.queried_company_generator = self.injector.get(QueriedCompanyGenerator)
-        self.notifier = self.injector.get(NotifierTestImpl)
         self.presenter = self.injector.get(QueryCompaniesPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.session.login_member(uuid4())
 
     def test_empty_view_model_does_not_show_results(self):

--- a/tests/www/presenters/test_query_plans_presenter.py
+++ b/tests/www/presenters/test_query_plans_presenter.py
@@ -7,15 +7,10 @@ from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import QueriedPlanGenerator
 
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
-
 
 class QueryPlansPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.notifier = self.injector.get(NotifierTestImpl)
         self.presenter = self.injector.get(QueryPlansPresenter)
         self.queried_plan_generator = QueriedPlanGenerator()
         self.session.login_member(uuid4())

--- a/tests/www/presenters/test_register_accountant_presenter.py
+++ b/tests/www/presenters/test_register_accountant_presenter.py
@@ -7,20 +7,13 @@ from arbeitszeit_web.www.presenters.register_accountant_presenter import (
     RegisterAccountantPresenter,
 )
 from tests.session import FakeSession
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.notifier import NotifierTestImpl
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(RegisterAccountantPresenter)
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_that_registration_rejection_results_in_error_message_shown(self) -> None:
         response = self.create_rejected_response()

--- a/tests/www/presenters/test_register_company_presenter.py
+++ b/tests/www/presenters/test_register_company_presenter.py
@@ -6,7 +6,6 @@ from arbeitszeit_web.www.presenters.register_company_presenter import (
     RegisterCompanyPresenter,
 )
 from tests.forms import RegisterFormImpl
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 RejectionReason = RegisterCompany.Response.RejectionReason
@@ -16,7 +15,6 @@ class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(RegisterCompanyPresenter)
-        self.translator = self.injector.get(FakeTranslator)
         self.form = RegisterFormImpl.create()
 
     def test_that_correct_error_message_is_displayed_when_email_is_already_registered(

--- a/tests/www/presenters/test_register_hours_worked_presenter.py
+++ b/tests/www/presenters/test_register_hours_worked_presenter.py
@@ -5,10 +5,7 @@ from arbeitszeit_web.www.controllers.register_hours_worked_controller import (
 from arbeitszeit_web.www.presenters.register_hours_worked_presenter import (
     RegisterHoursWorkedPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
 
 SUCCESS_USE_CASE_RESPONSE = RegisterHoursWorkedResponse(rejection_reason=None)
 
@@ -28,9 +25,7 @@ REJECTED_CONTROLLER_RES_NEGATIVE_AMOUNT = ControllerRejection(
 class PresentUseCaseResponseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
         self.presenter = self.injector.get(RegisterHoursWorkedPresenter)
-        self.translator = self.injector.get(FakeTranslator)
 
     def test_presenter_renders_warning_if_use_case_response_is_rejected(self):
         self.presenter.present_use_case_response(REJECTED_USE_CASE_RESPONSE)
@@ -61,8 +56,6 @@ class PresentUseCaseResponseTests(BaseTestCase):
 class PresentControllerResponseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = FakeTranslator()
-        self.notifier = NotifierTestImpl()
         self.presenter = RegisterHoursWorkedPresenter(
             notifier=self.notifier, translator=self.translator
         )

--- a/tests/www/presenters/test_register_member_presenter.py
+++ b/tests/www/presenters/test_register_member_presenter.py
@@ -5,18 +5,13 @@ from arbeitszeit_web.www.presenters.register_member_presenter import (
     RegisterMemberPresenter,
 )
 from tests.forms import RegisterFormImpl
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(RegisterMemberPresenter)
-        self.translator = self.injector.get(FakeTranslator)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_no_errors_are_rendered_when_registration_was_a_success(self) -> None:
         form = RegisterFormImpl.create()

--- a/tests/www/presenters/test_register_private_consumption_presenter.py
+++ b/tests/www/presenters/test_register_private_consumption_presenter.py
@@ -5,17 +5,12 @@ from arbeitszeit.use_cases.register_private_consumption import (
 from arbeitszeit_web.www.presenters.register_private_consumption_presenter import (
     RegisterPrivateConsumptionPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
 
 
 class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(RegisterPrivateConsumptionPresenter)
 
     def test_presenter_shows_correct_notification_when_registration_was_a_success(

--- a/tests/www/presenters/test_register_productive_consumption_presenter.py
+++ b/tests/www/presenters/test_register_productive_consumption_presenter.py
@@ -6,11 +6,7 @@ from arbeitszeit.use_cases.register_productive_consumption import (
 from arbeitszeit_web.www.presenters.register_productive_consumption_presenter import (
     RegisterProductiveConsumptionPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .notifier import NotifierTestImpl
-from .url_index import UrlIndexTestImpl
 
 reasons = RegisterProductiveConsumptionResponse.RejectionReason
 
@@ -18,10 +14,7 @@ reasons = RegisterProductiveConsumptionResponse.RejectionReason
 class RegisterProductiveConsumptionTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.notifier = self.injector.get(NotifierTestImpl)
-        self.trans = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(RegisterProductiveConsumptionPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_show_confirmation_when_registration_was_successful(self) -> None:
         self.presenter.present(
@@ -30,7 +23,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext("Successfully registered."), self.notifier.infos
+            self.translator.gettext("Successfully registered."), self.notifier.infos
         )
 
     def test_missing_plan_show_correct_notification(self) -> None:
@@ -40,7 +33,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext("Plan does not exist."), self.notifier.warnings
+            self.translator.gettext("Plan does not exist."), self.notifier.warnings
         )
 
     def test_invalid_consumption_type_shows_correct_notification(self) -> None:
@@ -50,7 +43,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext("The specified type of consumption is invalid."),
+            self.translator.gettext("The specified type of consumption is invalid."),
             self.notifier.warnings,
         )
 
@@ -61,7 +54,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext(
+            self.translator.gettext(
                 "The specified plan has expired. Please contact the provider to obtain a current plan ID."
             ),
             self.notifier.warnings,
@@ -74,7 +67,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext(
+            self.translator.gettext(
                 "Registration failed. Companies cannot acquire public products."
             ),
             self.notifier.warnings,
@@ -87,7 +80,7 @@ class RegisterProductiveConsumptionTests(BaseTestCase):
             )
         )
         self.assertIn(
-            self.trans.gettext(
+            self.translator.gettext(
                 "Registration failed. Companies cannot acquire their own products."
             ),
             self.notifier.warnings,

--- a/tests/www/presenters/test_registration_email_presenter.py
+++ b/tests/www/presenters/test_registration_email_presenter.py
@@ -7,10 +7,7 @@ from tests.datetime_service import FakeDatetimeService
 from tests.email import Email, FakeEmailConfiguration, FakeEmailSender
 from tests.text_renderer import TextRendererImpl
 from tests.token import FakeTokenService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class MemberPresenterTests(BaseTestCase):
@@ -18,8 +15,6 @@ class MemberPresenterTests(BaseTestCase):
         super().setUp()
         self.email_sender = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(RegistrationEmailPresenter)
         self.text_renderer = self.injector.get(TextRendererImpl)
         self.email_address = "test@test.test"
@@ -73,8 +68,6 @@ class CompanyPresenterTests(BaseTestCase):
         super().setUp()
         self.email_sender = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(RegistrationEmailPresenter)
         self.text_renderer = self.injector.get(TextRendererImpl)
         self.email_address = "test@test.test"

--- a/tests/www/presenters/test_request_cooperation_presenter.py
+++ b/tests/www/presenters/test_request_cooperation_presenter.py
@@ -5,7 +5,6 @@ from arbeitszeit_web.www.presenters.request_cooperation_presenter import (
     RequestCooperationPresenter,
 )
 from tests.email import FakeEmailSender
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 RejectionReason = RequestCooperationResponse.RejectionReason
@@ -14,7 +13,6 @@ RejectionReason = RequestCooperationResponse.RejectionReason
 class RequestCooperationPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(RequestCooperationPresenter)
         self.mail_service = self.injector.get(FakeEmailSender)
 

--- a/tests/www/presenters/test_request_email_address_change_presenter.py
+++ b/tests/www/presenters/test_request_email_address_change_presenter.py
@@ -1,0 +1,86 @@
+from arbeitszeit.use_cases import request_email_address_change as use_case
+from arbeitszeit_web.www.presenters import (
+    request_email_address_change_presenter as presenter,
+)
+
+from ..base_test_case import BaseTestCase
+
+
+class RequestEmailAddressChangePresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(presenter.RequestEmailAddressChangePresenter)
+
+    def test_on_success_redirect_to_non_empty_target(self) -> None:
+        response = use_case.Response(is_rejected=False)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url
+
+    def test_on_success_redirect_logged_in_member_to_account_details_page(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=False)
+        view_model = self.presenter.render_response(response)
+        assert (
+            view_model.redirect_url == self.url_index.get_member_account_details_url()
+        )
+
+    def test_on_success_redirect_logged_in_company_to_account_details_page(
+        self,
+    ) -> None:
+        self.session.login_company(self.company_generator.create_company())
+        response = use_case.Response(is_rejected=False)
+        view_model = self.presenter.render_response(response)
+        assert (
+            view_model.redirect_url == self.url_index.get_company_account_details_url()
+        )
+
+    def test_on_success_redirect_logged_in_accountant_to_account_details_page(
+        self,
+    ) -> None:
+        self.session.login_accountant(self.accountant_generator.create_accountant())
+        response = use_case.Response(is_rejected=False)
+        view_model = self.presenter.render_response(response)
+        assert (
+            view_model.redirect_url
+            == self.url_index.get_accountant_account_details_url()
+        )
+
+    def test_on_failure_dont_redirect_logged_in_member(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=True)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url is None
+
+    def test_on_failure_dont_redirect_logged_in_company(
+        self,
+    ) -> None:
+        self.session.login_company(self.company_generator.create_company())
+        response = use_case.Response(is_rejected=True)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url is None
+
+    def test_on_failure_dont_redirect_logged_in_accountant(
+        self,
+    ) -> None:
+        self.session.login_accountant(self.accountant_generator.create_accountant())
+        response = use_case.Response(is_rejected=True)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url is None
+
+    def test_on_failure_show_a_warning_that_the_request_was_denied(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=True)
+        self.presenter.render_response(response)
+        expected_message = self.translator.gettext(
+            "Your request for an email address change was rejected."
+        )
+        assert expected_message in self.notifier.warnings
+
+    def test_on_success_dont_show_a_warning_that_the_request_was_denied(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=False)
+        self.presenter.render_response(response)
+        expected_message = self.translator.gettext(
+            "Your request for an email address change was rejected."
+        )
+        assert expected_message not in self.notifier.warnings

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -9,7 +9,6 @@ from arbeitszeit_web.www.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = ShowAAccountDetailsUseCase.TransactionInfo(
@@ -30,7 +29,6 @@ DEFAULT_INFO2 = ShowAAccountDetailsUseCase.TransactionInfo(
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowAAccountDetailsPresenter)
 

--- a/tests/www/presenters/test_show_company_work_invite_details_presenter.py
+++ b/tests/www/presenters/test_show_company_work_invite_details_presenter.py
@@ -7,17 +7,12 @@ from arbeitszeit.use_cases.show_company_work_invite_details import (
 from arbeitszeit_web.www.presenters.show_company_work_invite_details_presenter import (
     ShowCompanyWorkInviteDetailsPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(ShowCompanyWorkInviteDetailsPresenter)
 
     def test_use_case_response_without_details_doesnt_render_to_view_model(

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -23,10 +23,7 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_cooperations_presenter import (
     ShowMyCooperationsPresenter,
 )
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-
-from .url_index import UrlIndexTestImpl
 
 LIST_COORDINATIONS_RESPONSE_LEN_1 = ListCoordinationsResponse(
     coordinations=[
@@ -107,8 +104,6 @@ def get_coop_plans_response_length_1(
 class ShowMyCooperationsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
-        self.translator = FakeTranslator()
         self.presenter = self.injector.get(ShowMyCooperationsPresenter)
 
     def test_coordinations_are_presented_correctly(self):
@@ -283,7 +278,6 @@ class InboundTest(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ShowMyCooperationsPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.COOP_ID = uuid4()
         self.PLAN_ID = uuid4()
         self.PLANNER_ID = uuid4()
@@ -347,7 +341,6 @@ class OutboundTest(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ShowMyCooperationsPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.COOP_ID = uuid4()
         self.PLAN_ID = uuid4()
         self.view_model = self.presenter.present(
@@ -395,7 +388,6 @@ class CooperatingPlansTest(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ShowMyCooperationsPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.COOP_ID = uuid4()
         self.PLAN_ID = uuid4()
         self.view_model = self.presenter.present(

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -13,29 +13,20 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPresenter
 from tests.data_generators import CooperationGenerator, PlanGenerator
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.notifier import NotifierTestImpl
 
-from .url_index import (
-    HidePlanUrlIndexTestImpl,
-    RenewPlanUrlIndexTestImpl,
-    UrlIndexTestImpl,
-)
+from .url_index import HidePlanUrlIndexTestImpl, RenewPlanUrlIndexTestImpl
 
 
 class ShowMyPlansPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.url_index = self.injector.get(UrlIndexTestImpl)
         self.renew_plan_url_index = self.injector.get(RenewPlanUrlIndexTestImpl)
         self.hide_plan_url_index = self.injector.get(HidePlanUrlIndexTestImpl)
-        self.translator = self.injector.get(FakeTranslator)
         self.presenter = self.injector.get(ShowMyPlansPresenter)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.coop_generator = self.injector.get(CooperationGenerator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
-        self.notifier = self.injector.get(NotifierTestImpl)
         self.session.login_company(uuid4())
         self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
         self.datetime_service.freeze_time(datetime(2000, 1, 1))

--- a/tests/www/presenters/test_show_p_account_details.py
+++ b/tests/www/presenters/test_show_p_account_details.py
@@ -9,7 +9,6 @@ from arbeitszeit_web.www.presenters.show_p_account_details_presenter import (
     ShowPAccountDetailsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = ShowPAccountDetailsUseCase.TransactionInfo(
@@ -30,7 +29,6 @@ DEFAULT_INFO2 = ShowPAccountDetailsUseCase.TransactionInfo(
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowPAccountDetailsPresenter)
 

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -9,18 +9,14 @@ from arbeitszeit_web.www.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.url_index import UrlIndexTestImpl
 
 
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.translator = self.injector.get(FakeTranslator)
         self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowPRDAccountDetailsPresenter)
-        self.url_index = self.injector.get(UrlIndexTestImpl)
 
     def test_return_empty_list_when_no_transactions_took_place(self):
         response = self._use_case_response()

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -70,6 +70,9 @@ class UrlIndexTestImpl:
     get_member_query_companies_url = UrlIndexMethod()
     get_company_query_companies_url = UrlIndexMethod()
     get_unconfirmed_member_url = UrlIndexMethod()
+    get_member_account_details_url = UrlIndexMethod()
+    get_company_account_details_url = UrlIndexMethod()
+    get_accountant_account_details_url = UrlIndexMethod()
 
     def get_member_confirmation_url(self, *, token: str) -> str:
         return f"get_member_confirmation_url {token}"


### PR DESCRIPTION
The presenter implemented here does two things:

1) It generates a warning that is displayed to the user when the
   request has failed.
2) It figures out the appropriate redirect when the request was
   granted.

However it is not integrated with the web frontend yet. This will be done in a future change.

Further the base test class `tests.www.base_test_case.BaseTestCase`
now has three additional attributes `notifier`, `translator` and
`url_index` which can be accessed by all presenter and controller
tests should those need to do so. The rational behind this change is
that it is kind of noisy and tedious establish those objects in every
second test. This made it necessary to adjust many tests to not
override those new read-only attributes.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf