### PR TITLE
Provide development shells with different supported python versions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -436,6 +436,19 @@ how to set this up locally.  The benefit of this for you is that you
 can avoid building dependencies that are already built once in the 
 continuous integration (CI) pipeline.
 
+Developing with different python versions
+-----------------------------------------
+
+You can access a development environment with any of the supported
+python versions via ``nix develop``. Check `flake.nix` for the
+supported environments under the key ``devShells``. For example to
+enter a development shell with ``python3.9`` set as the default
+interpreter run ``nix develop .#python39``. This will drop you into a
+shell with python3.9 as the default python interpreter. This won't
+change anything else on your machine and the respective python
+interpreter will be garbage collected the next time you run
+``nix-collect-garbage``.
+
 Invite Accountants
 -------------------
 

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,12 @@
             default = nixos-unstable;
             nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
             nixos-unstable = pkgs.callPackage nix/devShell.nix { };
+            python39 =
+              pkgs.callPackage nix/devShell.nix { python3 = pkgs.python39; };
+            python310 =
+              pkgs.callPackage nix/devShell.nix { python3 = pkgs.python310; };
+            python311 =
+              pkgs.callPackage nix/devShell.nix { python3 = pkgs.python311; };
           };
           packages = {
             default = pkgs.python3.pkgs.arbeitszeitapp;


### PR DESCRIPTION
Our nix flake setup now provided shells to the user with different versions of the python interpreter. The README now contains a section on how to access those development environments.