### PR TITLE
Cooperation summary: add planner of plans

### DIFF
--- a/arbeitszeit/use_cases/get_coop_summary.py
+++ b/arbeitszeit/use_cases/get_coop_summary.py
@@ -20,6 +20,8 @@ class AssociatedPlan:
     plan_name: str
     plan_individual_price: Decimal
     plan_coop_price: Decimal
+    planner_id: UUID
+    planner_name: str
 
 
 @dataclass
@@ -63,6 +65,8 @@ class GetCoopSummary:
                 if not plan.is_public_service
                 else Decimal(0),
                 plan_coop_price=self.price_calculator.calculate_cooperative_price(plan),
+                planner_id=plan.planner,
+                planner_name=self._get_planner_name(plan.planner),
             )
             for plan in self.database_gateway.get_plans()
             .that_are_part_of_cooperation(request.coop_id)
@@ -77,3 +81,8 @@ class GetCoopSummary:
             current_coordinator_name=coordinator.name,
             plans=plans,
         )
+
+    def _get_planner_name(self, planner_id: UUID) -> str:
+        planner = self.database_gateway.get_companies().with_id(planner_id).first()
+        assert planner
+        return planner.name

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -38,6 +38,7 @@
             <thead>
                 <tr>
                     <th>{{ gettext("Plan") }}</th>
+                    <th>{{ gettext("Planner") }}</th>
                     <th>{{ gettext("Individual price") }}</th>
                     <th>{{ gettext("Cooperation price") }}</th>
                     {% if view_model.show_end_coop_button %}
@@ -49,6 +50,7 @@
                 {% for plan in view_model.plans %}
                 <tr>
                     <td><a href="{{ plan.plan_url }}">{{ plan.plan_name }}</a></td>
+                    <td><a href="{{ plan.planner_url }}">{{ plan.planner_name }}</a></td>
                     <td>{{ plan.plan_individual_price }}</td>
                     <td>{{ plan.plan_coop_price }}</td>
                     {% if view_model.show_end_coop_button %}

--- a/tests/www/presenters/test_get_coop_summary_presenter.py
+++ b/tests/www/presenters/test_get_coop_summary_presenter.py
@@ -22,6 +22,8 @@ TESTING_RESPONSE_MODEL = GetCoopSummarySuccess(
             plan_name="plan_name",
             plan_individual_price=Decimal("1"),
             plan_coop_price=Decimal(50.005),
+            planner_id=uuid4(),
+            planner_name="A Cooperating Company Coop.",
         )
     ],
 )
@@ -108,5 +110,24 @@ class GetCoopSummarySuccessPresenterTests(BaseTestCase):
             self.url_index.get_end_coop_url(
                 plan_id=TESTING_RESPONSE_MODEL.plans[0].plan_id,
                 cooperation_id=TESTING_RESPONSE_MODEL.coop_id,
+            ),
+        )
+
+    def test_first_plans_planner_name_is_displayed_correctly(self):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertEqual(
+            view_model.plans[0].planner_name,
+            "A Cooperating Company Coop.",
+        )
+
+    def test_url_to_first_plans_planner_company_summary_page_is_displayed_correctly(
+        self,
+    ):
+        view_model = self.presenter.present(TESTING_RESPONSE_MODEL)
+        self.assertEqual(
+            view_model.plans[0].planner_url,
+            self.url_index.get_company_summary_url(
+                user_role=UserRole.company,
+                company_id=TESTING_RESPONSE_MODEL.plans[0].planner_id,
             ),
         )


### PR DESCRIPTION
This commit adds a column "planner" to the table of participating plans of a cooperation on the "cooperation_summary"-page. Fixes #833

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea