### PR TITLE
Improve logging output for update_dependencies program

### DIFF
--- a/arbeitszeit_development/command.py
+++ b/arbeitszeit_development/command.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import shlex
+import subprocess
+from dataclasses import dataclass
+from logging import getLogger
+from typing import Optional, Protocol
+
+logger = getLogger(__name__)
+
+
+class SubprocessRunner(Protocol):
+    def run_command(self, command: Subprocess) -> CompletedProcess:
+        ...
+
+
+@dataclass
+class Subprocess:
+    command: list[str]
+    capture_output: bool = False
+    check: bool = True
+
+
+@dataclass
+class CompletedProcess:
+    return_code: int
+    stdout: Optional[str]
+    stderr: Optional[str]
+
+
+class Shell:
+    def run_command(self, command: Subprocess) -> CompletedProcess:
+        completed_process = subprocess.run(
+            command.command,
+            universal_newlines=True,
+            capture_output=command.capture_output,
+            check=command.check,
+        )
+        return CompletedProcess(
+            return_code=completed_process.returncode,
+            stdout=completed_process.stdout,
+            stderr=completed_process.stderr,
+        )
+
+
+@dataclass
+class LoggingSubprocessRunner:
+    def __init__(self, subprocess_runner: SubprocessRunner) -> None:
+        self.runner = subprocess_runner
+
+    def run_command(self, command: Subprocess) -> CompletedProcess:
+        logger.debug(
+            "Run command `%s`",
+            " ".join(shlex.quote(c) for c in command.command),
+        )
+        return self.runner.run_command(command)

--- a/arbeitszeit_development/generate_type_stubs.py
+++ b/arbeitszeit_development/generate_type_stubs.py
@@ -1,7 +1,8 @@
 import shutil
-import subprocess
 from logging import getLogger
 from typing import Generator, Iterable, TypeVar
+
+from .command import Shell, Subprocess, SubprocessRunner
 
 LOGGER = getLogger(__name__)
 
@@ -25,11 +26,13 @@ TARGET_PACKAGES = [
 T = TypeVar("T")
 
 
-def main():
+def main(subprocess_runner: SubprocessRunner):
     LOGGER.info("Update type stubs from dependencies")
     packages = list(flatten(["-p", package_name] for package_name in TARGET_PACKAGES))
     shutil.rmtree("type_stubs")
-    subprocess.run(["stubgen", "-o", "type_stubs"] + packages)
+    subprocess_runner.run_command(
+        Subprocess(command=["stubgen", "-o", "type_stubs"] + packages)
+    )
 
 
 def flatten(list_of_lists: Iterable[Iterable[T]]) -> Generator[T, None, None]:
@@ -38,4 +41,4 @@ def flatten(list_of_lists: Iterable[Iterable[T]]) -> Generator[T, None, None]:
 
 
 if __name__ == "__main__":
-    main()
+    main(subprocess_runner=Shell())

--- a/arbeitszeit_development/nix.py
+++ b/arbeitszeit_development/nix.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Optional
+
+from .command import CompletedProcess, Subprocess, SubprocessRunner
+
+
+@dataclass
+class NixFlake:
+    path: Path
+    subprocess_runner: SubprocessRunner
+
+    def shell(self, attribute: Optional[str] = None) -> NixShell:
+        return NixShell(
+            flake_path=self.path,
+            attribute=attribute,
+            subprocess_runner=self.subprocess_runner,
+        )
+
+
+@dataclass
+class NixShell:
+    flake_path: Path
+    attribute: Optional[str]
+    subprocess_runner: SubprocessRunner
+
+    def run_command(self, command: Subprocess) -> CompletedProcess:
+        installable = str(self.flake_path) + (
+            "#" + self.attribute if self.attribute else ""
+        )
+        command = replace(
+            command,
+            command=["nix", "develop", installable, "--command"] + command.command,
+        )
+        return self.subprocess_runner.run_command(command)

--- a/arbeitszeit_development/update_dependencies.py
+++ b/arbeitszeit_development/update_dependencies.py
@@ -1,53 +1,65 @@
-import subprocess
+import argparse
+import logging
+from dataclasses import dataclass
+from pathlib import Path
 
-from . import update_python_packages
+from arbeitszeit_development import generate_type_stubs
+
+from . import update_bulma, update_constraints, update_python_packages
+from .command import LoggingSubprocessRunner, Shell, Subprocess, SubprocessRunner
+from .nix import NixFlake
 
 
 def main() -> None:
-    update_flake()
-    update_bulma()
-    update_python_packages.main()
-    update_constraints()
-    generate_type_stubs()
+    shell = LoggingSubprocessRunner(Shell())
+    flake = NixFlake(path=Path(".").resolve(), subprocess_runner=shell)
+    development_shell = flake.shell()
+    update_flake(shell)
+    update_bulma.main()
+    update_python_packages.main(shell)
+    update_constraints.main(development_shell)
+    generate_type_stubs.main(development_shell)
 
 
-def update_flake() -> None:
-    subprocess.run(["nix", "flake", "update"], check=True)
-
-
-def update_bulma() -> None:
-    subprocess.run(
-        ["python", "-m", "arbeitszeit_development.update_bulma"],
-        check=True,
+def update_flake(subprocess_runner: SubprocessRunner) -> None:
+    subprocess_runner.run_command(
+        Subprocess(command=["nix", "flake", "update"], check=True)
     )
 
 
-def update_constraints() -> None:
-    subprocess.run(
-        [
-            "nix",
-            "develop",
-            "-c",
-            "python",
-            "-m",
-            "arbeitszeit_development.update_constraints",
-        ],
-        check=True,
-    )
+@dataclass
+class Options:
+    log_level: int
 
 
-def generate_type_stubs() -> None:
-    subprocess.run(
-        [
-            "nix",
-            "develop",
-            "-c",
-            "python",
-            "-m",
-            "arbeitszeit_development.generate_type_stubs",
-        ]
+def parse_arguments() -> Options:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--verbosity",
+        "-v",
+        help="Increase logging verbosity",
+        action="count",
+        default=0,
     )
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        help="Decrease logging verbosity",
+        action="count",
+        default=0,
+    )
+    args = parser.parse_args()
+    verbosity_level = args.verbosity - args.quiet
+    if verbosity_level < 0:
+        log_level = logging.WARNING
+    elif verbosity_level == 0:
+        log_level = logging.INFO
+    else:
+        log_level = logging.DEBUG
+    return Options(log_level=log_level)
 
 
 if __name__ == "__main__":
+    options = parse_arguments()
+    logging.basicConfig(level=options.log_level)
     main()


### PR DESCRIPTION
Previously the logging output of the mainenance program `arbeitszeit_development.update_dependencies` was fixed. The user was not able to control the amount of logging when running this program. With this change we introduced a `-v` flag to the program by which the user can increase the logging output. Currently the flag will change the output such that all subcommands being run are printed to stderr which should help to inform the user what is going on. This will be useful for debugging and understanding the program.

The previous design of this program made it hard to control the logging output globally since most of the subroutines involved in this program were run as separate subprocesses. This made it hard and inconvenient to globally control the logging in those subroutines. The design was changed such that all subroutines run as part of the main process. To achieve that we had to enable some subroutines to run the required command lines tools within the nix development shell. For this purpose we introduced the `SubprocessRunner` protocol.

The `SubprocessRunner` protocol allows clients to run arbitrary subprocesses. The runner objects themselves are responsible for constructing the approriate environment. This allows us to separate the commands that need to be run from the environment they are run in.

Plan-ID: a6a663c1-c041-4085-a627-c4f3395928bf (2x)