### PR TITLE
Work on listing coordinations of cooperation

### DIFF
--- a/arbeitszeit/use_cases/list_coordinations_of_cooperation.py
+++ b/arbeitszeit/use_cases/list_coordinations_of_cooperation.py
@@ -32,20 +32,21 @@ class ListCoordinationsOfCooperationUseCase:
         tenures_and_coordinators = list(
             self.database_gateway.get_coordination_tenures()
             .of_cooperation(request.cooperation)
+            .ordered_by_start_date(ascending=False)
             .joined_with_coordinator()
         )
-        tenures_and_coordinators.sort(key=lambda t: t[0].start_date, reverse=True)
         coordinations: list[CoordinationInfo] = []
-        for index, (tenure, coordinator) in enumerate(tenures_and_coordinators):
-            info = CoordinationInfo(
-                coordinator_id=coordinator.id,
-                coordinator_name=coordinator.name,
-                start_time=tenure.start_date,
-                end_time=None
-                if index == 0
-                else tenures_and_coordinators[index - 1][0].start_date,
+        end_timestamp = None
+        for tenure, coordinator in tenures_and_coordinators:
+            coordinations.append(
+                CoordinationInfo(
+                    coordinator_id=coordinator.id,
+                    coordinator_name=coordinator.name,
+                    start_time=tenure.start_date,
+                    end_time=end_timestamp,
+                )
             )
-            coordinations.append(info)
+            end_timestamp = tenure.start_date
         assert coordinations  # there cannot be a cooperation without at least one coordination_tenure
         cooperation = (
             self.database_gateway.get_cooperations()

--- a/tests/use_cases/test_list_coordinations_of_cooperation.py
+++ b/tests/use_cases/test_list_coordinations_of_cooperation.py
@@ -91,7 +91,47 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
         response = self.use_case.list_coordinations(
             self.create_use_case_request(coop=coop)
         )
+        assert len(response.coordinations) == 1
         assert response.coordinations[0].end_time is None
+
+    def test_that_first_coordination_of_two_in_response_has_no_end_time(
+        self,
+    ) -> None:
+        coop = self.cooperation_generator.create_cooperation()
+        self.coordination_tenure_generator.create_coordination_tenure(cooperation=coop)
+        response = self.use_case.list_coordinations(
+            self.create_use_case_request(coop=coop)
+        )
+        assert len(response.coordinations) == 2
+        assert response.coordinations[0].end_time is None
+
+    def test_that_second_coordination_of_two_in_response_has_correct_end_time(
+        self,
+    ) -> None:
+        first_timestamp = datetime(2021, 10, 5, 10)
+        self.datetime_service.freeze_time(first_timestamp)
+        coop = self.cooperation_generator.create_cooperation()
+        self.datetime_service.advance_time(timedelta(days=2))
+        self.coordination_tenure_generator.create_coordination_tenure(cooperation=coop)
+        response = self.use_case.list_coordinations(
+            self.create_use_case_request(coop=coop)
+        )
+        assert len(response.coordinations) == 2
+        assert response.coordinations[1].end_time == first_timestamp + timedelta(days=2)
+
+    def test_that_of_three_coordinations_only_the_first_in_response_has_no_end_time(
+        self,
+    ) -> None:
+        coop = self.cooperation_generator.create_cooperation()
+        self.coordination_tenure_generator.create_coordination_tenure(cooperation=coop)
+        self.coordination_tenure_generator.create_coordination_tenure(cooperation=coop)
+        response = self.use_case.list_coordinations(
+            self.create_use_case_request(coop=coop)
+        )
+        assert len(response.coordinations) == 3
+        assert response.coordinations[0].end_time is None
+        assert response.coordinations[1].end_time
+        assert response.coordinations[2].end_time
 
     def create_use_case_request(
         self, coop: UUID


### PR DESCRIPTION
These two small commits are preparational work for the upcoming web layer code of listing coordinations of cooperations.

**Add attr "end_time" to list of coordinators** 

The ListCoordinationsOfCooperationUseCase returned already the start_time of the coordination tenure, but not the end_time. The code in this commit calculates the end_time: The latest tenure in a cooperation has no end_time, the older coordination tenures have as their end_time the start_time of the more recent coordination tenure.

**Let ListCoordinations use case return coop info** 

The info on the coordination's cooperation will be shown on the list coordinations page.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea (2x)