### PR TITLE
Implement EmailChangeConfirmation presenter

### DIFF
--- a/arbeitszeit_web/email/email_change_confirmation_presenter.py
+++ b/arbeitszeit_web/email/email_change_confirmation_presenter.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+
+from arbeitszeit import email_notifications
+from arbeitszeit_web.email import EmailConfiguration, MailService
+from arbeitszeit_web.text_renderer import TextRenderer
+from arbeitszeit_web.token import TokenService
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class EmailChangeConfirmationPresenter:
+    email_service: MailService
+    token_service: TokenService
+    text_renderer: TextRenderer
+    url_index: UrlIndex
+    translator: Translator
+    email_configuration: EmailConfiguration
+
+    def present_email_change_confirmation(
+        self, email_change_confirmation: email_notifications.EmailChangeConfirmation
+    ) -> None:
+        self.email_service.send_message(
+            subject=self.translator.gettext("Email address change requested"),
+            sender=self.email_configuration.get_sender_address(),
+            html=self.text_renderer.render_email_change_notification(
+                change_email_url=self.url_index.get_change_email_url(
+                    token=self.token_service.generate_token(
+                        "{old_email}:{new_email}".format(
+                            old_email=email_change_confirmation.old_email_address,
+                            new_email=email_change_confirmation.new_email_address,
+                        )
+                    )
+                )
+            ),
+            recipients=[email_change_confirmation.new_email_address],
+        )

--- a/arbeitszeit_web/email/email_sender.py
+++ b/arbeitszeit_web/email/email_sender.py
@@ -4,6 +4,7 @@ from arbeitszeit import email_notifications as interface
 
 from .accountant_invitation_presenter import AccountantInvitationEmailPresenter
 from .cooperation_request_email_presenter import CooperationRequestEmailPresenter
+from .email_change_confirmation_presenter import EmailChangeConfirmationPresenter
 from .invite_worker_presenter import InviteWorkerPresenterImpl
 from .notify_accountant_about_new_plan_presenter import (
     NotifyAccountantsAboutNewPlanPresenterImpl,
@@ -18,6 +19,7 @@ class EmailSender:
     accountant_invitation_presenter: AccountantInvitationEmailPresenter
     invite_worker_presenter: InviteWorkerPresenterImpl
     request_cooperation_presenter: CooperationRequestEmailPresenter
+    email_change_confirmation_presenter: EmailChangeConfirmationPresenter
 
     def send_email(self, message: interface.Message) -> None:
         if isinstance(message, interface.MemberRegistration):
@@ -44,4 +46,6 @@ class EmailSender:
         elif isinstance(message, interface.CooperationRequestEmail):
             self.request_cooperation_presenter.present(message)
         elif isinstance(message, interface.EmailChangeConfirmation):
-            raise NotImplementedError()
+            self.email_change_confirmation_presenter.present_email_change_confirmation(
+                message
+            )

--- a/arbeitszeit_web/text_renderer.py
+++ b/arbeitszeit_web/text_renderer.py
@@ -17,3 +17,6 @@ class TextRenderer(Protocol):
         self, *, invitation_url: str
     ) -> str:
         ...
+
+    def render_email_change_notification(self, *, change_email_url: str) -> str:
+        ...

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -159,6 +159,9 @@ class UrlIndex(Protocol):
     def get_accountant_account_details_url(self) -> str:
         ...
 
+    def get_change_email_url(self, *, token: str) -> str:
+        ...
+
 
 class RenewPlanUrlIndex(Protocol):
     def get_renew_plan_url(self, plan_id: UUID) -> str:

--- a/tests/email_presenters/test_accountant_invitation_presenter.py
+++ b/tests/email_presenters/test_accountant_invitation_presenter.py
@@ -5,7 +5,6 @@ from arbeitszeit_web.email.accountant_invitation_presenter import (
     AccountantInvitationEmailPresenter,
     ViewModel,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.email import FakeEmailConfiguration
 from tests.token import FakeTokenService
 from tests.www.base_test_case import BaseTestCase
@@ -23,7 +22,6 @@ class PresenterTests(BaseTestCase):
         self.accountant_invitation_url_index = self.injector.get(
             AccountantInvitationUrlIndexImpl
         )
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.token_service = self.injector.get(FakeTokenService)
 
     def test_that_token_recipient_is_also_mail_recipient(self) -> None:

--- a/tests/email_presenters/test_email_change_confirmation_presenter.py
+++ b/tests/email_presenters/test_email_change_confirmation_presenter.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+
+from parameterized import parameterized
+
+from arbeitszeit import email_notifications
+from arbeitszeit_web.email.email_change_confirmation_presenter import (
+    EmailChangeConfirmationPresenter,
+)
+from tests.email import FakeEmailConfiguration
+from tests.text_renderer import TextRendererImpl
+from tests.token import FakeTokenService
+from tests.www.base_test_case import BaseTestCase
+
+
+class EmailChangeConfirmationPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(EmailChangeConfirmationPresenter)
+        self.text_renderer = self.injector.get(TextRendererImpl)
+        self.token_service = self.injector.get(FakeTokenService)
+        self.email_configuration = self.injector.get(FakeEmailConfiguration)
+
+    def test_that_one_email_is_sent_when_presenting(self) -> None:
+        self.presenter.present_email_change_confirmation(
+            self.create_email_change_confirmation()
+        )
+        assert len(self.email_service.sent_mails) == 1
+
+    @parameterized.expand(
+        [
+            ("test@test.test",),
+            ("other@test.test",),
+        ]
+    )
+    def test_that_latest_email_was_sent_to_new_email_address(
+        self, expected_email_address: str
+    ) -> None:
+        self.presenter.present_email_change_confirmation(
+            self.create_email_change_confirmation(
+                new_email_address=expected_email_address
+            )
+        )
+        assert self.email_service.sent_mails[-1].recipients == [expected_email_address]
+
+    def test_that_the_content_of_the_mail_is_rendered_correctly(self) -> None:
+        old_email = "test@test.test"
+        new_email = "new@test.test"
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        self.presenter.present_email_change_confirmation(
+            self.create_email_change_confirmation(
+                new_email_address=new_email,
+                old_email_address=old_email,
+            )
+        )
+        assert self.email_service.sent_mails[
+            -1
+        ].html == self.text_renderer.render_email_change_notification(
+            change_email_url=self.url_index.get_change_email_url(
+                token=self.token_service.generate_token(f"{old_email}:{new_email}")
+            )
+        )
+
+    def test_that_the_subject_line_of_the_sent_mail_is_correct(self) -> None:
+        expected_subject = self.translator.gettext("Email address change requested")
+        self.presenter.present_email_change_confirmation(
+            self.create_email_change_confirmation()
+        )
+        assert self.email_service.sent_mails[-1].subject == expected_subject
+
+    def test_that_sender_is_the_default_one(self) -> None:
+        self.presenter.present_email_change_confirmation(
+            self.create_email_change_confirmation()
+        )
+        assert (
+            self.email_service.sent_mails[-1].sender
+            == self.email_configuration.get_sender_address()
+        )
+
+    def create_email_change_confirmation(
+        self,
+        new_email_address: str = "new@test.test",
+        old_email_address: str = "old@test.test",
+    ) -> email_notifications.EmailChangeConfirmation:
+        return email_notifications.EmailChangeConfirmation(
+            old_email_address=old_email_address,
+            new_email_address=new_email_address,
+        )

--- a/tests/email_presenters/test_email_sender_impl.py
+++ b/tests/email_presenters/test_email_sender_impl.py
@@ -1,4 +1,10 @@
-from arbeitszeit.email_notifications import CooperationRequestEmail
+from parameterized import parameterized
+
+from arbeitszeit.email_notifications import (
+    CooperationRequestEmail,
+    EmailChangeConfirmation,
+    Message,
+)
 from arbeitszeit_web.email.email_sender import EmailSender
 from tests.www.base_test_case import BaseTestCase
 
@@ -8,12 +14,25 @@ class EmailSenderImplTests(BaseTestCase):
         super().setUp()
         self.email_sender_impl = self.injector.get(EmailSender)
 
-    def test(self) -> None:
+    @parameterized.expand(
+        [
+            (
+                CooperationRequestEmail(
+                    coordinator_email_address="test@test.test",
+                    coordinator_name="test name",
+                ),
+            ),
+            (
+                EmailChangeConfirmation(
+                    old_email_address="test@test.test",
+                    new_email_address="test@test.test",
+                ),
+            ),
+        ]
+    )
+    def test_that_email_is_sent_via_mail_service_with_different_message_types(
+        self, message: Message
+    ) -> None:
         email_sent_before = len(self.email_service.sent_mails)
-        self.email_sender_impl.send_email(
-            CooperationRequestEmail(
-                coordinator_email_address="test@test.test",
-                coordinator_name="test name",
-            )
-        )
+        self.email_sender_impl.send_email(message)
         assert email_sent_before + 1 == len(self.email_service.sent_mails)

--- a/tests/email_presenters/test_registration_email_presenter.py
+++ b/tests/email_presenters/test_registration_email_presenter.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from arbeitszeit_web.email.registration_email_presenter import (
     RegistrationEmailPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.email import Email, FakeEmailConfiguration
 from tests.text_renderer import TextRendererImpl
 from tests.token import FakeTokenService
@@ -18,7 +17,6 @@ class MemberPresenterTests(BaseTestCase):
         self.text_renderer = self.injector.get(TextRendererImpl)
         self.email_address = "test@test.test"
         self.token_service = self.injector.get(FakeTokenService)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_some_email_is_sent_out(self) -> None:
         self.presenter.show_member_registration_message(self.email_address)
@@ -70,7 +68,6 @@ class CompanyPresenterTests(BaseTestCase):
         self.text_renderer = self.injector.get(TextRendererImpl)
         self.email_address = "test@test.test"
         self.token_service = self.injector.get(FakeTokenService)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_some_email_is_sent_out(self) -> None:
         self.presenter.show_company_registration_message(self.email_address)

--- a/tests/text_renderer.py
+++ b/tests/text_renderer.py
@@ -21,3 +21,4 @@ class TextRendererImpl:
     render_company_registration_message = RenderMethod()
     render_accountant_notification_about_new_plan = RenderMethod()
     render_member_notfication_about_work_invitation = RenderMethod()
+    render_email_change_notification = RenderMethod()

--- a/tests/www/base_test_case.py
+++ b/tests/www/base_test_case.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, Generic, Type, TypeVar
 from unittest import TestCase
 
 from tests.data_generators import AccountantGenerator, CompanyGenerator, MemberGenerator
+from tests.datetime_service import FakeDatetimeService
 from tests.email import FakeEmailService
 from tests.session import FakeSession
 from tests.translator import FakeTranslator
@@ -55,6 +56,7 @@ class BaseTestCase(TestCase):
     # alphabetically
     accountant_generator = _lazy_property(AccountantGenerator)
     company_generator = _lazy_property(CompanyGenerator)
+    datetime_service = _lazy_property(FakeDatetimeService)
     email_service = _lazy_property(FakeEmailService)
     member_generator = _lazy_property(MemberGenerator)
     notifier = _lazy_property(NotifierTestImpl)

--- a/tests/www/controllers/test_confirm_company_controller.py
+++ b/tests/www/controllers/test_confirm_company_controller.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from arbeitszeit_web.www.controllers.confirm_company_controller import (
     ConfirmCompanyController,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.token import FakeTokenService
 from tests.www.base_test_case import BaseTestCase
 
@@ -13,7 +12,6 @@ class ConfirmCompanyControllerTests(BaseTestCase):
         super().setUp()
         self.controller = self.injector.get(ConfirmCompanyController)
         self.token_service = self.injector.get(FakeTokenService)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_no_request_is_yielded_if_token_is_a_random_string(self) -> None:
         assert self.controller.process_request(token="random string 123") is None

--- a/tests/www/controllers/test_confirm_member_controller.py
+++ b/tests/www/controllers/test_confirm_member_controller.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from arbeitszeit_web.www.controllers.confirm_member_controller import (
     ConfirmMemberController,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.token import FakeTokenService
 from tests.www.base_test_case import BaseTestCase
 
@@ -13,7 +12,6 @@ class ConfirmMemberControllerTests(BaseTestCase):
         super().setUp()
         self.controller = self.injector.get(ConfirmMemberController)
         self.token_service = self.injector.get(FakeTokenService)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_invalid_token_yields_no_use_case_request(self) -> None:
         assert self.controller.process_request(token="testtoken 123") is None

--- a/tests/www/presenters/test_company_consumptions_presenter.py
+++ b/tests/www/presenters/test_company_consumptions_presenter.py
@@ -12,7 +12,6 @@ from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
     ViewModel,
 )
 from tests.data_generators import ConsumptionGenerator
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -21,7 +20,6 @@ class TestPresenter(BaseTestCase):
         super().setUp()
         self.query_consumptions = self.injector.get(QueryCompanyConsumptions)
         self.consumption_generator = self.injector.get(ConsumptionGenerator)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(CompanyConsumptionsPresenter)
 
     def test_show_consumptions_from_company(self) -> None:
@@ -54,7 +52,7 @@ class TestPresenter(BaseTestCase):
 
         assert presentation.consumptions[
             0
-        ].consumption_date == FakeDatetimeService().format_datetime(
+        ].consumption_date == self.datetime_service.format_datetime(
             now, zone="Europe/Berlin"
         )
         assert presentation.consumptions[0].product_name == "Produkt A"
@@ -71,7 +69,7 @@ class TestPresenter(BaseTestCase):
 
         assert presentation.consumptions[
             1
-        ].consumption_date == FakeDatetimeService().format_datetime(
+        ].consumption_date == self.datetime_service.format_datetime(
             now, zone="Europe/Berlin"
         )
         assert presentation.consumptions[1].product_name == "Produkt A"

--- a/tests/www/presenters/test_get_company_dashboard_presenter.py
+++ b/tests/www/presenters/test_get_company_dashboard_presenter.py
@@ -7,7 +7,6 @@ from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.get_company_dashboard_presenter import (
     GetCompanyDashboardPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.url_index import UrlIndexTestImpl
 
@@ -16,7 +15,6 @@ class TestPresenter(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetCompanyDashboardPresenter)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.plan_index = self.injector.get(UrlIndexTestImpl)
 
     def test_presenter_successfully_presents_a_use_case_response(self):

--- a/tests/www/presenters/test_get_company_transactions.py
+++ b/tests/www/presenters/test_get_company_transactions.py
@@ -13,7 +13,6 @@ from arbeitszeit.use_cases.get_company_transactions import (
 from arbeitszeit_web.www.presenters.get_company_transactions_presenter import (
     GetCompanyTransactionsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -21,7 +20,6 @@ class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(GetCompanyTransactionsPresenter)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_return_empty_list_when_no_transactions_took_place(self):
         response = GetCompanyTransactionsResponse(transactions=[])

--- a/tests/www/presenters/test_get_member_account_presenter.py
+++ b/tests/www/presenters/test_get_member_account_presenter.py
@@ -10,14 +10,12 @@ from arbeitszeit.use_cases.get_member_account import (
 from arbeitszeit_web.www.presenters.get_member_account_presenter import (
     GetMemberAccountPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 
 class TestPresenter(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(GetMemberAccountPresenter)
 
     def test_that_empty_transaction_list_is_shown_if_no_transactions_took_place(

--- a/tests/www/presenters/test_get_statistics_presenter.py
+++ b/tests/www/presenters/test_get_statistics_presenter.py
@@ -5,7 +5,6 @@ from arbeitszeit.use_cases.get_statistics import StatisticsResponse
 from arbeitszeit_web.www.presenters.get_statistics_presenter import (
     GetStatisticsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 TESTING_RESPONSE_MODEL = StatisticsResponse(
@@ -27,7 +26,6 @@ TESTING_RESPONSE_MODEL = StatisticsResponse(
 class GetStatisticsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(GetStatisticsPresenter)
 
     def test_planned_resources_hours_are_truncated_at_2_digits_after_comma(

--- a/tests/www/presenters/test_plan_details_formatter.py
+++ b/tests/www/presenters/test_plan_details_formatter.py
@@ -3,7 +3,6 @@ from uuid import uuid4
 
 from arbeitszeit_web.formatters.plan_details_formatter import PlanDetailsFormatter
 from arbeitszeit_web.session import UserRole
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 from tests.www.presenters.data_generators import PlanDetailsGenerator
 
@@ -14,7 +13,6 @@ class PlanDetailsFormatterTests(BaseTestCase):
         self.formatter = self.injector.get(PlanDetailsFormatter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.plan_details = self.plan_details_generator.create_plan_details()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.session.login_company(company=uuid4())
 
     def test_plan_id_is_displayed_correctly_as_tuple_of_strings(self):

--- a/tests/www/presenters/test_private_consumptions_presenter.py
+++ b/tests/www/presenters/test_private_consumptions_presenter.py
@@ -9,7 +9,6 @@ from arbeitszeit.use_cases.query_private_consumptions import (
 from arbeitszeit_web.www.presenters.private_consumptions_presenter import (
     PrivateConsumptionsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -17,7 +16,6 @@ class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(PrivateConsumptionsPresenter)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
 
     def test_that_date_is_formatted_properly(self) -> None:
         response = self.create_response_with_one_consumption(

--- a/tests/www/presenters/test_show_a_account_details_presenter.py
+++ b/tests/www/presenters/test_show_a_account_details_presenter.py
@@ -8,7 +8,6 @@ from arbeitszeit.use_cases.show_a_account_details import ShowAAccountDetailsUseC
 from arbeitszeit_web.www.presenters.show_a_account_details_presenter import (
     ShowAAccountDetailsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = ShowAAccountDetailsUseCase.TransactionInfo(
@@ -29,7 +28,6 @@ DEFAULT_INFO2 = ShowAAccountDetailsUseCase.TransactionInfo(
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowAAccountDetailsPresenter)
 
     def test_return_empty_list_when_no_transactions_took_place(self):

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -12,7 +12,6 @@ from arbeitszeit.use_cases.show_my_plans import (
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPresenter
 from tests.data_generators import CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 from .url_index import HidePlanUrlIndexTestImpl, RenewPlanUrlIndexTestImpl
@@ -26,7 +25,6 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.presenter = self.injector.get(ShowMyPlansPresenter)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.coop_generator = self.injector.get(CooperationGenerator)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.session.login_company(uuid4())
         self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
         self.datetime_service.freeze_time(datetime(2000, 1, 1))

--- a/tests/www/presenters/test_show_p_account_details.py
+++ b/tests/www/presenters/test_show_p_account_details.py
@@ -8,7 +8,6 @@ from arbeitszeit.use_cases.show_p_account_details import ShowPAccountDetailsUseC
 from arbeitszeit_web.www.presenters.show_p_account_details_presenter import (
     ShowPAccountDetailsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 DEFAULT_INFO1 = ShowPAccountDetailsUseCase.TransactionInfo(
@@ -29,7 +28,6 @@ DEFAULT_INFO2 = ShowPAccountDetailsUseCase.TransactionInfo(
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowPAccountDetailsPresenter)
 
     def test_return_empty_list_when_no_transactions_took_place(self):

--- a/tests/www/presenters/test_show_prd_account_details_presenter.py
+++ b/tests/www/presenters/test_show_prd_account_details_presenter.py
@@ -8,14 +8,12 @@ from arbeitszeit.use_cases.show_prd_account_details import ShowPRDAccountDetails
 from arbeitszeit_web.www.presenters.show_prd_account_details_presenter import (
     ShowPRDAccountDetailsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.www.base_test_case import BaseTestCase
 
 
 class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowPRDAccountDetailsPresenter)
 
     def test_return_empty_list_when_no_transactions_took_place(self):

--- a/tests/www/presenters/test_show_r_account_details.py
+++ b/tests/www/presenters/test_show_r_account_details.py
@@ -8,7 +8,6 @@ from arbeitszeit.use_cases.show_r_account_details import ShowRAccountDetailsUseC
 from arbeitszeit_web.www.presenters.show_r_account_details_presenter import (
     ShowRAccountDetailsPresenter,
 )
-from tests.datetime_service import FakeDatetimeService
 from tests.translator import FakeTranslator
 from tests.www.base_test_case import BaseTestCase
 
@@ -31,7 +30,6 @@ class CompanyTransactionsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.trans = self.injector.get(FakeTranslator)
-        self.datetime_service = self.injector.get(FakeDatetimeService)
         self.presenter = self.injector.get(ShowRAccountDetailsPresenter)
 
     def test_return_empty_list_when_no_transactions_took_place(self):

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -74,6 +74,7 @@ class UrlIndexTestImpl:
     get_member_account_details_url = UrlIndexMethod()
     get_company_account_details_url = UrlIndexMethod()
     get_accountant_account_details_url = UrlIndexMethod()
+    get_change_email_url = UrlIndexMethod()
 
     def get_member_confirmation_url(self, *, token: str) -> str:
         return f"get_member_confirmation_url {token}"


### PR DESCRIPTION
This change implements a rudimentary presenter for email change notifications. This functionality is not yet integrated into the application since multiple pieces of this remain to be implemented.

The test implementation is not ideal since we interrogate the email content via its expected implementation. Therefore the tests for email content are expected to be quite fragile/break often.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)