### PR TITLE
Remove hard coded urls from templates

### DIFF
--- a/arbeitszeit_flask/templates/auth/login_company.html
+++ b/arbeitszeit_flask/templates/auth/login_company.html
@@ -11,7 +11,7 @@
                 <div class="notification is-danger">{{ error }}</div>
                 {% endfor %}
                 {% endfor %}
-                <form method="POST" action="/company/login">
+                <form method="POST" action="{{ url_for('.login_company') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">
                         <div class="control has-icons-left">

--- a/arbeitszeit_flask/templates/auth/login_member.html
+++ b/arbeitszeit_flask/templates/auth/login_member.html
@@ -11,7 +11,7 @@
                 <div class="notification is-danger">{{ error }}</div>
                 {% endfor %}
                 {% endfor %}
-                <form method="POST" action="/member/login">
+                <form method="POST" action="{{ url_for('.login_member') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">
                         <div class="control has-icons-left">

--- a/arbeitszeit_flask/templates/auth/signup_company.html
+++ b/arbeitszeit_flask/templates/auth/signup_company.html
@@ -11,7 +11,7 @@
                 <div class="notification is-danger">{{ error }}</div>
                 {% endfor %}
                 {% endfor %}
-                <form method="POST" action="/company/signup">
+                <form method="POST" action="{{ url_for('.signup_company') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">
                         <div class="control has-icons-left">

--- a/arbeitszeit_flask/templates/auth/signup_member.html
+++ b/arbeitszeit_flask/templates/auth/signup_member.html
@@ -11,7 +11,7 @@
                 <div class="notification is-danger">{{ error }}</div>
                 {% endfor %}
                 {% endfor %}
-                <form method="POST" action="/member/signup">
+                <form method="POST" action="{{ url_for('.signup_member') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">
                         <div class="control has-icons-left">


### PR DESCRIPTION
This change removes 4 instances of hardcoded urls from our html templates in favour of using the `url_for` template function provided by flask.

*No labour time registration needed*