### PR TITLE
Unify all html templates into one base.html template

### DIFF
--- a/arbeitszeit_flask/templates/accountant/404.html
+++ b/arbeitszeit_flask/templates/accountant/404.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/accountant/company_summary.html
+++ b/arbeitszeit_flask/templates/accountant/company_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Company overview") }}</div>

--- a/arbeitszeit_flask/templates/accountant/dashboard.html
+++ b/arbeitszeit_flask/templates/accountant/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/accountant/get_accountant_account_details.html
+++ b/arbeitszeit_flask/templates/accountant/get_accountant_account_details.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 {% block content %}
 <div class="section has-text-centered">
   <h1 class="title">{{ gettext('User Account Data') }}</h1>

--- a/arbeitszeit_flask/templates/accountant/plan_details.html
+++ b/arbeitszeit_flask/templates/accountant/plan_details.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Plan information") }}</div>

--- a/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
+++ b/arbeitszeit_flask/templates/accountant/plans-to-review-list.html
@@ -1,4 +1,8 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
+
+{% block navbar_start %}
+  <div class="navbar-item">{{ gettext("List unreviewed plans") }}</div>
+{% endblock %}
 
 {% block content %}
 <section class="section"> 

--- a/arbeitszeit_flask/templates/auth/login_accountant.html
+++ b/arbeitszeit_flask/templates/auth/login_accountant.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">

--- a/arbeitszeit_flask/templates/auth/login_company.html
+++ b/arbeitszeit_flask/templates/auth/login_company.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">
@@ -35,6 +35,11 @@
                     </div>
                     <button class="button is-block is-primary is-large is-fullwidth">{{ gettext("Login") }}</button>
                 </form>
+            </div>
+            <div class="box has-text-centered">
+              <a href="{{ url_for('.signup_company') }}">
+                {{ gettext("Click here to create a new account.") }}
+              </a>
             </div>
         </div>
     </div>

--- a/arbeitszeit_flask/templates/auth/login_member.html
+++ b/arbeitszeit_flask/templates/auth/login_member.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">
@@ -35,6 +35,11 @@
                     </div>
                     <button class="button is-block is-primary is-large is-fullwidth">{{ gettext("Login") }}</button>
                 </form>
+            </div>
+            <div class="box has-text-centered">
+              <a href="{{ url_for('.signup_member') }}">
+                {{ gettext("Click here to create a new account.") }}
+              </a>
             </div>
         </div>
     </div>

--- a/arbeitszeit_flask/templates/auth/signup_accountant.html
+++ b/arbeitszeit_flask/templates/auth/signup_accountant.html
@@ -1,4 +1,4 @@
-{% extends "base_general_pages.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">

--- a/arbeitszeit_flask/templates/auth/signup_company.html
+++ b/arbeitszeit_flask/templates/auth/signup_company.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">
@@ -39,6 +39,11 @@
                     </div>
                     <button class="button is-block is-primary is-large is-fullwidth">{{ gettext("Sign Up") }}</button>
                 </form>
+            </div>
+            <div class="box has-text-centered">
+              <a href="{{ url_for('.login_company') }}">
+                {{ gettext("Click here to log in with an existing account.") }}
+              </a>
             </div>
         </div>
     </div>

--- a/arbeitszeit_flask/templates/auth/signup_member.html
+++ b/arbeitszeit_flask/templates/auth/signup_member.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium">
@@ -42,6 +42,11 @@
 
                     <button class="button is-block is-primary is-large is-fullwidth">{{ gettext("Sign Up") }}</button>
                 </form>
+            </div>
+            <div class="box has-text-centered">
+              <a href="{{ url_for('.login_member') }}">
+                {{ gettext("Click here to log in with an existing account.") }}
+              </a>
             </div>
         </div>
     </div>

--- a/arbeitszeit_flask/templates/auth/start.html
+++ b/arbeitszeit_flask/templates/auth/start.html
@@ -1,4 +1,4 @@
-{% extends "base_general_pages.html" %}
+{% extends "base.html" %}
 
 {% block body %}
 <section class="hero is-fullheight">

--- a/arbeitszeit_flask/templates/auth/start_hilfe.html
+++ b/arbeitszeit_flask/templates/auth/start_hilfe.html
@@ -1,4 +1,4 @@
-{% extends "base_general_pages.html" %}
+{% extends "base.html" %}
 {% from 'macros/start_hilfe.html' import start_hilfe %}
 
 {% block navigation_items %}

--- a/arbeitszeit_flask/templates/auth/unconfirmed_company.html
+++ b/arbeitszeit_flask/templates/auth/unconfirmed_company.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium has-text-centered">

--- a/arbeitszeit_flask/templates/auth/unconfirmed_member.html
+++ b/arbeitszeit_flask/templates/auth/unconfirmed_member.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section is-medium has-text-centered">

--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -1,3 +1,7 @@
+{% from 'macros/accountant_navigation.html' import accountant_navigation with context %}
+{% from 'macros/company_navigation.html' import company_navigation with context %}
+{% from 'macros/member_navigation.html' import member_navigation with context %}
+{% from 'macros/anonymous_navigation.html' import anonymous_navigation with context%}
 {% from 'macros/show_notifications.html' import show_notifications %}
 
 <!DOCTYPE html>
@@ -20,13 +24,33 @@
 <body>
   {% block body %}
   {% block navigation %}
+
+  {% if session['user_type'] == 'company' %}
+  {% set user_navigation = company_navigation %}
+
+  {% elif session['user_type'] == 'member' %}
+  {% set user_navigation = member_navigation %}
+
+  {% elif session['user_type'] == 'accountant' %}
+  {% set user_navigation = accountant_navigation %}
+
+  {% else %}
+  {% set user_navigation = anonymous_navigation %}
+
+  {% endif %}
+
+  {% call user_navigation() %}
+  {% block navbar_start %}
   {% endblock %}
+  {% endcall %}
+
+  {% endblock navigation%}
 
   {{ show_notifications() }}
 
   {% block content %}
-  {% endblock %}
-  {% endblock %}
+  {% endblock content %}
+  {% endblock body %}
 </body>
 
 </html>

--- a/arbeitszeit_flask/templates/company/404.html
+++ b/arbeitszeit_flask/templates/company/404.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/company/account_a.html
+++ b/arbeitszeit_flask/templates/company/account_a.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a>

--- a/arbeitszeit_flask/templates/company/account_p.html
+++ b/arbeitszeit_flask/templates/company/account_p.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a>

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a>

--- a/arbeitszeit_flask/templates/company/account_r.html
+++ b/arbeitszeit_flask/templates/company/account_r.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a>

--- a/arbeitszeit_flask/templates/company/company_summary.html
+++ b/arbeitszeit_flask/templates/company/company_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Company overview") }}</div>

--- a/arbeitszeit_flask/templates/company/coop_summary.html
+++ b/arbeitszeit_flask/templates/company/coop_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Cooperation") }}</div>

--- a/arbeitszeit_flask/templates/company/create_cooperation.html
+++ b/arbeitszeit_flask/templates/company/create_cooperation.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_cooperations') }}">{{ gettext("My cooperations") }}</a>

--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% from 'macros/draft_form.html' import draft_form %}
 

--- a/arbeitszeit_flask/templates/company/dashboard.html
+++ b/arbeitszeit_flask/templates/company/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/company/get_company_account_details.html
+++ b/arbeitszeit_flask/templates/company/get_company_account_details.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 {% block content %}
 <div class="section has-text-centered">
   <h1 class="title">{{ gettext('User Account Data') }}</h1>

--- a/arbeitszeit_flask/templates/company/help.html
+++ b/arbeitszeit_flask/templates/company/help.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/company/invite_worker_to_company.html
+++ b/arbeitszeit_flask/templates/company/invite_worker_to_company.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Invite worker") }}</div>

--- a/arbeitszeit_flask/templates/company/list_all_cooperations.html
+++ b/arbeitszeit_flask/templates/company/list_all_cooperations.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("All cooperations") }}</div>

--- a/arbeitszeit_flask/templates/company/list_all_transactions.html
+++ b/arbeitszeit_flask/templates/company/list_all_transactions.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <a class="navbar-item" href="{{ url_for('main_company.my_accounts') }}">{{ gettext("Accounts") }}</a>

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Accounts") }}</div>

--- a/arbeitszeit_flask/templates/company/my_consumptions.html
+++ b/arbeitszeit_flask/templates/company/my_consumptions.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("My consumptions") }}</div>

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("My cooperations") }}</div>

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("My plans") }}</div>

--- a/arbeitszeit_flask/templates/company/plan_details.html
+++ b/arbeitszeit_flask/templates/company/plan_details.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Plan information") }}</div>

--- a/arbeitszeit_flask/templates/company/query_companies.html
+++ b/arbeitszeit_flask/templates/company/query_companies.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("All companies") }}</div>

--- a/arbeitszeit_flask/templates/company/query_plans.html
+++ b/arbeitszeit_flask/templates/company/query_plans.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("All plans") }}</div>

--- a/arbeitszeit_flask/templates/company/register_hours_worked.html
+++ b/arbeitszeit_flask/templates/company/register_hours_worked.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Register hours worked") }}</div>

--- a/arbeitszeit_flask/templates/company/register_productive_consumption.html
+++ b/arbeitszeit_flask/templates/company/register_productive_consumption.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Registration of productive consumption") }}</div>

--- a/arbeitszeit_flask/templates/company/request_cooperation.html
+++ b/arbeitszeit_flask/templates/company/request_cooperation.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Request cooperation")}}</div>

--- a/arbeitszeit_flask/templates/company/statistics.html
+++ b/arbeitszeit_flask/templates/company/statistics.html
@@ -1,4 +1,4 @@
-{% extends "base_company.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Global statistics") }}</div>

--- a/arbeitszeit_flask/templates/macros/accountant_navigation.html
+++ b/arbeitszeit_flask/templates/macros/accountant_navigation.html
@@ -1,19 +1,13 @@
-{% extends "base.html" %}
+{% macro accountant_navigation() %}
 
-{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
       <a href="{{ url_for('main_accountant.get_accountant_account_details') }}"
          class="navbar-item"
          >
-        {% if current_user.is_authenticated %}
         <span class="icon"><i class="fas fa-book"></i></span>&nbsp;
         {{ current_user.name|truncate(20, True) }}
-        {% else %}
-        <span class="icon"><i class="fas fa-book"></i></span>&nbsp;
-        {{ gettext("Accountant view") }}
-        {% endif %}
       </a>
     </div>
 
@@ -27,35 +21,20 @@
 
   <div id="navbarOnTop" class="navbar-menu">
     <div class="navbar-start">
-      {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_accountant.dashboard') }}" class="navbar-item">
         {{ gettext("Dashboard") }}
       </a>
-      {% block navbar_start %}
-      {% endblock %}
-      {% endif %}
+      {{ caller() }}
     </div>
 
     <div class="navbar-end">
-      {% if not current_user.is_authenticated %}
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.login_accountant') }}">
-          {{ gettext("Sign in")}}
-        </a>
-      </div>
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.zurueck') }}">
-          {{ gettext("Back")}}
-        </a>
-      </div>
-      {% else %}
       <div class="navbar-item">
         <a class="button" href="{{ url_for('auth.logout') }}">
           {{ gettext("Sign out")}}
         </a>
       </div>
-      {% endif %}
     </div>
   </div>
 </nav>
-{% endblock %}
+
+{% endmacro %}

--- a/arbeitszeit_flask/templates/macros/anonymous_navigation.html
+++ b/arbeitszeit_flask/templates/macros/anonymous_navigation.html
@@ -1,8 +1,15 @@
-{% extends "base.html" %}
+{% macro anonymous_navigation(user_name) %}
 
-{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
+    <div class="navbar-item has-background-primary has-text-white">
+      <a href="{{ url_for('auth.start') }}"
+         class="navbar-item"
+         >
+        Arbeitszeitapp
+      </a>
+    </div>
+
     <a role="button" class="navbar-burger" onclick="expandMenu()" aria-label="menu" aria-expanded="false"
       data-target="navbarOnTop">
       <span aria-hidden="true"></span>
@@ -10,7 +17,11 @@
       <span aria-hidden="true"></span>
     </a>
   </div>
+
   <div id="navbarOnTop" class="navbar-menu">
+    <div class="navbar-start">
+      {{ caller() }}
+    </div>
     <div class="navbar-end">
       <div class="navbar-item has-dropdown is-hoverable">
 	<a class="navbar-link">
@@ -26,14 +37,18 @@
 	  {% endif %}
 	</div>
       </div>
-      {% block navigation_items %}
       <div class="navbar-item">
 	<a class="button is-primary" href="{{ url_for('auth.help') }}">
 	  {{ gettext('Help') }}
 	</a>
       </div>
-      {% endblock %}
+      <div class="navbar-item">
+        <a class="button" href="{{ url_for('auth.zurueck') }}">
+          {{ gettext("Back")}}
+        </a>
+      </div>
     </div>
   </div>
 </nav>
-{% endblock %}
+
+{% endmacro %}

--- a/arbeitszeit_flask/templates/macros/company_navigation.html
+++ b/arbeitszeit_flask/templates/macros/company_navigation.html
@@ -1,19 +1,13 @@
-{% extends "base.html" %}
+{% macro company_navigation() %}
 
-{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
       <a href="{{ url_for('main_company.get_company_account_details') }}"
          class="navbar-item"
          >
-        {% if current_user.is_authenticated %}
         <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
         {{ current_user.name|truncate(20, True) }}
-        {% else %}
-        <span class="icon"><i class="fas fa-industry"></i></span>&nbsp;
-        {{ gettext("Company view") }}
-        {% endif %}
       </a>
     </div>
 
@@ -27,32 +21,12 @@
 
   <div id="navbarOnTop" class="navbar-menu">
     <div class="navbar-start">
-      {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_company.dashboard') }}" class="navbar-item">
         {{ gettext("Dashboard") }}
       </a>
-      {% block navbar_start %}
-      {% endblock %}
-      {% endif %}
+      {{ caller() }}
     </div>
     <div class="navbar-end">
-      {% if not current_user.is_authenticated %}
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.login_company') }}">
-          {{ gettext("Sign in") }}
-        </a>
-      </div>
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.signup_company') }}">
-          {{ gettext("Sign up") }}
-        </a>
-      </div>
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.zurueck') }}">
-          {{ gettext("Back") }}
-        </a>
-      </div>
-      {% else %}
       <div class="navbar-item">
         <a class="button" href="{{ url_for('auth.logout') }}">
           {{ gettext("Sign out") }}
@@ -63,8 +37,8 @@
           {{ gettext("?") }}
         </a>
       </div>
-      {% endif %}
     </div>
   </div>
 </nav>
-{% endblock %}
+
+{% endmacro %}

--- a/arbeitszeit_flask/templates/macros/member_navigation.html
+++ b/arbeitszeit_flask/templates/macros/member_navigation.html
@@ -1,23 +1,15 @@
-{% extends "base.html" %}
+{% macro member_navigation() %}
 
-{% block navigation %}
 <nav class="navbar is-transparent" role="navigation" aria-label="main navigation">
   <div class="navbar-brand">
     <div class="navbar-item has-background-primary has-text-white">
       <a href="{{ url_for('main_member.get_member_account_details') }}"
          class="navbar-item"
          >
-        {% if current_user.is_authenticated %}
         <span class="icon">
           <i class="fas fa-user"></i>
         </span>&nbsp;
         {{ current_user.name|truncate(20, True) }}
-        {% else %}
-        <span class="icon">
-          <i class="fas fa-user"></i>
-        </span>&nbsp;
-        {{ gettext("Member view") }}
-        {% endif %}
       </a>
     </div>
 
@@ -31,33 +23,13 @@
 
   <div id="navbarOnTop" class="navbar-menu">
     <div class="navbar-start">
-      {% if current_user.is_authenticated %}
       <a href="{{ url_for('main_member.dashboard') }}" class="navbar-item">
         {{ gettext("Dashboard") }}
       </a>
-      {% block navbar_start %}
-      {% endblock %}
-      {% endif %}
+      {{ caller() }}
     </div>
 
     <div class="navbar-end">
-      {% if not current_user.is_authenticated %}
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.login_member') }}">
-          {{ gettext("Sign in")}}
-        </a>
-      </div>
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.signup_member') }}">
-          {{ gettext("Sign up")}}
-        </a>
-      </div>
-      <div class="navbar-item">
-        <a class="button" href="{{ url_for('auth.zurueck') }}">
-          {{ gettext("Back")}}
-        </a>
-      </div>
-      {% else %}
       <div class="navbar-item">
         <a class="button" href="{{ url_for('auth.logout') }}">
           {{ gettext("Sign out")}}
@@ -68,8 +40,8 @@
           ?
         </a>
       </div>
-      {% endif %}
     </div>
   </div>
 </nav>
-{% endblock %}
+
+{% endmacro %}

--- a/arbeitszeit_flask/templates/member/404.html
+++ b/arbeitszeit_flask/templates/member/404.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 

--- a/arbeitszeit_flask/templates/member/company_summary.html
+++ b/arbeitszeit_flask/templates/member/company_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Company overview") }}</div>

--- a/arbeitszeit_flask/templates/member/consumptions.html
+++ b/arbeitszeit_flask/templates/member/consumptions.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("My consumptions") }}</div>

--- a/arbeitszeit_flask/templates/member/coop_summary.html
+++ b/arbeitszeit_flask/templates/member/coop_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Cooperation") }}</div>

--- a/arbeitszeit_flask/templates/member/dashboard.html
+++ b/arbeitszeit_flask/templates/member/dashboard.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <div class="section">

--- a/arbeitszeit_flask/templates/member/get_member_account_details.html
+++ b/arbeitszeit_flask/templates/member/get_member_account_details.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 {% block content %}
 <div class="section has-text-centered">
   <h1 class="title">{{ gettext('User Account Data') }}</h1>

--- a/arbeitszeit_flask/templates/member/help.html
+++ b/arbeitszeit_flask/templates/member/help.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 {% block content %}
 
 {% from 'macros/start_hilfe.html' import start_hilfe %}

--- a/arbeitszeit_flask/templates/member/my_account.html
+++ b/arbeitszeit_flask/templates/member/my_account.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("My account") }}</div>

--- a/arbeitszeit_flask/templates/member/plan_details.html
+++ b/arbeitszeit_flask/templates/member/plan_details.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Plan information") }}</div>

--- a/arbeitszeit_flask/templates/member/query_companies.html
+++ b/arbeitszeit_flask/templates/member/query_companies.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("All companies") }}</div>

--- a/arbeitszeit_flask/templates/member/query_plans.html
+++ b/arbeitszeit_flask/templates/member/query_plans.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("All plans") }}</div>

--- a/arbeitszeit_flask/templates/member/register_private_consumption.html
+++ b/arbeitszeit_flask/templates/member/register_private_consumption.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Register consumption") }}</div>

--- a/arbeitszeit_flask/templates/member/show_company_work_invite_details.html
+++ b/arbeitszeit_flask/templates/member/show_company_work_invite_details.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 {% block content %}
 <div class="section has-text-centered">
   <p>

--- a/arbeitszeit_flask/templates/member/statistics.html
+++ b/arbeitszeit_flask/templates/member/statistics.html
@@ -1,4 +1,4 @@
-{% extends "base_member.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Global statistics") }}</div>


### PR DESCRIPTION
# Problem

Before this change html templates for arbeitszeitapp were separated into 4 different base templates which were used rather inconsistently. For example the the base_member.html template was used by all member routes but also by some auth routes. Because of those inconsistencies the base templates base_member.html, base_company.html and base_accountant.html had to handle authenticated and anonymous users. This was complicated and hard to understand.

# Solution

After this change there is only one base template base.html. This base template selects the appropriate navigation bar according to the users role, e.g. member, company, accoutant or anonymous. Apart from simplifying the html template logic this will enable us to consistently present certain UI elements, such as language selection widgets in the future for all pages.

The login pages for members and companies were changed slightly because of the above change to the template logic. Both of the mentioned login pages now contain a link to the signup page. This was necessary because previously those signup pages were accessed via links in the top navigation bar which are now gone.

# Screenshots

All member, accountant and company pages look identical to the versions before this change.

I'm sorry non-german speakers...

![Screenshot from 2023-11-15 15-39-47](https://github.com/arbeitszeit/arbeitszeitapp/assets/4805746/e1fc3bfc-27a0-407e-aec7-894bfcb6654e)
![Screenshot from 2023-11-15 15-39-27](https://github.com/arbeitszeit/arbeitszeitapp/assets/4805746/cca04d46-758e-4121-8695-a261ef71d3db)
![Screenshot from 2023-11-15 15-46-06](https://github.com/arbeitszeit/arbeitszeitapp/assets/4805746/0d62a7c5-cb02-499b-bc30-2c4bba2eca02)


Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (2x)