### PR TITLE
Revoke plan filing web implementation

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -47,6 +47,7 @@ from arbeitszeit.use_cases.list_outbound_coop_requests import (
 )
 from arbeitszeit.use_cases.query_company_consumptions import QueryCompanyConsumptions
 from arbeitszeit.use_cases.request_cooperation import RequestCooperation
+from arbeitszeit.use_cases.revoke_plan_filing import RevokePlanFilingUseCase
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
 from arbeitszeit.use_cases.toggle_product_availablity import ToggleProductAvailability
 from arbeitszeit_flask.database import commit_changes
@@ -99,6 +100,9 @@ from arbeitszeit_web.www.controllers.query_companies_controller import (
 from arbeitszeit_web.www.controllers.request_cooperation_controller import (
     RequestCooperationController,
 )
+from arbeitszeit_web.www.controllers.revoke_plan_filing_controller import (
+    RevokePlanFilingController,
+)
 from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
     CompanyConsumptionsPresenter,
 )
@@ -138,6 +142,9 @@ from arbeitszeit_web.www.presenters.query_companies_presenter import (
 )
 from arbeitszeit_web.www.presenters.request_cooperation_presenter import (
     RequestCooperationPresenter,
+)
+from arbeitszeit_web.www.presenters.revoke_plan_filing_presenter import (
+    RevokePlanFilingPresenter,
 )
 from arbeitszeit_web.www.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
@@ -367,6 +374,20 @@ def my_plans(
         "company/my_plans.html",
         context=view_model.to_dict(),
     )
+
+
+@CompanyRoute("/company/plan/revoke/<uuid:plan_id>", methods=["POST"])
+@commit_changes
+def revoke_plan_filing(
+    plan_id: UUID,
+    controller: RevokePlanFilingController,
+    use_case: RevokePlanFilingUseCase,
+    presenter: RevokePlanFilingPresenter,
+):
+    request = controller.create_request(plan_id=plan_id)
+    response = use_case.revoke_plan_filing(request=request)
+    presenter.present(response)
+    return redirect(url_for("main_company.my_plans"))
 
 
 @CompanyRoute("/company/toggle_availability/<uuid:plan_id>", methods=["GET"])

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -120,7 +120,9 @@ class Plan(db.Model):
 class PlanReview(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     approval_date = db.Column(db.DateTime, nullable=True, default=None)
-    plan_id = db.Column(db.String, db.ForeignKey("plan.id"), nullable=False)
+    plan_id = db.Column(
+        db.String, db.ForeignKey("plan.id", ondelete="CASCADE"), nullable=False
+    )
 
     plan = db.relationship("Plan", back_populates="review")
 

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -325,7 +325,7 @@ class PlanQueryResult(FlaskQueryResult[records.Plan]):
         )
 
     def delete(self) -> None:
-        raise NotImplementedError()
+        self.query.delete()
 
     def update(self) -> PlanUpdate:
         return PlanUpdate(

--- a/arbeitszeit_flask/migrations/versions/e25cf496eef3_add_on_delete_cascade_on_plan_review_.py
+++ b/arbeitszeit_flask/migrations/versions/e25cf496eef3_add_on_delete_cascade_on_plan_review_.py
@@ -1,0 +1,27 @@
+"""add on delete cascade on plan_review fkey
+
+Revision ID: e25cf496eef3
+Revises: c56e8291e74d
+Create Date: 2023-09-21 19:18:00.762149
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e25cf496eef3'
+down_revision = 'c56e8291e74d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('plan_review', schema=None) as batch_op:
+        batch_op.drop_constraint('plan_review_plan_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key('plan_review_plan_id_fkey', 'plan', ['plan_id'], ['id'], ondelete='CASCADE')
+
+def downgrade():
+    with op.batch_alter_table('plan_review', schema=None) as batch_op:
+        batch_op.drop_constraint('plan_review_plan_id_fkey', type_='foreignkey')
+        batch_op.create_foreign_key('plan_review_plan_id_fkey', 'plan', ['plan_id'], ['id'])

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -64,6 +64,7 @@
           <th>{{ gettext("Costs")}}</th>
           <th>{{ gettext("Type")}}</th>
           <th>{{ gettext("Plan created")}}</th>
+          <th>{{ gettext("Revoke") }}</th>
         </tr>
       </thead>
       <tbody>
@@ -73,6 +74,16 @@
           <td>{{ plan.price_per_unit }}</td>
           <td>{{ plan.type_of_plan }}</td>
           <td>{{ plan.plan_creation_date }}</td>
+          <td><form method="post" action="{{ plan.revoke_plan_filing_url }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button class="button is-ghost" type="submit" title="{{ gettext('Revoke plan filing') }}">
+            <i class="fas fa-times"></i>
+          </button>
+          </form>
+          </td>
+
+          
+          
         </tr>
         {% endfor %}
       </tbody>

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -168,6 +168,9 @@ class GeneralUrlIndex:
     def get_file_plan_url(self, draft_id: UUID) -> str:
         return url_for("main_company.file_plan", draft_id=draft_id)
 
+    def get_revoke_plan_filing_url(self, plan_id: UUID) -> str:
+        return url_for("main_company.revoke_plan_filing", plan_id=plan_id)
+
     def get_unreviewed_plans_list_view_url(self) -> str:
         return url_for("main_accountant.list_plans_with_pending_review")
 

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -111,6 +111,9 @@ class UrlIndex(Protocol):
     def get_file_plan_url(self, draft_id: UUID) -> str:
         ...
 
+    def get_revoke_plan_filing_url(self, plan_id: UUID) -> str:
+        ...
+
     def get_unreviewed_plans_list_view_url(self) -> str:
         ...
 

--- a/arbeitszeit_web/www/controllers/revoke_plan_filing_controller.py
+++ b/arbeitszeit_web/www/controllers/revoke_plan_filing_controller.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.use_cases.revoke_plan_filing import RevokePlanFilingUseCase
+from arbeitszeit_web.session import Session
+
+
+@dataclass
+class RevokePlanFilingController:
+    session: Session
+
+    def create_request(self, plan_id: UUID) -> RevokePlanFilingUseCase.Request:
+        requester = self.session.get_current_user()
+        assert requester
+        return RevokePlanFilingUseCase.Request(plan=plan_id, requester=requester)

--- a/arbeitszeit_web/www/presenters/revoke_plan_filing_presenter.py
+++ b/arbeitszeit_web/www/presenters/revoke_plan_filing_presenter.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.revoke_plan_filing import RevokePlanFilingUseCase
+from arbeitszeit_web.translator import Translator
+
+from ...notification import Notifier
+
+
+@dataclass
+class RevokePlanFilingPresenter:
+    notifier: Notifier
+    translator: Translator
+
+    def present(self, use_case_response: RevokePlanFilingUseCase.Response) -> None:
+        if use_case_response.is_rejected:
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "Unexpected error: Not possible to revoke plan filing."
+                )
+            )
+        else:
+            self.notifier.display_info(
+                self.translator.gettext("Filing of plan has been successfully revoked.")
+            )

--- a/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
@@ -40,6 +40,7 @@ class NonActivePlansRow:
     price_per_unit: str
     type_of_plan: str
     plan_creation_date: str
+    revoke_plan_filing_url: str
 
 
 @dataclass
@@ -151,6 +152,9 @@ class ShowMyPlansPresenter:
                     price_per_unit=self.__format_price(plan.price_per_unit),
                     type_of_plan=self.__get_type_of_plan(plan.is_public_service),
                     plan_creation_date=self.__format_date(plan.plan_creation_date),
+                    revoke_plan_filing_url=self.url_index.get_revoke_plan_filing_url(
+                        plan.id
+                    ),
                 )
                 for plan in response.non_active_plans
             ],

--- a/tests/flask_integration/flask.py
+++ b/tests/flask_integration/flask.py
@@ -15,6 +15,7 @@ from tests.data_generators import (
     CompanyGenerator,
     EmailGenerator,
     MemberGenerator,
+    PlanGenerator,
 )
 from tests.markers import database_required
 
@@ -61,6 +62,7 @@ class ViewTestCase(FlaskTestCase):
         self.company_generator = self.injector.get(CompanyGenerator)
         self.email_generator = self.injector.get(EmailGenerator)
         self.accountant_generator = self.injector.get(AccountantGenerator)
+        self.plan_generator = self.injector.get(PlanGenerator)
 
     def login_member(
         self,

--- a/tests/flask_integration/test_revoke_plan_filing_view.py
+++ b/tests/flask_integration/test_revoke_plan_filing_view.py
@@ -1,0 +1,18 @@
+from uuid import uuid4
+
+from .flask import ViewTestCase
+
+
+class CompanyViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+
+    def test_revoke_existing_plan_as_company_results_in_302_status_code(self) -> None:
+        plan = self.plan_generator.create_plan(approved=False)
+        response = self.client.post(f"/company/plan/revoke/{plan.id}")
+        self.assertEqual(response.status_code, 302)
+
+    def test_revoke_unexisting_plan_as_company_results_in_302_status_code(self) -> None:
+        response = self.client.post(f"/company/plan/revoke/{uuid4()}")
+        self.assertEqual(response.status_code, 302)

--- a/tests/www/controllers/test_revoke_plan_filing_controller.py
+++ b/tests/www/controllers/test_revoke_plan_filing_controller.py
@@ -1,0 +1,23 @@
+from uuid import uuid4
+
+from arbeitszeit_web.www.controllers.revoke_plan_filing_controller import (
+    RevokePlanFilingController,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class RevokePlanFilingControllerTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(RevokePlanFilingController)
+        self.requester = uuid4()
+        self.session.login_company(company=self.requester)
+
+    def test_id_of_the_plan_to_revoke_gets_passed_to_response_object(self) -> None:
+        expected_id = uuid4()
+        use_case_request = self.controller.create_request(plan_id=expected_id)
+        assert use_case_request.plan == expected_id
+
+    def test_the_requester_id_gets_passed_to_response_object(self) -> None:
+        use_case_request = self.controller.create_request(plan_id=uuid4())
+        assert use_case_request.requester == self.requester

--- a/tests/www/presenters/test_revoke_plan_filing_presenter.py
+++ b/tests/www/presenters/test_revoke_plan_filing_presenter.py
@@ -1,0 +1,36 @@
+from uuid import uuid4
+
+from arbeitszeit.use_cases.revoke_plan_filing import RevokePlanFilingUseCase
+from arbeitszeit_web.www.presenters.revoke_plan_filing_presenter import (
+    RevokePlanFilingPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class RevokePlanFilingPresenterTest(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(RevokePlanFilingPresenter)
+
+    def test_warning_is_displayed_when_revoking_failed(self) -> None:
+        response = self.get_use_case_response(rejected=True)
+        self.presenter.present(use_case_response=response)
+        assert self.notifier.warnings
+
+    def test_info_message_is_displayed_when_revoking_succeeded(self) -> None:
+        response = self.get_use_case_response(rejected=False)
+        self.presenter.present(use_case_response=response)
+        assert self.notifier.infos
+
+    def get_use_case_response(
+        self, *, rejected: bool
+    ) -> RevokePlanFilingUseCase.Response:
+        if rejected:
+            return RevokePlanFilingUseCase.Response(
+                plan_draft=None,
+                rejection_reason=RevokePlanFilingUseCase.Response.RejectionReason.plan_not_found,
+            )
+        else:
+            return RevokePlanFilingUseCase.Response(
+                plan_draft=uuid4(), rejection_reason=None
+            )

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -149,6 +149,16 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         )
         self.assertEqual(row1.type_of_plan, self.translator.gettext("Productive"))
 
+    def test_non_active_plan_has_correct_revocation_url(self) -> None:
+        plan = self.plan_generator.create_plan(approved=False)
+        use_case_response = self.response_with_one_non_active_plan(plan)
+        view_model = self.presenter.present(use_case_response)
+        row = view_model.non_active_plans.rows[0]
+        self.assertEqual(
+            row.revoke_plan_filing_url,
+            self.url_index.get_revoke_plan_filing_url(plan.id),
+        )
+
     def test_that_relative_expiration_is_calculated_correctly(self) -> None:
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
         plan = self._create_active_plan(timeframe=5)

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -61,6 +61,7 @@ class UrlIndexTestImpl:
     get_accountant_dashboard_url = UrlIndexMethod()
     get_my_plans_url = UrlIndexMethod()
     get_file_plan_url = UrlIndexMethod()
+    get_revoke_plan_filing_url = UrlIndexMethod()
     get_unreviewed_plans_list_view_url = UrlIndexMethod()
     get_approve_plan_url = UrlIndexMethod()
     get_my_plan_drafts_url = UrlIndexMethod()


### PR DESCRIPTION
fixes #812

This commit provides the missing web implementation for companies to revoke a filed plan. The plan to revoke gets deleted and a new plan draft with the same attributes gets created. When the plan gets deleted, the associated plan review in the database gets deleted, as well.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea (6x)