### PR TITLE
Change flask's prefered url schema in dev to http

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -428,6 +428,20 @@ how to set this up locally.  The benefit of this for you is that you
 can avoid building dependencies that are already built once in the 
 continuous integration (CI) pipeline.
 
+Invite Accountants
+-------------------
+
+When manually filing plans in the development environment, you need 
+at least one accountant to approve these files. You can invite 
+accountants from the terminal, using the following command:
+
+  .. code-block:: bash
+
+   flask invite-accountant example@mail.de
+
+An invitation mail will be printed to ``stdout`` containing an invite link.
+
+
 Web API
 --------
 

--- a/arbeitszeit_flask/development_settings.py
+++ b/arbeitszeit_flask/development_settings.py
@@ -1,5 +1,6 @@
-from os import environ, path
+from os import environ
 
+PREFERRED_URL_SCHEME = "http"
 DEBUG_DETAILS = environ.get("DEBUG_DETAILS") in ("true", "True", "1", "t")
 TESTING = True
 SQLALCHEMY_DATABASE_URI = environ.get("DEV_DATABASE_URI")


### PR DESCRIPTION
fixes #827 
fixes #829 

With this change, urls generated via `url_for` outside of request contexts are rendered with "http" url scheme in development environment. Before, the sent invite urls for accountants could not be followed in dev environment. Moreover, a section has been added to the README, explaining how to invite accountants.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea