### PR TITLE
Update development dependencies

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -3,7 +3,7 @@ alembic==1.9.4
 aniso8601==9.0.1
 attrs==23.1.0
 Babel==2.12.1
-black==23.3.0
+black==23.9.1
 blinker==1.5
 Brotli==1.0.9
 brotlicffi==1.0.9
@@ -27,7 +27,7 @@ flask-babel==3.1.0
 Flask-HTTPAuth==4.8.0
 Flask-Login==0.6.2
 Flask-Mail==0.9.1
-Flask-Migrate==4.0.4
+Flask-Migrate==4.0.5
 flask-restx==1.1.0
 Flask-SQLAlchemy==3.0.3
 flask-talisman==1.1.0
@@ -61,7 +61,7 @@ parameterized==0.9.0
 pathspec==0.11.0
 pbr==5.11.1
 Pillow==10.0.0
-pip==23.0.1
+pip==23.2.1
 platformdirs==3.9.1
 pluggy==1.2.0
 psycopg2==2.9.5
@@ -95,7 +95,7 @@ sphinxcontrib-websupport==1.2.4
 SQLAlchemy==2.0.19
 tomli==2.0.1
 types-python-dateutil==2.8.19
-types-pytz==2023.3.0
+types-pytz==2023.3.1
 typing_extensions==4.7.1
 urllib3==1.26.16
 watchdog==3.0.0

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixos-23-05": {
       "locked": {
-        "lastModified": 1694048570,
-        "narHash": "sha256-PEQptwFCVaJ+jLFJgrZll2shQ9VI/7xVhrCYkJo8iIw=",
+        "lastModified": 1695272228,
+        "narHash": "sha256-4uw2OdJPVyjdB+xcDst9SecrNIpxKXJ2usN3M5HVa7o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4f77ea639305f1de0a14d9d41eef83313360638c",
+        "rev": "55ac2a9d2024f15c56adf20da505b29659911da8",
         "type": "github"
       },
       "original": {
@@ -89,11 +89,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1694062546,
-        "narHash": "sha256-PiGI4f2BGnZcedP6slLjCLGLRLXPa9+ogGGgVPfGxys=",
+        "lastModified": 1695318763,
+        "narHash": "sha256-FHVPDRP2AfvsxAdc+AsgFJevMz5VBmnZglFUMlxBkcY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b200e0df08f80c32974a6108ce431d8a8a5e6547",
+        "rev": "e12483116b3b51a185a33a272bf351e357ba9a99",
         "type": "github"
       },
       "original": {

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -10,6 +10,7 @@ mkShell {
     types-dateutil
     types-pytz
     coverage
+    pip
   ]) ++ [ nixfmt sqlite ]
     ++ python3.pkgs.arbeitszeitapp.optional-dependencies.profiling;
   inputsFrom = [ python3.pkgs.arbeitszeitapp ];


### PR DESCRIPTION
This change updates the nix and pip managed dependencies. The changeset was generated via `python -m
arbeitszeitapp_development.update_depencies`. Also `pip` was explicitly added to the development environment since with the latest update it was not part of the default python environment anymore.

No registration of consumption needed.