### PR TITLE
Refactor email sending logic when company requests cooperation

### DIFF
--- a/arbeitszeit/email_notifications.py
+++ b/arbeitszeit/email_notifications.py
@@ -43,15 +43,23 @@ class EmailChangeConfirmation:
     new_email_address: str
 
 
+@dataclass
+class CooperationRequestEmail:
+    coordinator_email_address: str
+    coordinator_name: str
+
+
 # This type definition can be used by implementations of the
-# EmailSender protocol for static type checking purposes.
+# EmailSender protocol for static type checking purposes. Keep this
+# list alphabetically sorted.
 Message: TypeAlias = Union[
-    MemberRegistration,
-    CompanyRegistration,
-    AccountantNotificationAboutNewPlan,
     AccountantInvitation,
-    WorkerInvitation,
+    AccountantNotificationAboutNewPlan,
+    CompanyRegistration,
+    CooperationRequestEmail,
     EmailChangeConfirmation,
+    MemberRegistration,
+    WorkerInvitation,
 ]
 # Implementations can rely on this set to contain all possible message
 # types.

--- a/arbeitszeit/use_cases/request_cooperation.py
+++ b/arbeitszeit/use_cases/request_cooperation.py
@@ -4,6 +4,7 @@ from typing import Optional, Tuple
 from uuid import UUID
 
 from arbeitszeit.datetime_service import DatetimeService
+from arbeitszeit.email_notifications import CooperationRequestEmail, EmailSender
 from arbeitszeit.records import Company, EmailAddress
 from arbeitszeit.repositories import DatabaseGateway
 
@@ -39,6 +40,7 @@ class RequestCooperationResponse:
 class RequestCooperation:
     database_gateway: DatabaseGateway
     datetime_service: DatetimeService
+    email_sender: EmailSender
 
     def __call__(
         self, request: RequestCooperationRequest
@@ -49,6 +51,12 @@ class RequestCooperation:
             return RequestCooperationResponse(
                 coordinator_name=None, coordinator_email=None, rejection_reason=reason
             )
+        self.email_sender.send_email(
+            CooperationRequestEmail(
+                coordinator_email_address=email.address,
+                coordinator_name=coordinator.name,
+            )
+        )
         self.database_gateway.get_plans().with_id(
             request.plan_id
         ).update().set_requested_cooperation(request.cooperation_id).perform()

--- a/arbeitszeit_web/email/cooperation_request_email_presenter.py
+++ b/arbeitszeit_web/email/cooperation_request_email_presenter.py
@@ -1,0 +1,24 @@
+from dataclasses import dataclass
+from html import escape
+
+from arbeitszeit.email_notifications import CooperationRequestEmail
+from arbeitszeit_web.email import EmailConfiguration, MailService
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class CooperationRequestEmailPresenter:
+    translator: Translator
+    mail_service: MailService
+    email_configuration: EmailConfiguration
+
+    def present(self, email: CooperationRequestEmail) -> None:
+        self.mail_service.send_message(
+            subject=self.translator.gettext("A company requests cooperation"),
+            recipients=[email.coordinator_email_address],
+            html=self.translator.gettext(
+                "Hello %(coordinator)s,<br>A company wants to be part of a cooperation that you are coordinating. Please check the request in the Arbeitszeitapp."
+            )
+            % dict(coordinator=escape(email.coordinator_name)),
+            sender=self.email_configuration.get_sender_address(),
+        )

--- a/arbeitszeit_web/email/email_sender.py
+++ b/arbeitszeit_web/email/email_sender.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from arbeitszeit import email_notifications as interface
 
 from .accountant_invitation_presenter import AccountantInvitationEmailPresenter
+from .cooperation_request_email_presenter import CooperationRequestEmailPresenter
 from .invite_worker_presenter import InviteWorkerPresenterImpl
 from .notify_accountant_about_new_plan_presenter import (
     NotifyAccountantsAboutNewPlanPresenterImpl,
@@ -16,6 +17,7 @@ class EmailSender:
     notify_accountants_about_new_plan: NotifyAccountantsAboutNewPlanPresenterImpl
     accountant_invitation_presenter: AccountantInvitationEmailPresenter
     invite_worker_presenter: InviteWorkerPresenterImpl
+    request_cooperation_presenter: CooperationRequestEmailPresenter
 
     def send_email(self, message: interface.Message) -> None:
         if isinstance(message, interface.MemberRegistration):
@@ -39,5 +41,7 @@ class EmailSender:
                 worker_email=message.worker_email,
                 invite=message.invite,
             )
+        elif isinstance(message, interface.CooperationRequestEmail):
+            self.request_cooperation_presenter.present(message)
         elif isinstance(message, interface.EmailChangeConfirmation):
             raise NotImplementedError()

--- a/tests/email.py
+++ b/tests/email.py
@@ -14,7 +14,7 @@ class Email:
 
 
 @singleton
-class FakeEmailSender:
+class FakeEmailService:
     def __init__(self) -> None:
         self.sent_mails: List[Email] = []
 

--- a/tests/email_presenters/test_cooperation_request_email_presenter.py
+++ b/tests/email_presenters/test_cooperation_request_email_presenter.py
@@ -1,0 +1,51 @@
+from typing import Optional
+
+from arbeitszeit import email_notifications
+from arbeitszeit_web.email.cooperation_request_email_presenter import (
+    CooperationRequestEmailPresenter,
+)
+from tests.email import FakeEmailService
+from tests.www.base_test_case import BaseTestCase
+
+
+class CooperationRequestEmailPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(CooperationRequestEmailPresenter)
+        self.mail_service = self.injector.get(FakeEmailService)
+
+    def test_mail_gets_sent_if_request_was_successful(self) -> None:
+        self.presenter.present(self.create_email())
+        self.assertTrue(self.mail_service.sent_mails)
+
+    def test_mail_gets_sent_to_coordinator_if_request_was_successful(self) -> None:
+        recipient = "company@comp.any"
+        self.presenter.present(self.create_email(coordinator_mail=recipient))
+        self.assertEqual(self.mail_service.sent_mails[0].recipients, [recipient])
+
+    def test_mail_gets_sent_and_subject_and_html_body_are_not_empty(self) -> None:
+        self.presenter.present(self.create_email())
+        self.assertTrue(self.mail_service.sent_mails[0].subject)
+        self.assertTrue(self.mail_service.sent_mails[0].html)
+
+    def test_mail_html_body_has_name_of_coordinator_safely_escaped(self) -> None:
+        coordinator_name = '<a href="dangerous site">coordinator</a>'
+        self.presenter.present(self.create_email(coordinator_name=coordinator_name))
+        self.assertIn(
+            "&lt;a href=&quot;dangerous site&quot;&gt;coordinator&lt;/a&gt;",
+            self.mail_service.sent_mails[0].html,
+        )
+
+    def create_email(
+        self,
+        coordinator_mail: Optional[str] = None,
+        coordinator_name: Optional[str] = None,
+    ) -> email_notifications.CooperationRequestEmail:
+        if coordinator_mail is None:
+            coordinator_mail = "company@comp.any"
+        if coordinator_name is None:
+            coordinator_name = "company xy"
+        return email_notifications.CooperationRequestEmail(
+            coordinator_name=coordinator_name,
+            coordinator_email_address=coordinator_mail,
+        )

--- a/tests/email_presenters/test_email_sender_impl.py
+++ b/tests/email_presenters/test_email_sender_impl.py
@@ -1,0 +1,19 @@
+from arbeitszeit.email_notifications import CooperationRequestEmail
+from arbeitszeit_web.email.email_sender import EmailSender
+from tests.www.base_test_case import BaseTestCase
+
+
+class EmailSenderImplTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.email_sender_impl = self.injector.get(EmailSender)
+
+    def test(self) -> None:
+        email_sent_before = len(self.email_service.sent_mails)
+        self.email_sender_impl.send_email(
+            CooperationRequestEmail(
+                coordinator_email_address="test@test.test",
+                coordinator_name="test name",
+            )
+        )
+        assert email_sent_before + 1 == len(self.email_service.sent_mails)

--- a/tests/email_presenters/test_invite_worker_mail_presenter.py
+++ b/tests/email_presenters/test_invite_worker_mail_presenter.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from arbeitszeit_web.email.invite_worker_presenter import InviteWorkerPresenterImpl
-from tests.email import FakeEmailConfiguration, FakeEmailSender
+from tests.email import FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.www.base_test_case import BaseTestCase
 
@@ -10,7 +10,6 @@ class SendMailTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(InviteWorkerPresenterImpl)
-        self.email_service = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
         self.text_renderer = self.injector.get(TextRendererImpl)
 

--- a/tests/email_presenters/test_notify_accountant_about_new_plan_presenter.py
+++ b/tests/email_presenters/test_notify_accountant_about_new_plan_presenter.py
@@ -4,7 +4,7 @@ from arbeitszeit.email_notifications import AccountantNotificationAboutNewPlan
 from arbeitszeit_web.email.notify_accountant_about_new_plan_presenter import (
     NotifyAccountantsAboutNewPlanPresenterImpl,
 )
-from tests.email import FakeAddressBook, FakeEmailConfiguration, FakeEmailSender
+from tests.email import FakeAddressBook, FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.www.base_test_case import BaseTestCase
 
@@ -15,7 +15,6 @@ class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(NotifyAccountantsAboutNewPlanPresenterImpl)
-        self.email_sender = self.injector.get(FakeEmailSender)
         self.address_book = self.injector.get(FakeAddressBook)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
         self.text_renderer = self.injector.get(TextRendererImpl)
@@ -25,7 +24,7 @@ class PresenterTests(BaseTestCase):
             product_name="test product", plan_id=uuid4(), accountant_id=uuid4()
         )
         self.presenter.notify_accountant_about_new_plan(notification)
-        assert self.email_sender.sent_mails
+        assert self.email_service.sent_mails
 
     def test_that_email_gets_sent_to_correct_address(self) -> None:
         user = uuid4()
@@ -35,7 +34,7 @@ class PresenterTests(BaseTestCase):
         self.presenter.notify_accountant_about_new_plan(notification)
         assert (
             self.address_book.get_user_email_address(user)
-            in self.email_sender.sent_mails[0].recipients
+            in self.email_service.sent_mails[0].recipients
         )
 
     def test_that_email_gets_sent_to_only_one_recipient(self) -> None:
@@ -43,7 +42,7 @@ class PresenterTests(BaseTestCase):
             product_name="test product", plan_id=uuid4(), accountant_id=uuid4()
         )
         self.presenter.notify_accountant_about_new_plan(notification)
-        assert len(self.email_sender.sent_mails[0].recipients) == 1
+        assert len(self.email_service.sent_mails[0].recipients) == 1
 
     def test_that_no_email_gets_sent_if_user_email_address_cannot_be_retrieved(
         self,
@@ -56,14 +55,14 @@ class PresenterTests(BaseTestCase):
             accountant_id=user,
         )
         self.presenter.notify_accountant_about_new_plan(notification)
-        assert not self.email_sender.sent_mails
+        assert not self.email_service.sent_mails
 
     def test_that_subject_line_is_correct(self) -> None:
         notification = Notification(
             product_name="test product", plan_id=uuid4(), accountant_id=uuid4()
         )
         self.presenter.notify_accountant_about_new_plan(notification)
-        assert self.email_sender.sent_mails[0].subject == self.translator.gettext(
+        assert self.email_service.sent_mails[0].subject == self.translator.gettext(
             "Plan was filed"
         )
 
@@ -73,7 +72,7 @@ class PresenterTests(BaseTestCase):
         )
         self.presenter.notify_accountant_about_new_plan(notification)
         assert (
-            self.email_sender.sent_mails[0].sender
+            self.email_service.sent_mails[0].sender
             == self.email_configuration.get_sender_address()
         )
 
@@ -82,7 +81,7 @@ class PresenterTests(BaseTestCase):
             product_name="test product", plan_id=uuid4(), accountant_id=uuid4()
         )
         self.presenter.notify_accountant_about_new_plan(notification)
-        assert self.email_sender.sent_mails[
+        assert self.email_service.sent_mails[
             0
         ].html == self.text_renderer.render_accountant_notification_about_new_plan(
             product_name="test product",

--- a/tests/email_presenters/test_registration_email_presenter.py
+++ b/tests/email_presenters/test_registration_email_presenter.py
@@ -4,7 +4,7 @@ from arbeitszeit_web.email.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
 from tests.datetime_service import FakeDatetimeService
-from tests.email import Email, FakeEmailConfiguration, FakeEmailSender
+from tests.email import Email, FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.token import FakeTokenService
 from tests.www.base_test_case import BaseTestCase
@@ -13,7 +13,6 @@ from tests.www.base_test_case import BaseTestCase
 class MemberPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.email_sender = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
         self.presenter = self.injector.get(RegistrationEmailPresenter)
         self.text_renderer = self.injector.get(TextRendererImpl)
@@ -23,7 +22,7 @@ class MemberPresenterTests(BaseTestCase):
 
     def test_that_some_email_is_sent_out(self) -> None:
         self.presenter.show_member_registration_message(self.email_address)
-        self.assertTrue(self.email_sender.sent_mails)
+        self.assertTrue(self.email_service.sent_mails)
 
     def test_that_email_is_sent_to_exactly_one_recipient(self) -> None:
         self.presenter.show_member_registration_message(self.email_address)
@@ -60,13 +59,12 @@ class MemberPresenterTests(BaseTestCase):
         self.assertEqual(email.subject, self.translator.gettext("Account confirmation"))
 
     def get_sent_email(self) -> Email:
-        return self.email_sender.sent_mails[0]
+        return self.email_service.sent_mails[0]
 
 
 class CompanyPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.email_sender = self.injector.get(FakeEmailSender)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
         self.presenter = self.injector.get(RegistrationEmailPresenter)
         self.text_renderer = self.injector.get(TextRendererImpl)
@@ -76,7 +74,7 @@ class CompanyPresenterTests(BaseTestCase):
 
     def test_that_some_email_is_sent_out(self) -> None:
         self.presenter.show_company_registration_message(self.email_address)
-        self.assertTrue(self.email_sender.sent_mails)
+        self.assertTrue(self.email_service.sent_mails)
 
     def test_that_email_is_sent_to_exactly_one_recipient(self) -> None:
         self.presenter.show_company_registration_message(self.email_address)
@@ -113,4 +111,4 @@ class CompanyPresenterTests(BaseTestCase):
         self.assertEqual(email.subject, self.translator.gettext("Account confirmation"))
 
     def get_sent_email(self) -> Email:
-        return self.email_sender.sent_mails[0]
+        return self.email_service.sent_mails[0]

--- a/tests/www/base_test_case.py
+++ b/tests/www/base_test_case.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Generic, Type, TypeVar
 from unittest import TestCase
 
 from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
+from tests.email import FakeEmailService
 from tests.session import FakeSession
 from tests.translator import FakeTranslator
 from tests.www.presenters.notifier import NotifierTestImpl
@@ -54,8 +55,9 @@ class BaseTestCase(TestCase):
     # alphabetically
     accountant_generator = _lazy_property(AccountantGenerator)
     company_generator = _lazy_property(CompanyGenerator)
+    email_service = _lazy_property(FakeEmailService)
     member_generator = _lazy_property(MemberGenerator)
     notifier = _lazy_property(NotifierTestImpl)
     session = _lazy_property(FakeSession)
-    url_index = _lazy_property(UrlIndexTestImpl)
     translator = _lazy_property(FakeTranslator)
+    url_index = _lazy_property(UrlIndexTestImpl)

--- a/tests/www/dependency_injection.py
+++ b/tests/www/dependency_injection.py
@@ -15,7 +15,7 @@ from arbeitszeit_web.url_index import (
     UrlIndex,
 )
 from tests.dependency_injection import TestingModule
-from tests.email import FakeEmailConfiguration, FakeEmailSender
+from tests.email import FakeEmailConfiguration, FakeEmailService
 from tests.email_presenters.accountant_invitation_email_view import (
     AccountantInvitationEmailViewImpl,
 )
@@ -50,7 +50,7 @@ class WwwTestsInjector(Module):
         binder[Request] = AliasProvider(FakeRequest)
         binder[LanguageChangerUrlIndex] = AliasProvider(LanguageChangerUrlIndexImpl)
         binder[LanguageService] = AliasProvider(FakeLanguageService)
-        binder[MailService] = AliasProvider(FakeEmailSender)
+        binder[MailService] = AliasProvider(FakeEmailService)
         binder[RenewPlanUrlIndex] = AliasProvider(RenewPlanUrlIndexTestImpl)
         binder[HidePlanUrlIndex] = AliasProvider(HidePlanUrlIndexTestImpl)
 


### PR DESCRIPTION
This change entirely concerns the RequestCooperation use case. The goal of this change was to preserve the current behavior of the application and instead make the source code more managable/legile.

Before this change the code was set up such that the RequestCooperationPresenter was responsible for sending a notification email to the cooperations coordinator while generating the http respons for the requester. This is confusing/unexpected since all other email notifications are sent out explicitly via a trigger in the appropriate use case object.

This change moves the trigger for sending an email to the coordinator of a cooperation part of the use case object.

As part of this change some minor refactoring was also done to the test logic. The FakeEmailSender was renamed to FakeEmailService since it is an implementation of the EmailService interface and not the EmailSender interface.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf