### PR TITLE
Create button to copy plan id to clipboard

### DIFF
--- a/arbeitszeit_flask/static/main.js
+++ b/arbeitszeit_flask/static/main.js
@@ -64,3 +64,8 @@ document.addEventListener('DOMContentLoaded', () => {
   function copyTextToClipboard(text) {
     navigator.clipboard.writeText(text);
   }
+
+  function changeElementIconToCheckIcon(elementId) {
+    let element = document.getElementById(elementId); 
+    element.classList.toggle("fa-check");
+  }

--- a/arbeitszeit_flask/templates/macros/plan_details.html
+++ b/arbeitszeit_flask/templates/macros/plan_details.html
@@ -15,8 +15,11 @@
                                 <p class="title is-4">{{ view_model.details.plan_id[0] }}</p>
                                 <p class="subtitle">
                                     {{ view_model.details.plan_id[1] }}&nbsp;
-                                    <a  role="button" onclick="copyTextToClipboard('{{ view_model.details.plan_id[1] }}')">
-                                        <span class="icon"><i class="fa-regular fa-copy"></i></span>
+                                    <a  
+                                    role="button" 
+                                    onclick="copyTextToClipboard('{{ view_model.details.plan_id[1] }}'); 
+                                    changeElementIconToCheckIcon('changeableIcon')">
+                                        <span class="icon"><i id="changeableIcon" class="fa-regular fa-copy"></i></span>
                                     </a>
                                 </p>
                             </article>


### PR DESCRIPTION
fixes #414

**new javascript func copyTextToClipboard** 

The new function is added to `main.js` file. The function is implemented in plan_details.html to make copying the plan id easier.

**Change icon when copying to clipboard** 

The "copy" icon changes to "check" after copying the plan id to the clipboard. Implemented in the plan details page. This signals to the user that copying succeeded.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea (2x)