### PR TITLE
Reorganize github CI actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -3,7 +3,18 @@ name: Arbeitszeitapp CI Tests
 on: push
 
 jobs:
-  linux-nixos-unstable:
+  static-code-analysis:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v22
+    - uses: cachix/cachix-action@v12
+      with:
+        name: arbeitszeit
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - run: nix develop --command ./run-checks --no-unittests
+
+  flake-check:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -13,24 +24,6 @@ jobs:
         name: arbeitszeit
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix flake check --print-build-logs
-    - run: nix build --print-build-logs
-    - run: nix develop --command ./run-checks
-      env:
-        ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
-    services:
-      postgres:
-        image: postgres
-        env:
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
 
   check-migrations:
     runs-on: ubuntu-latest
@@ -64,30 +57,27 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-  linux-pip:
+  unittests-pip:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python 3.10
       uses: actions/setup-python@v4.5.0
       with:
-        python-version: '3.10.10'
+        python-version: '3.10'
         cache: 'pip'
-
     - name: Install dependencies
       run: |
         python -m venv ./venv && . ./venv/bin/activate
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-
-    - name: Test with ./run-checks
+    - name: Test
       run: |
         . ./venv/bin/activate
-        ./run-checks
+        pytest
         deactivate
       env:
         ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
-
     - name: Try build developer documentation
       run: |
         . ./venv/bin/activate
@@ -108,7 +98,10 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
-  linux-nixos-23-05:
+  unittests-nixpkgs:
+    strategy:
+      matrix:
+        devShell: [nixos-unstable, nixos-23-05]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -125,7 +118,7 @@ jobs:
     # running into these incompatibilities we simply don't run
     # them. As long as all the tests from `pytest` run successfully we
     # should be okay.
-    - run: nix develop .#nixos-23-05 --command pytest
+    - run: nix develop .#${{ matrix.devShell }} --command pytest
       env:
         ARBEITSZEITAPP_TEST_DB: postgresql://postgres:postgres@localhost:5432/postgres
     services:

--- a/flake.nix
+++ b/flake.nix
@@ -21,9 +21,10 @@
             overlays = [ self.overlays.default ];
           };
         in {
-          devShells = {
-            default = pkgs.callPackage nix/devShell.nix { };
+          devShells = rec {
+            default = nixos-unstable;
             nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
+            nixos-unstable = pkgs.callPackage nix/devShell.nix { };
           };
           packages = {
             default = pkgs.python3.pkgs.arbeitszeitapp;


### PR DESCRIPTION
### Reorganize CI jobs

The CI jobs were reorganized such that it is easier to recognize what
went wrong in case of an error. The following list explains briefly
the idea behind the jobs created.

static-code-analysis: There is one job specifically for static code
analysis, e.g. linting, mypy.

flake-check: Run all checks defined in flake.nix. This job build the
python package for all supported python interpreter versions.

check-migrations: Check if all required migrations for the DB schema
are present.

unittests-pip: Run the unittest with the required python packages
installed via pip and requirements.txt.

unittest-nixpkgs: Run all unittests with the system packages provided
by nixos-unstable and most recent stable release.

### Update github CI dependencies

This PR updates the github actions used in our CI. Specifically the
install-nix-action was updated from v18 to v22. Also the individual
jobs were renamed with more descriptive names.


### Plan-ID

 b412d2bb-074a-489b-86f6-90b87077c17a (2x)