### PR TITLE
Coop summary: show "end coop" buttons

### DIFF
--- a/arbeitszeit/use_cases/get_coop_summary.py
+++ b/arbeitszeit/use_cases/get_coop_summary.py
@@ -22,6 +22,7 @@ class AssociatedPlan:
     plan_individual_price: Decimal
     planner_id: UUID
     planner_name: str
+    requester_is_planner: bool
 
 
 @dataclass
@@ -71,7 +72,7 @@ class GetCoopSummary:
             current_coordinator=coordinator.id,
             current_coordinator_name=coordinator.name,
             coop_price=self._get_cooperative_price(plans),
-            plans=self._get_associated_plans(plans),
+            plans=self._get_associated_plans(plans, request.requester_id),
         )
 
     def _get_planner_name(self, planner_id: UUID) -> str:
@@ -85,7 +86,9 @@ class GetCoopSummary:
         coop_price = calculate_average_costs(plans=[p.to_summary() for p in plans])
         return coop_price
 
-    def _get_associated_plans(self, plans: list[Plan]) -> list[AssociatedPlan]:
+    def _get_associated_plans(
+        self, plans: list[Plan], requester: UUID
+    ) -> list[AssociatedPlan]:
         return [
             AssociatedPlan(
                 plan_id=plan.id,
@@ -95,6 +98,7 @@ class GetCoopSummary:
                 ),
                 planner_id=plan.planner,
                 planner_name=self._get_planner_name(plan.planner),
+                requester_is_planner=plan.planner == requester,
             )
             for plan in plans
         ]

--- a/arbeitszeit_flask/templates/macros/coop_summary.html
+++ b/arbeitszeit_flask/templates/macros/coop_summary.html
@@ -57,7 +57,7 @@
                         </p>
                     </div>
                     <div>
-                        {% if view_model.show_end_coop_button %}
+                        {% if plan.show_end_coop_button %}
                         <a class="button is-small is-danger" href="{{ plan.end_coop_url }}">
                             <span class="icon">
                                 <i class="fas fa-times"></i>

--- a/arbeitszeit_web/www/presenters/get_coop_summary_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_coop_summary_presenter.py
@@ -16,11 +16,11 @@ class AssociatedPlan:
     end_coop_url: str
     planner_name: str
     planner_url: str
+    show_end_coop_button: bool
 
 
 @dataclass
 class GetCoopSummaryViewModel:
-    show_end_coop_button: bool
     coop_id: str
     coop_name: str
     coop_definition: List[str]
@@ -44,7 +44,6 @@ class GetCoopSummarySuccessPresenter:
     def present(self, response: GetCoopSummarySuccess) -> GetCoopSummaryViewModel:
         user_role = self.session.get_user_role()
         return GetCoopSummaryViewModel(
-            show_end_coop_button=response.requester_is_coordinator,
             coop_id=str(response.coop_id),
             coop_name=response.coop_name,
             coop_definition=response.coop_definition.splitlines(),
@@ -71,6 +70,8 @@ class GetCoopSummarySuccessPresenter:
                     planner_url=self.url_index.get_company_summary_url(
                         user_role=user_role, company_id=plan.planner_id
                     ),
+                    show_end_coop_button=response.requester_is_coordinator
+                    or plan.requester_is_planner,
                 )
                 for plan in response.plans
             ],

--- a/tests/use_cases/test_get_coop_summary.py
+++ b/tests/use_cases/test_get_coop_summary.py
@@ -213,3 +213,27 @@ class AssociatedPlansTests(BaseTestCase):
         response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].planner_name == expected_planner_name
+
+    def test_that_associated_plan_shows_that_planner_is_also_requester_of_coop_summary(
+        self,
+    ) -> None:
+        expected_planner = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=expected_planner)
+        coop = self.cooperation_generator.create_cooperation(plans=[plan])
+        response = self.get_coop_summary(
+            GetCoopSummaryRequest(requester_id=plan.planner, coop_id=coop.id)
+        )
+        assert isinstance(response, GetCoopSummarySuccess)
+        assert response.plans[0].requester_is_planner == True
+
+    def test_that_associated_plan_shows_that_planner_is_not_requester_of_coop_summary(
+        self,
+    ) -> None:
+        expected_planner = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=expected_planner)
+        coop = self.cooperation_generator.create_cooperation(plans=[plan])
+        response = self.get_coop_summary(
+            GetCoopSummaryRequest(requester_id=uuid4(), coop_id=coop.id)
+        )
+        assert isinstance(response, GetCoopSummarySuccess)
+        assert response.plans[0].requester_is_planner == False


### PR DESCRIPTION
After this commit, the "end cooperation" buttons in the associated plan list of the coop summary page are not only shown when the requester of the page is the coordinator of the cooperation, but also if it is the planner of the associated plan. Both should have the right to retrieve the plan from the cooperation. Also, the presenter tests have been refactored.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea (2x)

---

![image](https://github.com/arbeitszeit/arbeitszeitapp/assets/61537351/1240d6c1-53bd-4ce9-a68e-cb12e6492c00)
