### PR TITLE
Let Cooperation DataGenerator return UUID instead of record object

### DIFF
--- a/tests/flask_integration/database_gateway_impl/test_company_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_company_result.py
@@ -315,7 +315,7 @@ class ThatIsCoordinatingCooperationTests(FlaskTestCase):
         assert (
             not self.database_gateway.get_companies()
             .with_id(company)
-            .that_is_coordinating_cooperation(cooperation.id)
+            .that_is_coordinating_cooperation(cooperation)
         )
 
     def test_that_coordinator_is_included(self) -> None:
@@ -324,5 +324,5 @@ class ThatIsCoordinatingCooperationTests(FlaskTestCase):
         assert (
             self.database_gateway.get_companies()
             .with_id(company)
-            .that_is_coordinating_cooperation(cooperation.id)
+            .that_is_coordinating_cooperation(cooperation)
         )

--- a/tests/flask_integration/database_gateway_impl/test_cooperation_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_cooperation_result.py
@@ -103,7 +103,7 @@ class CoordinatedByCompanyTests(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         self.db_gateway.create_coordination_tenure(
             company=coordinator,
-            cooperation=cooperation.id,
+            cooperation=cooperation,
             start_date=datetime(2000, 1, 2),
         )
         cooperations = self.db_gateway.get_cooperations()
@@ -118,10 +118,10 @@ class CoordinatedByCompanyTests(FlaskTestCase):
         coop_2 = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         tenure_start_date = datetime(2000, 1, 2)
         self.db_gateway.create_coordination_tenure(
-            company=coordinator, cooperation=coop_1.id, start_date=tenure_start_date
+            company=coordinator, cooperation=coop_1, start_date=tenure_start_date
         )
         self.db_gateway.create_coordination_tenure(
-            company=coordinator, cooperation=coop_2.id, start_date=tenure_start_date
+            company=coordinator, cooperation=coop_2, start_date=tenure_start_date
         )
         assert (
             len(self.db_gateway.get_cooperations().coordinated_by_company(coordinator))
@@ -136,7 +136,7 @@ class CoordinatedByCompanyTests(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         self.db_gateway.create_coordination_tenure(
             company=coordinator,
-            cooperation=cooperation.id,
+            cooperation=cooperation,
             start_date=datetime(2000, 1, 1),
         )
         cooperations = self.db_gateway.get_cooperations()
@@ -163,7 +163,7 @@ class JoinedWithCurrentCoordinatorTests(FlaskTestCase):
         self.datetime_service.advance_time(timedelta(days=1))
         expected_coordination = self.db_gateway.create_coordination_tenure(
             company=coordinator_id,
-            cooperation=coop.id,
+            cooperation=coop,
             start_date=self.datetime_service.now(),
         )
         cooperations = self.db_gateway.get_cooperations()
@@ -189,7 +189,7 @@ class JoinedWithCurrentCoordinatorTests(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         self.db_gateway.create_coordination_tenure(
             company=new_coordinator,
-            cooperation=cooperation.id,
+            cooperation=cooperation,
             start_date=datetime(2000, 1, 2),
         )
         assert (

--- a/tests/flask_integration/database_gateway_impl/test_plan_results.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_results.py
@@ -365,7 +365,7 @@ class GetAllPlans(FlaskTestCase):
             requested_cooperation=other_coop
         )
         results = self.database_gateway.get_plans().with_open_cooperation_request(
-            cooperation=coop.id
+            cooperation=coop
         )
         assert plan_requesting_at_coop.id in [plan.id for plan in results]
         assert plan_requesting_at_other_coop.id not in [plan.id for plan in results]
@@ -414,7 +414,7 @@ class GetAllPlans(FlaskTestCase):
         self.plan_generator.create_plan(cooperation=cooperation1)
         self.plan_generator.create_plan(cooperation=cooperation2)
         plans = self.database_gateway.get_plans().that_are_part_of_cooperation(
-            cooperation1.id, cooperation2.id
+            cooperation1, cooperation2
         )
         assert len(plans) == 2
 
@@ -423,7 +423,7 @@ class GetAllPlans(FlaskTestCase):
         plan1 = self.plan_generator.create_plan(cooperation=coop)
         plan2 = self.plan_generator.create_plan(cooperation=coop)
         plan3 = self.plan_generator.create_plan(requested_cooperation=None)
-        plans = self.database_gateway.get_plans().that_are_part_of_cooperation(coop.id)
+        plans = self.database_gateway.get_plans().that_are_part_of_cooperation(coop)
         assert len(plans) == 2
         assert plans.with_id(plan1.id)
         assert plans.with_id(plan2.id)
@@ -432,7 +432,7 @@ class GetAllPlans(FlaskTestCase):
     def test_nothing_returned_when_no_plans_in_cooperation(self) -> None:
         coop = self.cooperation_generator.create_cooperation()
         self.plan_generator.create_plan(requested_cooperation=None)
-        plans = self.database_gateway.get_plans().that_are_part_of_cooperation(coop.id)
+        plans = self.database_gateway.get_plans().that_are_part_of_cooperation(coop)
         assert len(plans) == 0
 
     def test_possible_to_add_and_to_remove_plan_to_cooperation(self) -> None:
@@ -440,11 +440,11 @@ class GetAllPlans(FlaskTestCase):
         plan = self.plan_generator.create_plan()
 
         self.database_gateway.get_plans().with_id(plan.id).update().set_cooperation(
-            cooperation.id
+            cooperation
         ).perform()
         plan_from_orm = self.database_gateway.get_plans().with_id(plan.id).first()
         assert plan_from_orm
-        assert plan_from_orm.cooperation == cooperation.id
+        assert plan_from_orm.cooperation == cooperation
 
         self.database_gateway.get_plans().with_id(plan.id).update().set_cooperation(
             None
@@ -851,7 +851,7 @@ class ThatRequestCooperationWithCoordinatorTests(FlaskTestCase):
         cooperation = self.cooperation_generator.create_cooperation()
         plan = self.plan_generator.create_plan()
         plan_result = self.database_gateway.get_plans().with_id(plan.id)
-        plan_result.update().set_requested_cooperation(cooperation.id).perform()
+        plan_result.update().set_requested_cooperation(cooperation).perform()
         assert plan_result.that_request_cooperation_with_coordinator()
         plan_result.update().set_requested_cooperation(None).perform()
         assert not plan_result.that_request_cooperation_with_coordinator()
@@ -882,7 +882,7 @@ class ThatRequestCooperationWithCoordinatorTests(FlaskTestCase):
         self.datetime_service.advance_time(timedelta(days=1))
         self.database_gateway.create_coordination_tenure(
             company=new_coordinator,
-            cooperation=cooperation.id,
+            cooperation=cooperation,
             start_date=self.datetime_service.now(),
         )
         self.datetime_service.advance_time(timedelta(days=1))

--- a/tests/flask_integration/test_create_cooperation_view.py
+++ b/tests/flask_integration/test_create_cooperation_view.py
@@ -46,14 +46,15 @@ class AuthenticatedCompanyTests(ViewTestCase):
         )
 
     def test_returns_400_when_posting_already_existing_coop_name(self) -> None:
-        exiting_coop = self.cooperation_generator.create_cooperation()
+        name_of_existing_coop = "Existing Cooperation"
+        self.cooperation_generator.create_cooperation(name=name_of_existing_coop)
         self.assert_response_has_expected_code(
             method="post",
             url=self.url,
             login=LogInUser.company,
             expected_code=400,
             data={
-                "name": exiting_coop.name.title(),
+                "name": name_of_existing_coop,
                 "definition": "Coop definition",
             },
         )

--- a/tests/flask_integration/test_end_cooperation_view.py
+++ b/tests/flask_integration/test_end_cooperation_view.py
@@ -23,7 +23,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
         self,
     ) -> None:
         cooperation = self.cooperation_generator.create_cooperation()
-        url = f"/company/end_cooperation?plan_id={uuid4()}&cooperation_id={str(cooperation.id)}"
+        url = f"/company/end_cooperation?plan_id={uuid4()}&cooperation_id={str(cooperation)}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
@@ -42,7 +42,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
     ) -> None:
         plan = self.plan_generator.create_plan()
         cooperation = self.cooperation_generator.create_cooperation(plans=[plan])
-        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation.id)}"
+        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation)}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 404)
 
@@ -51,7 +51,7 @@ class AuthenticatedCompanyTests(ViewTestCase):
     ) -> None:
         plan = self.plan_generator.create_plan(planner=self.company.id)
         cooperation = self.cooperation_generator.create_cooperation(plans=[plan])
-        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation.id)}"
+        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation)}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 
@@ -62,6 +62,6 @@ class AuthenticatedCompanyTests(ViewTestCase):
         cooperation = self.cooperation_generator.create_cooperation(
             plans=[plan], coordinator=self.company
         )
-        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation.id)}"
+        url = f"/company/end_cooperation?plan_id={str(plan.id)}&cooperation_id={str(cooperation)}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)

--- a/tests/flask_integration/test_get_coop_summary.py
+++ b/tests/flask_integration/test_get_coop_summary.py
@@ -18,7 +18,7 @@ class AuthenticatedMemberTests(ViewTestCase):
 
     def test_get_200_when_coop_exists(self) -> None:
         coop = self.coop_generator.create_cooperation()
-        url = f"/member/cooperation_summary/{coop.id}"
+        url = f"/member/cooperation_summary/{coop}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -36,6 +36,6 @@ class AuthenticatedCompanyTests(ViewTestCase):
 
     def test_get_200_when_coop_exists(self) -> None:
         coop = self.coop_generator.create_cooperation()
-        url = f"/company/cooperation_summary/{coop.id}"
+        url = f"/company/cooperation_summary/{coop}"
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -173,7 +173,7 @@ class GeneralUrlIndexTests(ViewTestCase):
     ) -> None:
         self.login_company()
         coop = self.cooperation_generator.create_cooperation()
-        url = self.url_index.get_coop_summary_url(UserRole.company, coop.id)
+        url = self.url_index.get_coop_summary_url(UserRole.company, coop)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -182,7 +182,7 @@ class GeneralUrlIndexTests(ViewTestCase):
     ) -> None:
         self.login_member()
         coop = self.cooperation_generator.create_cooperation()
-        url = self.url_index.get_coop_summary_url(UserRole.member, coop.id)
+        url = self.url_index.get_coop_summary_url(UserRole.member, coop)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
@@ -302,7 +302,7 @@ class GeneralUrlIndexTests(ViewTestCase):
         coop = self.cooperation_generator.create_cooperation(
             coordinator=company, plans=[plan]
         )
-        url = self.url_index.get_end_coop_url(plan.id, coop.id)
+        url = self.url_index.get_end_coop_url(plan.id, coop)
         response = self.client.get(url)
         self.assertEqual(response.status_code, 302)
 

--- a/tests/services/test_plan_details_service.py
+++ b/tests/services/test_plan_details_service.py
@@ -125,7 +125,7 @@ class PlanDetailsServiceTests(TestCase):
         details = self.service.get_details_from_plan(plan.id)
         assert details
         self.assertTrue(details.is_cooperating)
-        self.assertEqual(details.cooperation, coop.id)
+        self.assertEqual(details.cooperation, coop)
 
     def test_that_zero_active_days_is_shown_if_plan_is_not_active_yet(self) -> None:
         plan = self.plan_generator.create_plan(approved=False)

--- a/tests/use_cases/base_test_case.py
+++ b/tests/use_cases/base_test_case.py
@@ -66,7 +66,6 @@ class BaseTestCase(TestCase):
     company_generator = _lazy_property(CompanyGenerator)
     consumption_generator = _lazy_property(ConsumptionGenerator)
     control_thresholds = _lazy_property(ControlThresholdsTestImpl)
-    coop_generator = _lazy_property(CooperationGenerator)
     cooperation_generator = _lazy_property(CooperationGenerator)
     coordination_tenure_generator = _lazy_property(CoordinationTenureGenerator)
     datetime_service = _lazy_property(FakeDatetimeService)

--- a/tests/use_cases/test_accept_cooperation.py
+++ b/tests/use_cases/test_accept_cooperation.py
@@ -24,7 +24,7 @@ class AcceptCooperationTests(BaseTestCase):
             coordinator=requester
         )
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=uuid4(), cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=uuid4(), cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert response.is_rejected
@@ -50,7 +50,7 @@ class AcceptCooperationTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(cooperation=cooperation1)
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation2.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation2
         )
         response = self.accept_cooperation(request)
         assert response.is_rejected
@@ -65,7 +65,7 @@ class AcceptCooperationTests(BaseTestCase):
             coordinator=requester
         )
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert response.is_rejected
@@ -80,7 +80,7 @@ class AcceptCooperationTests(BaseTestCase):
             coordinator=requester
         )
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert response.is_rejected
@@ -99,7 +99,7 @@ class AcceptCooperationTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert response.is_rejected
@@ -115,7 +115,7 @@ class AcceptCooperationTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert not response.is_rejected
@@ -127,11 +127,11 @@ class AcceptCooperationTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.accept_cooperation(request)
         assert not response.is_rejected
-        self.assert_plan_in_cooperation(plan.id, cooperation.id)
+        self.assert_plan_in_cooperation(plan.id, cooperation)
 
     def test_two_cooperating_plans_have_same_prices(self) -> None:
         requester = self.company_generator.create_company_record()
@@ -147,10 +147,10 @@ class AcceptCooperationTests(BaseTestCase):
             requested_cooperation=cooperation,
         )
         request1 = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation
         )
         request2 = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation
         )
         self.accept_cooperation(request1)
         self.accept_cooperation(request2)
@@ -174,10 +174,10 @@ class AcceptCooperationTests(BaseTestCase):
             requested_cooperation=cooperation,
         )
         request1 = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan1.id, cooperation_id=cooperation
         )
         request2 = AcceptCooperationRequest(
-            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation.id
+            requester_id=requester.id, plan_id=plan2.id, cooperation_id=cooperation
         )
         self.accept_cooperation(request1)
         self.accept_cooperation(request2)
@@ -195,7 +195,7 @@ class AcceptCooperationTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = AcceptCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         self.accept_cooperation(request)
         response = self.accept_cooperation(request)
@@ -211,7 +211,7 @@ class AcceptCooperationTests(BaseTestCase):
             requested_cooperation=cooperation, timeframe=1
         )
         request = AcceptCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         self.datetime_service.advance_time(timedelta(days=2))
         response = self.accept_cooperation(request)

--- a/tests/use_cases/test_cancel_cooperation_request.py
+++ b/tests/use_cases/test_cancel_cooperation_request.py
@@ -26,7 +26,7 @@ class UseCaseTests(BaseTestCase):
         assert response == False
 
     def test_that_true_is_returned_when_coop_request_gets_canceled(self) -> None:
-        coop = self.coop_generator.create_cooperation()
+        coop = self.cooperation_generator.create_cooperation()
         company = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(
             planner=company, requested_cooperation=coop

--- a/tests/use_cases/test_deny_cooperation.py
+++ b/tests/use_cases/test_deny_cooperation.py
@@ -26,7 +26,7 @@ class UseCaseTests(BaseTestCase):
             coordinator=requester
         )
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=uuid4(), cooperation_id=cooperation.id
+            requester_id=requester, plan_id=uuid4(), cooperation_id=cooperation
         )
         response = self.deny_cooperation(request)
         assert response.is_rejected
@@ -54,7 +54,7 @@ class UseCaseTests(BaseTestCase):
             coordinator=requester
         )
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.deny_cooperation(request)
         assert response.is_rejected
@@ -73,7 +73,7 @@ class UseCaseTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.deny_cooperation(request)
         assert response.is_rejected
@@ -89,7 +89,7 @@ class UseCaseTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.deny_cooperation(request)
         assert not response.is_rejected
@@ -103,11 +103,11 @@ class UseCaseTests(BaseTestCase):
         )
         plan = self.plan_generator.create_plan(requested_cooperation=cooperation)
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         self.deny_cooperation(request)
         request_request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         self.request_cooperation(request_request)
 
@@ -122,7 +122,7 @@ class UseCaseTests(BaseTestCase):
         )
         self.datetime_service.advance_time(timedelta(days=2))
         request = DenyCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.deny_cooperation(request)
         assert response.is_rejected

--- a/tests/use_cases/test_end_cooperation.py
+++ b/tests/use_cases/test_end_cooperation.py
@@ -25,7 +25,7 @@ class TestEndCooperation(TestCase):
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=uuid4(),
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert response.is_rejected
@@ -52,7 +52,7 @@ class TestEndCooperation(TestCase):
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert response.is_rejected
@@ -72,7 +72,7 @@ class TestEndCooperation(TestCase):
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert response.is_rejected
@@ -90,7 +90,7 @@ class TestEndCooperation(TestCase):
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert not response.is_rejected
@@ -106,7 +106,7 @@ class TestEndCooperation(TestCase):
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert not response.is_rejected
@@ -116,12 +116,12 @@ class TestEndCooperation(TestCase):
     ) -> None:
         plan = self.plan_generator.create_plan(planner=self.requester)
         cooperation = self.coop_generator.create_cooperation(plans=[plan])
-        assert plan.cooperation == cooperation.id
+        assert plan.cooperation == cooperation
 
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert not response.is_rejected
@@ -132,11 +132,11 @@ class TestEndCooperation(TestCase):
     ) -> None:
         plan = self.plan_generator.create_plan(planner=self.requester)
         cooperation = self.coop_generator.create_cooperation(plans=[plan])
-        assert plan.cooperation == cooperation.id
+        assert plan.cooperation == cooperation
         request = EndCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.end_cooperation(request)
         assert not response.is_rejected

--- a/tests/use_cases/test_get_coop_summary.py
+++ b/tests/use_cases/test_get_coop_summary.py
@@ -29,7 +29,7 @@ class GetCoopSummaryTests(BaseTestCase):
     def test_that_requester_is_correctly_defined_as_equal_to_coordinator(self) -> None:
         requester = self.company_generator.create_company_record()
         coop = self.cooperation_generator.create_cooperation(coordinator=requester)
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(summary, lambda s: s.requester_is_coordinator == True)
 
     def test_that_requester_is_correctly_defined_as_different_from_coordinator(
@@ -37,7 +37,7 @@ class GetCoopSummaryTests(BaseTestCase):
     ) -> None:
         requester = self.company_generator.create_company_record()
         coop = self.cooperation_generator.create_cooperation()
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(summary, lambda s: s.requester_is_coordinator == False)
 
     def test_that_correct_amount_of_associated_plans_are_shown(self) -> None:
@@ -45,7 +45,7 @@ class GetCoopSummaryTests(BaseTestCase):
         plan1 = self.plan_generator.create_plan()
         plan2 = self.plan_generator.create_plan()
         coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(summary, lambda s: len(s.plans) == 2)
 
     def test_that_correct_coordinator_id_is_shown(self) -> None:
@@ -55,7 +55,7 @@ class GetCoopSummaryTests(BaseTestCase):
         coop = self.cooperation_generator.create_cooperation(
             plans=[plan1, plan2], coordinator=requester.id
         )
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(summary, lambda s: s.current_coordinator == requester.id)
 
     def test_that_correct_coordinator_id_is_shown_when_several_cooperations_exist(
@@ -71,7 +71,7 @@ class GetCoopSummaryTests(BaseTestCase):
         )
         self.cooperation_generator.create_cooperation()
 
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(summary, lambda s: s.current_coordinator == requester.id)
 
     def test_that_correct_coordinator_name_is_shown(self) -> None:
@@ -81,7 +81,7 @@ class GetCoopSummaryTests(BaseTestCase):
         )
         requester = self.company_generator.create_company_record()
         coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester.id, coop))
         self.assert_success(
             summary, lambda s: s.current_coordinator_name == expected_coordinator_name
         )
@@ -92,12 +92,12 @@ class GetCoopSummaryTests(BaseTestCase):
         plan = self.plan_generator.create_plan(timeframe=1)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
         self.datetime_service.advance_time(timedelta(days=2))
-        summary = self.get_coop_summary(GetCoopSummaryRequest(requester, coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(requester, coop))
         self.assert_success(summary, lambda s: len(s.plans) == 0)
 
     def test_that_coop_price_is_none_if_there_are_no_plans_associated(self) -> None:
         coop = self.cooperation_generator.create_cooperation(plans=None)
-        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         self.assert_success(summary, lambda s: s.coop_price is None)
 
     def test_that_coop_price_equals_individual_price_when_there_is_one_plan_in_a_cooperation(
@@ -109,7 +109,7 @@ class GetCoopSummaryTests(BaseTestCase):
             amount=10,
         )
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         self.assert_success(summary, lambda s: s.coop_price == expected_price)
 
     def test_that_correct_coop_price_is_calculated_when_there_are_two_plans_in_a_cooperation(
@@ -125,7 +125,7 @@ class GetCoopSummaryTests(BaseTestCase):
             amount=10,
         )
         coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
-        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        summary = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         self.assert_success(summary, lambda s: s.coop_price == expected_price)
 
     def assert_success(
@@ -148,14 +148,14 @@ class AssociatedPlansTests(BaseTestCase):
         plan1 = self.plan_generator.create_plan()
         plan2 = self.plan_generator.create_plan()
         coop = self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert len(response.plans) == 2
 
     def test_that_associated_plan_in_a_summary_has_correct_plan_id(self) -> None:
         plan = self.plan_generator.create_plan()
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].plan_id == plan.id
 
@@ -163,7 +163,7 @@ class AssociatedPlansTests(BaseTestCase):
         expected_prd_name = "A product name"
         plan = self.plan_generator.create_plan(product_name=expected_prd_name)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].plan_name == expected_prd_name
 
@@ -176,7 +176,7 @@ class AssociatedPlansTests(BaseTestCase):
             amount=10,
         )
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].plan_individual_price == expected_price
 
@@ -193,7 +193,7 @@ class AssociatedPlansTests(BaseTestCase):
             amount=10,
         )
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].plan_individual_price == expected_price
 
@@ -201,7 +201,7 @@ class AssociatedPlansTests(BaseTestCase):
         expected_planner = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=expected_planner)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].planner_id == expected_planner
 
@@ -210,7 +210,7 @@ class AssociatedPlansTests(BaseTestCase):
         planner = self.company_generator.create_company(name=expected_planner_name)
         plan = self.plan_generator.create_plan(planner=planner)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
-        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop.id))
+        response = self.get_coop_summary(GetCoopSummaryRequest(uuid4(), coop))
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].planner_name == expected_planner_name
 
@@ -221,7 +221,7 @@ class AssociatedPlansTests(BaseTestCase):
         plan = self.plan_generator.create_plan(planner=expected_planner)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
         response = self.get_coop_summary(
-            GetCoopSummaryRequest(requester_id=plan.planner, coop_id=coop.id)
+            GetCoopSummaryRequest(requester_id=plan.planner, coop_id=coop)
         )
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].requester_is_planner == True
@@ -233,7 +233,7 @@ class AssociatedPlansTests(BaseTestCase):
         plan = self.plan_generator.create_plan(planner=expected_planner)
         coop = self.cooperation_generator.create_cooperation(plans=[plan])
         response = self.get_coop_summary(
-            GetCoopSummaryRequest(requester_id=uuid4(), coop_id=coop.id)
+            GetCoopSummaryRequest(requester_id=uuid4(), coop_id=coop)
         )
         assert isinstance(response, GetCoopSummarySuccess)
         assert response.plans[0].requester_is_planner == False

--- a/tests/use_cases/test_list_all_cooperations.py
+++ b/tests/use_cases/test_list_all_cooperations.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
+from uuid import UUID
 
-from arbeitszeit.records import Cooperation
 from arbeitszeit.use_cases.list_all_cooperations import (
     ListAllCooperations,
     ListAllCooperationsResponse,
@@ -11,15 +11,8 @@ from tests.datetime_service import FakeDatetimeService
 from .dependency_injection import injection_test
 
 
-def coop_in_response(
-    cooperation: Cooperation, response: ListAllCooperationsResponse
-) -> bool:
-    return any(
-        (
-            cooperation.id == result.id and cooperation.name == result.name
-            for result in response.cooperations
-        )
-    )
+def coop_in_response(cooperation: UUID, response: ListAllCooperationsResponse) -> bool:
+    return any(cooperation == result.id for result in response.cooperations)
 
 
 @injection_test
@@ -47,14 +40,17 @@ def test_one_returned_cooperation_shows_correct_info(
     cooperation_generator: CooperationGenerator,
     plan_generator: PlanGenerator,
 ):
+    expected_cooperation_name = "Test Cooperation"
     plan = plan_generator.create_plan()
-    cooperation = cooperation_generator.create_cooperation(plans=[plan])
+    cooperation = cooperation_generator.create_cooperation(
+        plans=[plan], name=expected_cooperation_name
+    )
     response = use_case()
     assert len(response.cooperations) == 1
     assert coop_in_response(cooperation, response)
     assert response.cooperations[0].plan_count == 1
-    assert response.cooperations[0].id == cooperation.id
-    assert response.cooperations[0].name == cooperation.name
+    assert response.cooperations[0].id == cooperation
+    assert response.cooperations[0].name == expected_cooperation_name
 
 
 @injection_test

--- a/tests/use_cases/test_list_coordinations_of_company.py
+++ b/tests/use_cases/test_list_coordinations_of_company.py
@@ -62,7 +62,7 @@ def test_cooperation_is_listed_when_requester_is_coordinator_of_cooperation(
     )
     response = use_case(ListCoordinationsOfCompanyRequest(company.id))
     assert len(response.coordinations) == 1
-    assert response.coordinations[0].id == cooperation.id
+    assert response.coordinations[0].id == cooperation
 
 
 @injection_test
@@ -83,7 +83,7 @@ def test_only_cooperations_are_listed_where_requester_is_coordinator(
     )
     response = use_case(ListCoordinationsOfCompanyRequest(company.id))
     assert len(response.coordinations) == 1
-    assert response.coordinations[0].id == expected_cooperation.id
+    assert response.coordinations[0].id == expected_cooperation
 
 
 @injection_test

--- a/tests/use_cases/test_list_coordinations_of_cooperation.py
+++ b/tests/use_cases/test_list_coordinations_of_cooperation.py
@@ -23,7 +23,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
     ) -> None:
         coop = self.cooperation_generator.create_cooperation()
         response = self.use_case.list_coordinations(
-            self.create_use_case_request(coop=coop.id)
+            self.create_use_case_request(coop=coop)
         )
         assert len(response.coordinations) == 1
 
@@ -33,7 +33,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
         coop = self.cooperation_generator.create_cooperation()
         self.cooperation_generator.create_cooperation()
         response = self.use_case.list_coordinations(
-            self.create_use_case_request(coop=coop.id)
+            self.create_use_case_request(coop=coop)
         )
         assert len(response.coordinations) == 1
 
@@ -42,7 +42,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
         coordinator = self.company_generator.create_company(name=expected_name)
         coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         response = self.use_case.list_coordinations(
-            self.create_use_case_request(coop=coop.id)
+            self.create_use_case_request(coop=coop)
         )
         assert response.coordinations[0].coordinator_name == expected_name
 
@@ -50,7 +50,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
         coordinator = self.company_generator.create_company()
         coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         response = self.use_case.list_coordinations(
-            self.create_use_case_request(coop=coop.id)
+            self.create_use_case_request(coop=coop)
         )
         assert response.coordinations[0].coordinator_id == coordinator
 
@@ -62,7 +62,7 @@ class ListCoordinationsOfCooperationTest(BaseTestCase):
         coop = self.cooperation_generator.create_cooperation()
         self.datetime_service.advance_time(timedelta(days=2))
         response = self.use_case.list_coordinations(
-            self.create_use_case_request(coop=coop.id)
+            self.create_use_case_request(coop=coop)
         )
         assert response.coordinations[0].start_time == expected_time
 

--- a/tests/use_cases/test_list_inbound_coop_requests.py
+++ b/tests/use_cases/test_list_inbound_coop_requests.py
@@ -23,7 +23,7 @@ class UseCaseTest(BaseTestCase):
         self,
     ):
         coordinator = self.company_generator.create_company_record()
-        coop = self.coop_generator.create_cooperation()
+        coop = self.cooperation_generator.create_cooperation()
         self.plan_generator.create_plan(requested_cooperation=coop)
         response = self.use_case(ListInboundCoopRequestsRequest(coordinator.id))
         assert len(response.cooperation_requests) == 0
@@ -32,7 +32,7 @@ class UseCaseTest(BaseTestCase):
         self,
     ):
         coordinator = self.company_generator.create_company()
-        coop = self.coop_generator.create_cooperation(coordinator=coordinator)
+        coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         requesting_plan1 = self.plan_generator.create_plan(requested_cooperation=coop)
         requesting_plan2 = self.plan_generator.create_plan(requested_cooperation=coop)
         response = self.use_case(ListInboundCoopRequestsRequest(coordinator))
@@ -45,7 +45,7 @@ class UseCaseTest(BaseTestCase):
     ):
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
         coordinator = self.company_generator.create_company_record()
-        coop = self.coop_generator.create_cooperation(coordinator=coordinator)
+        coop = self.cooperation_generator.create_cooperation(coordinator=coordinator)
         self.plan_generator.create_plan(requested_cooperation=coop, timeframe=1)
         self.plan_generator.create_plan(requested_cooperation=coop, timeframe=5)
         self.datetime_service.advance_time(timedelta(days=2))

--- a/tests/use_cases/test_list_my_cooperations.py
+++ b/tests/use_cases/test_list_my_cooperations.py
@@ -46,7 +46,7 @@ class UseCaseTest(BaseTestCase):
     def test_one_plan_is_returned_if_requester_has_one_active_cooperating_plan(
         self,
     ) -> None:
-        coop = self.coop_generator.create_cooperation()
+        coop = self.cooperation_generator.create_cooperation()
         company = self.company_generator.create_company()
         request = ListMyCooperatingPlansUseCase.Request(company=company)
         self.plan_generator.create_plan(planner=company, cooperation=coop)
@@ -54,21 +54,22 @@ class UseCaseTest(BaseTestCase):
         assert len(result.cooperating_plans) == 1
 
     def test_returned_plan_has_correct_attributes(self) -> None:
-        coop = self.coop_generator.create_cooperation()
+        expected_coop_name = "Test Cooperation"
+        coop = self.cooperation_generator.create_cooperation(name=expected_coop_name)
         company = self.company_generator.create_company()
         request = ListMyCooperatingPlansUseCase.Request(company=company)
         plan = self.plan_generator.create_plan(planner=company, cooperation=coop)
         result = self.use_case.list_cooperations(request=request)
         cooperating_plan = result.cooperating_plans[0]
-        assert cooperating_plan.coop_id == coop.id
-        assert cooperating_plan.coop_name == coop.name
+        assert cooperating_plan.coop_id == coop
+        assert cooperating_plan.coop_name == expected_coop_name
         assert cooperating_plan.plan_id == plan.id
         assert cooperating_plan.plan_name == plan.prd_name
 
     def test_two_plans_are_returned_if_requester_has_two_active_cooperating_plan(
         self,
     ) -> None:
-        coop = self.coop_generator.create_cooperation()
+        coop = self.cooperation_generator.create_cooperation()
         company = self.company_generator.create_company()
         request = ListMyCooperatingPlansUseCase.Request(company=company)
         self.plan_generator.create_plan(planner=company, cooperation=coop)

--- a/tests/use_cases/test_request_cooperation.py
+++ b/tests/use_cases/test_request_cooperation.py
@@ -24,11 +24,11 @@ class RequestCooperationTests(BaseTestCase):
         self.requester = self.company_generator.create_company()
 
     def test_error_is_raised_when_plan_does_not_exist(self) -> None:
-        cooperation = self.coop_generator.create_cooperation()
+        cooperation = self.cooperation_generator.create_cooperation()
         request = RequestCooperationRequest(
             requester_id=self.requester,
             plan_id=uuid4(),
-            cooperation_id=cooperation.id,
+            cooperation_id=cooperation,
         )
         response = self.request_cooperation(request)
         assert response.is_rejected
@@ -50,15 +50,15 @@ class RequestCooperationTests(BaseTestCase):
         )
 
     def test_error_is_raised_when_plan_has_already_cooperation(self) -> None:
-        cooperation1 = self.coop_generator.create_cooperation()
-        cooperation2 = self.coop_generator.create_cooperation(
+        cooperation1 = self.cooperation_generator.create_cooperation()
+        cooperation2 = self.cooperation_generator.create_cooperation(
             name="name2", coordinator=self.requester
         )
         plan = self.plan_generator.create_plan(cooperation=cooperation1)
         request = RequestCooperationRequest(
             requester_id=self.requester,
             plan_id=plan.id,
-            cooperation_id=cooperation2.id,
+            cooperation_id=cooperation2,
         )
 
         response = self.request_cooperation(request)
@@ -70,13 +70,15 @@ class RequestCooperationTests(BaseTestCase):
 
     def test_error_is_raised_when_plan_is_already_requesting_cooperation(self) -> None:
         requester = self.company_generator.create_company()
-        cooperation1 = self.coop_generator.create_cooperation()
+        cooperation1 = self.cooperation_generator.create_cooperation()
         plan = self.plan_generator.create_plan(
             requested_cooperation=cooperation1,
         )
-        cooperation2 = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation2 = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation2.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation2
         )
         response = self.request_cooperation(request)
         assert response.is_rejected
@@ -88,9 +90,11 @@ class RequestCooperationTests(BaseTestCase):
     def test_error_is_raised_when_plan_is_public_plan(self) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(is_public_service=True)
-        cooperation = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert response.is_rejected
@@ -101,9 +105,11 @@ class RequestCooperationTests(BaseTestCase):
     def test_error_is_raised_when_requester_is_not_planner(self) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan()
-        cooperation = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert response.is_rejected
@@ -115,9 +121,11 @@ class RequestCooperationTests(BaseTestCase):
     def test_requesting_cooperation_is_successful(self) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
-        cooperation = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert not response.is_rejected
@@ -125,9 +133,11 @@ class RequestCooperationTests(BaseTestCase):
     def test_successful_cooperation_request_returns_coordinator_data(self) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
-        cooperation = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert response.coordinator_name
@@ -138,9 +148,11 @@ class RequestCooperationTests(BaseTestCase):
     ) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
-        cooperation = self.coop_generator.create_cooperation(coordinator=requester)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=requester
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         self.request_cooperation(request)
         assert plan.requested_cooperation
@@ -153,9 +165,9 @@ class RequestCooperationTests(BaseTestCase):
     def test_that_after_requesting_successfully_an_email_was_sent_out(self) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
-        cooperation = self.coop_generator.create_cooperation()
+        cooperation = self.cooperation_generator.create_cooperation()
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         messages_before_request = len(self.email_sender.get_messages_sent())
         response = self.request_cooperation(request)
@@ -167,9 +179,9 @@ class RequestCooperationTests(BaseTestCase):
     ) -> None:
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
-        cooperation = self.coop_generator.create_cooperation()
+        cooperation = self.cooperation_generator.create_cooperation()
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         messages_before_request = len(self.get_cooperation_request_emails())
         response = self.request_cooperation(request)
@@ -190,9 +202,11 @@ class RequestCooperationTests(BaseTestCase):
         coordinator = self.company_generator.create_company(
             email=expected_email_address
         )
-        cooperation = self.coop_generator.create_cooperation(coordinator=coordinator)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=coordinator
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert not response.is_rejected
@@ -213,9 +227,11 @@ class RequestCooperationTests(BaseTestCase):
         requester = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=requester)
         coordinator = self.company_generator.create_company(name=expected_name)
-        cooperation = self.coop_generator.create_cooperation(coordinator=coordinator)
+        cooperation = self.cooperation_generator.create_cooperation(
+            coordinator=coordinator
+        )
         request = RequestCooperationRequest(
-            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation.id
+            requester_id=requester, plan_id=plan.id, cooperation_id=cooperation
         )
         response = self.request_cooperation(request)
         assert not response.is_rejected

--- a/tests/use_cases/test_request_coordination_transfer.py
+++ b/tests/use_cases/test_request_coordination_transfer.py
@@ -88,11 +88,11 @@ class RequestCoordinationTransferTests(BaseTestCase):
         self.datetime_service.freeze_time(timestamp=datetime(2020, 5, 1))
         cooperation = self.cooperation_generator.create_cooperation()
         old_tenure = self.coordination_tenure_generator.create_coordination_tenure(
-            cooperation=cooperation.id
+            cooperation=cooperation
         )
         self.datetime_service.advance_time(dt=timedelta(days=1))
         self.coordination_tenure_generator.create_coordination_tenure(
-            cooperation=cooperation.id
+            cooperation=cooperation
         )
 
         response = self.use_case.request_transfer(
@@ -109,7 +109,7 @@ class RequestCoordinationTransferTests(BaseTestCase):
     ) -> None:
         cooperation = self.cooperation_generator.create_cooperation()
         current_tenure = self.coordination_tenure_generator.create_coordination_tenure(
-            cooperation=cooperation.id
+            cooperation=cooperation
         )
         self.use_case.request_transfer(
             request=self.get_use_case_request(requesting_tenure=current_tenure)
@@ -126,7 +126,7 @@ class RequestCoordinationTransferTests(BaseTestCase):
     def test_requesting_transfer_can_succeed(self) -> None:
         cooperation = self.cooperation_generator.create_cooperation()
         current_tenure = self.coordination_tenure_generator.create_coordination_tenure(
-            cooperation=cooperation.id
+            cooperation=cooperation
         )
         response = self.use_case.request_transfer(
             request=self.get_use_case_request(requesting_tenure=current_tenure)
@@ -156,12 +156,12 @@ class RequestCoordinationTransferTests(BaseTestCase):
     def test_that_delivered_notification_contains_cooperation_name(self) -> None:
         expected_name = "Cooperation Coop."
         cooperation = self.cooperation_generator.create_cooperation(name=expected_name)
-        self.successfully_request_a_transfer(cooperation=cooperation.id)
+        self.successfully_request_a_transfer(cooperation=cooperation)
         notification = self.get_latest_notification_delivered()
         self.assertEqual(notification.cooperation_name, expected_name)
 
     def test_that_delivered_notification_contains_cooperation_id(self) -> None:
-        expected_cooperation_id = self.cooperation_generator.create_cooperation().id
+        expected_cooperation_id = self.cooperation_generator.create_cooperation()
         self.successfully_request_a_transfer(cooperation=expected_cooperation_id)
         notification = self.get_latest_notification_delivered()
         self.assertEqual(notification.cooperation_id, expected_cooperation_id)
@@ -183,7 +183,7 @@ class RequestCoordinationTransferTests(BaseTestCase):
         self, cooperation: Optional[UUID] = None, candidate: Optional[UUID] = None
     ) -> None:
         if cooperation is None:
-            cooperation = self.cooperation_generator.create_cooperation().id
+            cooperation = self.cooperation_generator.create_cooperation()
         current_tenure = self.coordination_tenure_generator.create_coordination_tenure(
             cooperation=cooperation
         )


### PR DESCRIPTION
Previously our CooperationGenerator, that we use to create Cooperations for our tests, returned a records.Cooperation object. With this change a UUID is returned, which leads to a better decoupling of business logic from database logic.

Moreover, a redundant coop_generator in `BaseTestCase` has been removed.

Plan: fe6ed75b-5ad9-4821-a399-7ca8303e2fea (2x)

