### PR TITLE
Fix wrong base template name in accountant view

### DIFF
--- a/arbeitszeit_flask/templates/accountant/coop_summary.html
+++ b/arbeitszeit_flask/templates/accountant/coop_summary.html
@@ -1,4 +1,4 @@
-{% extends "base_accountant.html" %}
+{% extends "base.html" %}
 
 {% block navbar_start %}
 <div class="navbar-item">{{ gettext("Cooperation") }}</div>


### PR DESCRIPTION
The template `accountant/coop_summary.html` was using an old base template that is not in the codebase anymore. The commit addresses the problem by changing the base template used to the current one.

_No labour time registration necessary_