### PR TITLE
Unify all `*UrlIndex` interfaces into one

### DIFF
--- a/arbeitszeit_flask/auth/routes.py
+++ b/arbeitszeit_flask/auth/routes.py
@@ -11,7 +11,7 @@ from arbeitszeit.use_cases.log_in_member import LogInMemberUseCase
 from arbeitszeit.use_cases.resend_confirmation_mail import ResendConfirmationMailUseCase
 from arbeitszeit.use_cases.start_page import StartPageUseCase
 from arbeitszeit_flask.database import commit_changes
-from arbeitszeit_flask.dependency_injection import CompanyModule, with_injection
+from arbeitszeit_flask.dependency_injection import with_injection
 from arbeitszeit_flask.flask_session import FlaskSession
 from arbeitszeit_flask.forms import LoginForm
 from arbeitszeit_flask.template import AnonymousUserTemplateRenderer
@@ -192,7 +192,7 @@ def login_company(
 
 @auth.route("/company/signup", methods=["GET", "POST"])
 @commit_changes
-@with_injection(modules=[CompanyModule()])
+@with_injection()
 def signup_company(view: SignupCompanyView):
     return view.handle_request(request)
 
@@ -219,7 +219,7 @@ def confirm_email_company(
 
 
 @auth.route("/company/resend")
-@with_injection(modules=[CompanyModule()])
+@with_injection()
 @login_required
 def resend_confirmation_company(use_case: ResendConfirmationMailUseCase):
     request = use_case.Request(user=UUID(current_user.id))

--- a/arbeitszeit_flask/company/blueprint.py
+++ b/arbeitszeit_flask/company/blueprint.py
@@ -4,7 +4,7 @@ from typing import Any, Callable
 from flask import Blueprint, redirect
 
 from arbeitszeit_flask import types
-from arbeitszeit_flask.dependency_injection import CompanyModule, with_injection
+from arbeitszeit_flask.dependency_injection import with_injection
 from arbeitszeit_web.www.authentication import CompanyAuthenticator
 
 main_company = Blueprint(
@@ -28,12 +28,12 @@ class CompanyRoute:
         return self._apply_decorators(_wrapper)
 
     def _apply_decorators(self, function):
-        injection = with_injection([CompanyModule()])
+        injection = with_injection()
         return main_company.route(self.route_string, methods=self.methods)(
             injection(self._check_is_company_and_confirmed(function))
         )
 
-    @with_injection([CompanyModule()])
+    @with_injection()
     def _check_is_company_and_confirmed(
         self,
         func,

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -37,7 +37,7 @@ from arbeitszeit_flask.template import FlaskTemplateRenderer, TemplateRenderer
 from arbeitszeit_flask.text_renderer import TextRendererImpl
 from arbeitszeit_flask.token import FlaskTokenService
 from arbeitszeit_flask.translator import FlaskTranslator
-from arbeitszeit_flask.url_index import CompanyUrlIndex, GeneralUrlIndex
+from arbeitszeit_flask.url_index import GeneralUrlIndex
 from arbeitszeit_flask.views.accountant_invitation_email_view import (
     AccountantInvitationEmailViewImpl,
 )
@@ -55,20 +55,7 @@ from arbeitszeit_web.session import Session
 from arbeitszeit_web.text_renderer import TextRenderer
 from arbeitszeit_web.token import TokenService
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.url_index import (
-    AccountantInvitationUrlIndex,
-    HidePlanUrlIndex,
-    LanguageChangerUrlIndex,
-    RenewPlanUrlIndex,
-    UrlIndex,
-)
-
-
-class CompanyModule(Module):
-    def configure(self, binder: Binder) -> None:
-        super().configure(binder)
-        binder[RenewPlanUrlIndex] = AliasProvider(CompanyUrlIndex)
-        binder[HidePlanUrlIndex] = AliasProvider(CompanyUrlIndex)
+from arbeitszeit_web.url_index import UrlIndex
 
 
 class FlaskModule(Module):
@@ -104,14 +91,9 @@ class FlaskModule(Module):
         binder[Plotter] = AliasProvider(FlaskPlotter)
         binder[Colors] = AliasProvider(FlaskColors)
         binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)
-        binder[LanguageChangerUrlIndex] = AliasProvider(GeneralUrlIndex)
         binder.bind(
             AccountantInvitationEmailView,
             to=AliasProvider(AccountantInvitationEmailViewImpl),
-        )
-        binder.bind(
-            AccountantInvitationUrlIndex,
-            to=AliasProvider(GeneralUrlIndex),
         )
         binder.bind(
             PasswordHasher,

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -220,15 +220,8 @@ class GeneralUrlIndex:
     def get_accountant_account_details_url(self) -> str:
         return url_for("main_accountant.get_accountant_account_details")
 
-
-class CompanyUrlIndex:
     def get_renew_plan_url(self, plan_id: UUID) -> str:
         return url_for("main_company.create_draft_from_plan", plan_id=plan_id)
 
     def get_hide_plan_url(self, plan_id: UUID) -> str:
         return url_for("main_company.hide_plan", plan_id=plan_id)
-
-    def get_work_invite_url(self, invite_id: UUID) -> str:
-        # since invites don't make sense for a company, we redirect
-        # them in this case to their dashboard page.
-        return url_for("main_company.dashboard")

--- a/arbeitszeit_web/email/accountant_invitation_presenter.py
+++ b/arbeitszeit_web/email/accountant_invitation_presenter.py
@@ -4,7 +4,7 @@ from typing import List, Protocol
 from arbeitszeit_web.email import EmailConfiguration
 from arbeitszeit_web.token import TokenService
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.url_index import AccountantInvitationUrlIndex
+from arbeitszeit_web.url_index import UrlIndex
 
 
 @dataclass
@@ -25,7 +25,7 @@ class AccountantInvitationEmailPresenter:
     invitation_view: AccountantInvitationEmailView
     email_configuration: EmailConfiguration
     translator: Translator
-    invitation_url_index: AccountantInvitationUrlIndex
+    url_index: UrlIndex
     token_service: TokenService
 
     def send_accountant_invitation(self, email: str) -> None:
@@ -34,8 +34,6 @@ class AccountantInvitationEmailPresenter:
             subject=self.translator.gettext("Invitation to Arbeitszeitapp"),
             recipients=[email],
             sender=self.email_configuration.get_sender_address(),
-            registration_link_url=self.invitation_url_index.get_accountant_invitation_url(
-                token
-            ),
+            registration_link_url=self.url_index.get_accountant_invitation_url(token),
         )
         self.invitation_view.render_accountant_invitation_email(view_model)

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -162,23 +162,15 @@ class UrlIndex(Protocol):
     def get_change_email_url(self, *, token: str) -> str:
         ...
 
-
-class RenewPlanUrlIndex(Protocol):
     def get_renew_plan_url(self, plan_id: UUID) -> str:
         ...
 
-
-class HidePlanUrlIndex(Protocol):
     def get_hide_plan_url(self, plan_id: UUID) -> str:
         ...
 
-
-class AccountantInvitationUrlIndex(Protocol):
     def get_accountant_invitation_url(self, token: str) -> str:
         ...
 
-
-class LanguageChangerUrlIndex(Protocol):
     def get_language_change_url(self, language_code: str) -> str:
         ...
 

--- a/arbeitszeit_web/www/presenters/list_available_languages_presenter.py
+++ b/arbeitszeit_web/www/presenters/list_available_languages_presenter.py
@@ -5,7 +5,7 @@ from typing import List
 
 from arbeitszeit.use_cases.list_available_languages import ListAvailableLanguagesUseCase
 from arbeitszeit_web.language_service import LanguageService
-from arbeitszeit_web.url_index import LanguageChangerUrlIndex
+from arbeitszeit_web.url_index import UrlIndex
 
 
 @dataclass
@@ -20,7 +20,7 @@ class ListAvailableLanguagesPresenter:
         show_language_listing: bool
         languages_listing: List[ListAvailableLanguagesPresenter.LanguageListItem]
 
-    language_changer_url_index: LanguageChangerUrlIndex
+    url_index: UrlIndex
     language_service: LanguageService
 
     def present_available_languages_list(
@@ -30,9 +30,7 @@ class ListAvailableLanguagesPresenter:
             show_language_listing=bool(response.available_language_codes),
             languages_listing=[
                 self.LanguageListItem(
-                    change_url=self.language_changer_url_index.get_language_change_url(
-                        code
-                    ),
+                    change_url=self.url_index.get_language_change_url(code),
                     label=self.language_service.get_language_name(code) or code,
                 )
                 for code in response.available_language_codes

--- a/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_plans_presenter.py
@@ -7,12 +7,7 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansResponse
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.url_index import (
-    HidePlanUrlIndex,
-    RenewPlanUrlIndex,
-    UrlIndex,
-    UserUrlIndex,
-)
+from arbeitszeit_web.url_index import UrlIndex, UserUrlIndex
 
 
 @dataclass
@@ -97,8 +92,6 @@ class ShowMyPlansViewModel:
 class ShowMyPlansPresenter:
     url_index: UrlIndex
     user_url_index: UserUrlIndex
-    renew_plan_url_index: RenewPlanUrlIndex
-    hide_plan_url_index: HidePlanUrlIndex
     translator: Translator
     datetime_service: DatetimeService
     notifier: Notifier
@@ -170,10 +163,8 @@ class ShowMyPlansPresenter:
                     prd_name=f"{plan.prd_name}",
                     is_public_service=plan.is_public_service,
                     plan_creation_date=self.__format_date(plan.plan_creation_date),
-                    renew_plan_url=self.renew_plan_url_index.get_renew_plan_url(
-                        plan.id
-                    ),
-                    hide_plan_url=self.hide_plan_url_index.get_hide_plan_url(plan.id),
+                    renew_plan_url=self.url_index.get_renew_plan_url(plan.id),
+                    hide_plan_url=self.url_index.get_hide_plan_url(plan.id),
                 )
                 for plan in response.expired_plans
             ],

--- a/tests/email_presenters/test_accountant_invitation_presenter.py
+++ b/tests/email_presenters/test_accountant_invitation_presenter.py
@@ -8,7 +8,6 @@ from arbeitszeit_web.email.accountant_invitation_presenter import (
 from tests.email import FakeEmailConfiguration
 from tests.token import FakeTokenService
 from tests.www.base_test_case import BaseTestCase
-from tests.www.presenters.url_index import AccountantInvitationUrlIndexImpl
 
 from .accountant_invitation_email_view import AccountantInvitationEmailViewImpl
 
@@ -19,9 +18,6 @@ class PresenterTests(BaseTestCase):
         self.view = self.injector.get(AccountantInvitationEmailViewImpl)
         self.presenter = self.injector.get(AccountantInvitationEmailPresenter)
         self.email_configuration = self.injector.get(FakeEmailConfiguration)
-        self.accountant_invitation_url_index = self.injector.get(
-            AccountantInvitationUrlIndexImpl
-        )
         self.token_service = self.injector.get(FakeTokenService)
 
     def test_that_token_recipient_is_also_mail_recipient(self) -> None:
@@ -52,9 +48,7 @@ class PresenterTests(BaseTestCase):
         self.presenter.send_accountant_invitation(email="test@test.test")
         self.assertViewModel(
             lambda model: model.registration_link_url
-            == self.accountant_invitation_url_index.get_accountant_invitation_url(
-                expected_token
-            )
+            == self.url_index.get_accountant_invitation_url(expected_token)
         )
 
     def assertViewModel(self, condition: Callable[[ViewModel], bool]) -> None:

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -7,37 +7,11 @@ from arbeitszeit.use_cases.send_accountant_registration_token import (
     SendAccountantRegistrationTokenUseCase,
 )
 from arbeitszeit_flask.token import FlaskTokenService
-from arbeitszeit_flask.url_index import CompanyUrlIndex, GeneralUrlIndex
+from arbeitszeit_flask.url_index import GeneralUrlIndex
 from arbeitszeit_web.session import UserRole
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
+from tests.data_generators import CooperationGenerator, PlanGenerator
 
 from .flask import ViewTestCase
-
-
-class CompanyUrlIndexTests(ViewTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.url_index = CompanyUrlIndex()
-        self.plan_generator = self.injector.get(PlanGenerator)
-        self.company = self.login_company()
-        self.cooperation_generator = self.injector.get(CooperationGenerator)
-        self.company_generator = self.injector.get(CompanyGenerator)
-
-    def test_renew_plan_url_for_existing_plan_leads_to_functional_url(
-        self,
-    ) -> None:
-        plan = self.plan_generator.create_plan()
-        url = self.url_index.get_renew_plan_url(plan.id)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
-
-    def test_hide_plan_url_for_existing_plan_leads_to_functional_url(
-        self,
-    ) -> None:
-        plan = self.plan_generator.create_plan()
-        url = self.url_index.get_hide_plan_url(plan.id)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 302)
 
 
 class PlotUrlIndexTests(ViewTestCase):
@@ -367,3 +341,21 @@ class GeneralUrlIndexTests(ViewTestCase):
         url = self.url_index.get_unconfirmed_member_url()
         response = self.client.get(url)
         assert response.status_code < 400
+
+    def test_renew_plan_url_for_existing_plan_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        plan = self.plan_generator.create_plan()
+        url = self.url_index.get_renew_plan_url(plan.id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+    def test_hide_plan_url_for_existing_plan_leads_to_functional_url(
+        self,
+    ) -> None:
+        self.login_company()
+        plan = self.plan_generator.create_plan()
+        url = self.url_index.get_hide_plan_url(plan.id)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 302)

--- a/tests/www/dependency_injection.py
+++ b/tests/www/dependency_injection.py
@@ -7,13 +7,7 @@ from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.session import Session
-from arbeitszeit_web.url_index import (
-    AccountantInvitationUrlIndex,
-    HidePlanUrlIndex,
-    LanguageChangerUrlIndex,
-    RenewPlanUrlIndex,
-    UrlIndex,
-)
+from arbeitszeit_web.url_index import UrlIndex
 from tests.dependency_injection import TestingModule
 from tests.email import FakeEmailConfiguration, FakeEmailService
 from tests.email_presenters.accountant_invitation_email_view import (
@@ -25,13 +19,7 @@ from tests.session import FakeSession
 from tests.use_cases.dependency_injection import InMemoryModule
 
 from .presenters.notifier import NotifierTestImpl
-from .presenters.url_index import (
-    AccountantInvitationUrlIndexImpl,
-    HidePlanUrlIndexTestImpl,
-    LanguageChangerUrlIndexImpl,
-    RenewPlanUrlIndexTestImpl,
-    UrlIndexTestImpl,
-)
+from .presenters.url_index import UrlIndexTestImpl
 
 
 class WwwTestsInjector(Module):
@@ -41,18 +29,12 @@ class WwwTestsInjector(Module):
             AccountantInvitationEmailViewImpl
         )
         binder[EmailConfiguration] = AliasProvider(FakeEmailConfiguration)
-        binder[AccountantInvitationUrlIndex] = AliasProvider(
-            AccountantInvitationUrlIndexImpl
-        )
         binder[Notifier] = AliasProvider(NotifierTestImpl)
         binder[UrlIndex] = AliasProvider(UrlIndexTestImpl)
         binder[Session] = AliasProvider(FakeSession)
         binder[Request] = AliasProvider(FakeRequest)
-        binder[LanguageChangerUrlIndex] = AliasProvider(LanguageChangerUrlIndexImpl)
         binder[LanguageService] = AliasProvider(FakeLanguageService)
         binder[MailService] = AliasProvider(FakeEmailService)
-        binder[RenewPlanUrlIndex] = AliasProvider(RenewPlanUrlIndexTestImpl)
-        binder[HidePlanUrlIndex] = AliasProvider(HidePlanUrlIndexTestImpl)
 
 
 def get_dependency_injector() -> Injector:

--- a/tests/www/presenters/test_list_available_languages_presenter.py
+++ b/tests/www/presenters/test_list_available_languages_presenter.py
@@ -5,14 +5,11 @@ from arbeitszeit_web.www.presenters.list_available_languages_presenter import (
 from tests.language_service import FakeLanguageService
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import LanguageChangerUrlIndexImpl
-
 
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(ListAvailableLanguagesPresenter)
-        self.language_url_index = self.injector.get(LanguageChangerUrlIndexImpl)
         self.language_service = self.injector.get(FakeLanguageService)
 
     def test_dont_show_language_listing_if_no_languages_are_available(self) -> None:
@@ -54,7 +51,7 @@ class PresenterTests(BaseTestCase):
         view_model = self.presenter.present_available_languages_list(use_case_response)
         self.assertEqual(
             view_model.languages_listing[0].change_url,
-            self.language_url_index.get_language_change_url("ru"),
+            self.url_index.get_language_change_url("ru"),
         )
 
     def test_that_language_code_en_is_resolved_to_correct_change_link(self) -> None:
@@ -64,7 +61,7 @@ class PresenterTests(BaseTestCase):
         view_model = self.presenter.present_available_languages_list(use_case_response)
         self.assertEqual(
             view_model.languages_listing[0].change_url,
-            self.language_url_index.get_language_change_url("en"),
+            self.url_index.get_language_change_url("en"),
         )
 
     def test_language_name_is_properly_rendered_if_it_can_be_retrieved(self) -> None:

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -14,14 +14,10 @@ from arbeitszeit_web.www.presenters.show_my_plans_presenter import ShowMyPlansPr
 from tests.data_generators import CooperationGenerator, PlanGenerator
 from tests.www.base_test_case import BaseTestCase
 
-from .url_index import HidePlanUrlIndexTestImpl, RenewPlanUrlIndexTestImpl
-
 
 class ShowMyPlansPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.renew_plan_url_index = self.injector.get(RenewPlanUrlIndexTestImpl)
-        self.hide_plan_url_index = self.injector.get(HidePlanUrlIndexTestImpl)
         self.presenter = self.injector.get(ShowMyPlansPresenter)
         self.plan_generator = self.injector.get(PlanGenerator)
         self.coop_generator = self.injector.get(CooperationGenerator)
@@ -118,11 +114,11 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.assertEqual(row1.is_public_service, expected_plan.is_public_service)
         self.assertEqual(
             row1.renew_plan_url,
-            self.renew_plan_url_index.get_renew_plan_url(expected_plan.id),
+            self.url_index.get_renew_plan_url(expected_plan.id),
         )
         self.assertEqual(
             row1.hide_plan_url,
-            self.hide_plan_url_index.get_hide_plan_url(expected_plan.id),
+            self.url_index.get_hide_plan_url(expected_plan.id),
         )
 
     def test_presenter_shows_correct_info_of_one_single_non_active_plan(self) -> None:

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -2,7 +2,6 @@
 
 from typing import Any, Callable
 from urllib.parse import quote
-from uuid import UUID
 
 
 class UrlIndexMethod:
@@ -36,68 +35,48 @@ class UrlIndexTestImpl:
     names.
     """
 
-    get_plan_details_url = UrlIndexMethod()
-    get_member_dashboard_url = UrlIndexMethod()
-    get_work_invite_url = UrlIndexMethod()
+    get_accountant_account_details_url = UrlIndexMethod()
+    get_accountant_dashboard_url = UrlIndexMethod()
+    get_accountant_invitation_url = UrlIndexMethod()
+    get_answer_company_work_invite_url = UrlIndexMethod()
+    get_approve_plan_url = UrlIndexMethod()
+    get_change_email_url = UrlIndexMethod()
+    get_company_account_details_url = UrlIndexMethod()
+    get_company_confirmation_url = UrlIndexMethod()
+    get_company_dashboard_url = UrlIndexMethod()
+    get_company_query_companies_url = UrlIndexMethod()
+    get_company_query_plans_url = UrlIndexMethod()
     get_company_summary_url = UrlIndexMethod()
     get_coop_summary_url = UrlIndexMethod()
-    get_company_dashboard_url = UrlIndexMethod()
-    get_draft_list_url = UrlIndexMethod()
+    get_create_draft_url = UrlIndexMethod()
+    get_delete_draft_url = UrlIndexMethod()
     get_draft_details_url = UrlIndexMethod()
-    get_answer_company_work_invite_url = UrlIndexMethod()
+    get_draft_list_url = UrlIndexMethod()
+    get_end_coop_url = UrlIndexMethod()
+    get_file_plan_url = UrlIndexMethod()
     get_global_barplot_for_certificates_url = UrlIndexMethod()
     get_global_barplot_for_means_of_production_url = UrlIndexMethod()
     get_global_barplot_for_plans_url = UrlIndexMethod()
+    get_hide_plan_url = UrlIndexMethod()
+    get_language_change_url = UrlIndexMethod()
+    get_line_plot_of_company_a_account = UrlIndexMethod()
+    get_line_plot_of_company_p_account = UrlIndexMethod()
     get_line_plot_of_company_prd_account = UrlIndexMethod()
     get_line_plot_of_company_r_account = UrlIndexMethod()
-    get_line_plot_of_company_p_account = UrlIndexMethod()
-    get_line_plot_of_company_a_account = UrlIndexMethod()
+    get_member_account_details_url = UrlIndexMethod()
+    get_member_confirmation_url = UrlIndexMethod()
+    get_member_dashboard_url = UrlIndexMethod()
+    get_member_query_companies_url = UrlIndexMethod()
+    get_member_query_plans_url = UrlIndexMethod()
+    get_my_plan_drafts_url = UrlIndexMethod()
+    get_my_plans_url = UrlIndexMethod()
+    get_plan_details_url = UrlIndexMethod()
     get_register_private_consumption_url = UrlIndexMethod()
     get_register_productive_consumption_url = UrlIndexMethod()
-    get_toggle_availability_url = UrlIndexMethod()
+    get_renew_plan_url = UrlIndexMethod()
     get_request_coop_url = UrlIndexMethod()
-    get_end_coop_url = UrlIndexMethod()
-    get_delete_draft_url = UrlIndexMethod()
-    get_accountant_dashboard_url = UrlIndexMethod()
-    get_my_plans_url = UrlIndexMethod()
-    get_file_plan_url = UrlIndexMethod()
     get_revoke_plan_filing_url = UrlIndexMethod()
-    get_unreviewed_plans_list_view_url = UrlIndexMethod()
-    get_approve_plan_url = UrlIndexMethod()
-    get_my_plan_drafts_url = UrlIndexMethod()
-    get_create_draft_url = UrlIndexMethod()
-    get_member_query_plans_url = UrlIndexMethod()
-    get_company_query_plans_url = UrlIndexMethod()
-    get_member_query_companies_url = UrlIndexMethod()
-    get_company_query_companies_url = UrlIndexMethod()
+    get_toggle_availability_url = UrlIndexMethod()
     get_unconfirmed_member_url = UrlIndexMethod()
-    get_member_account_details_url = UrlIndexMethod()
-    get_company_account_details_url = UrlIndexMethod()
-    get_accountant_account_details_url = UrlIndexMethod()
-    get_change_email_url = UrlIndexMethod()
-
-    def get_member_confirmation_url(self, *, token: str) -> str:
-        return f"get_member_confirmation_url {token}"
-
-    def get_company_confirmation_url(self, *, token: str) -> str:
-        return f"get_company_confirmation_url {token}"
-
-
-class RenewPlanUrlIndexTestImpl:
-    def get_renew_plan_url(self, plan_id: UUID) -> str:
-        return f"fake_renew_url:{plan_id}"
-
-
-class HidePlanUrlIndexTestImpl:
-    def get_hide_plan_url(self, plan_id: UUID) -> str:
-        return f"fake_hide_plan_url:{plan_id}"
-
-
-class AccountantInvitationUrlIndexImpl:
-    def get_accountant_invitation_url(self, token: str) -> str:
-        return f"accountant invitation {token} url"
-
-
-class LanguageChangerUrlIndexImpl:
-    def get_language_change_url(self, language_code: str) -> str:
-        return f"language change url for {language_code}"
+    get_unreviewed_plans_list_view_url = UrlIndexMethod()
+    get_work_invite_url = UrlIndexMethod()


### PR DESCRIPTION
Before this change there were several UrlIndex interfaces separate from the one "main" UrlIndex interface. This was confusing and did not add any value to the codebase. After this change there will be one single UrlIndex interface. This change made it possible to provide the exact same dependency injection logic for all routes. Therefore the CompanyModule could be removed from our codebase.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a