### PR TITLE
Change behavior of "renew plan" button

### DIFF
--- a/arbeitszeit/use_cases/create_draft_from_plan.py
+++ b/arbeitszeit/use_cases/create_draft_from_plan.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+from arbeitszeit.datetime_service import DatetimeService
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class Request:
+    plan: UUID
+    company: UUID
+
+
+@dataclass
+class Response:
+    draft: Optional[UUID]
+
+    def is_rejected(self) -> bool:
+        return not self.draft
+
+
+@dataclass
+class CreateDraftFromPlanUseCase:
+    database: DatabaseGateway
+    datetime_service: DatetimeService
+
+    def create_draft_from_plan(self, request: Request) -> Response:
+        if not self.database.get_companies().with_id(request.company):
+            return Response(draft=None)
+        plan = self.database.get_plans().with_id(request.plan).first()
+        if not plan:
+            return Response(draft=None)
+        draft = self.database.create_plan_draft(
+            planner=request.company,
+            product_name=plan.prd_name,
+            description=plan.description,
+            costs=plan.production_costs,
+            production_unit=plan.prd_unit,
+            amount=plan.prd_amount,
+            timeframe_in_days=plan.timeframe,
+            is_public_service=plan.is_public_service,
+            creation_timestamp=self.datetime_service.now(),
+        )
+        return Response(draft=draft.id)

--- a/arbeitszeit/use_cases/get_draft_details.py
+++ b/arbeitszeit/use_cases/get_draft_details.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from datetime import datetime
 from decimal import Decimal
 from typing import Optional
 from uuid import UUID
@@ -19,6 +20,7 @@ class DraftDetailsSuccess:
     resources_cost: Decimal
     labour_cost: Decimal
     is_public_service: bool
+    creation_timestamp: datetime
 
 
 DraftDetailsResponse = Optional[DraftDetailsSuccess]
@@ -44,4 +46,5 @@ class GetDraftDetails:
             resources_cost=draft.production_costs.resource_cost,
             labour_cost=draft.production_costs.labour_cost,
             is_public_service=draft.is_public_service,
+            creation_timestamp=draft.creation_date,
         )

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -15,7 +15,7 @@ from arbeitszeit.use_cases.cancel_cooperation_solicitation import (
     CancelCooperationSolicitation,
     CancelCooperationSolicitationRequest,
 )
-from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraft
+from arbeitszeit.use_cases.create_draft_from_plan import CreateDraftFromPlanUseCase
 from arbeitszeit.use_cases.delete_draft import DeleteDraftUseCase
 from arbeitszeit.use_cases.deny_cooperation import (
     DenyCooperation,
@@ -81,9 +81,8 @@ from arbeitszeit_flask.views.register_productive_consumption import (
 )
 from arbeitszeit_flask.views.show_my_accounts_view import ShowMyAccountsView
 from arbeitszeit_web.query_plans import QueryPlansController, QueryPlansPresenter
-from arbeitszeit_web.url_index import UrlIndex
-from arbeitszeit_web.www.controllers.create_draft_controller import (
-    CreateDraftController,
+from arbeitszeit_web.www.controllers.create_draft_from_plan_controller import (
+    CreateDraftFromPlanController,
 )
 from arbeitszeit_web.www.controllers.delete_draft_controller import (
     DeleteDraftController,
@@ -106,8 +105,10 @@ from arbeitszeit_web.www.controllers.revoke_plan_filing_controller import (
 from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
     CompanyConsumptionsPresenter,
 )
+from arbeitszeit_web.www.presenters.create_draft_from_plan_presenter import (
+    CreateDraftFromPlanPresenter,
+)
 from arbeitszeit_web.www.presenters.create_draft_presenter import (
-    CreateDraftPresenter,
     GetPrefilledDraftDataPresenter,
 )
 from arbeitszeit_web.www.presenters.delete_draft_presenter import DeleteDraftPresenter
@@ -239,58 +240,18 @@ def delete_draft(
     return redirect(view_model.redirect_target)
 
 
-@CompanyRoute("/company/draft/from-plan/<uuid:plan_id>", methods=["GET", "POST"])
+@CompanyRoute("/company/draft/from-plan/<uuid:plan_id>", methods=["POST"])
 @commit_changes
 def create_draft_from_plan(
     plan_id: UUID,
-    get_plan_details_use_case: GetPlanDetailsUseCase,
-    get_plan_details_presenter: GetPrefilledDraftDataPresenter,
-    create_plan_draft_use_case: CreatePlanDraft,
-    create_draft_controller: CreateDraftController,
-    create_draft_presenter: CreateDraftPresenter,
-    not_found_view: Http404View,
-    url_index: UrlIndex,
+    use_case: CreateDraftFromPlanUseCase,
+    controller: CreateDraftFromPlanController,
+    presenter: CreateDraftFromPlanPresenter,
 ) -> Response:
-    form = CreateDraftForm(request.form)
-    if request.method == "GET":
-        use_case_request_get = GetPlanDetailsUseCase.Request(plan_id)
-        response = get_plan_details_use_case.get_plan_details(use_case_request_get)
-        if not response:
-            return not_found_view.get_response()
-        view_model_get = get_plan_details_presenter.show_prefilled_draft_data(
-            draft_data=response.plan_details, form=form
-        )
-        return FlaskResponse(
-            render_template(
-                "company/create_draft.html",
-                form=form,
-                view_model=view_model_get,
-            ),
-            status=200,
-        )
-    else:
-        if form.validate():
-            use_case_request = create_draft_controller.import_form_data(draft_form=form)
-            use_case_response = create_plan_draft_use_case(use_case_request)
-            view_model_post = create_draft_presenter.present_plan_creation(
-                use_case_response
-            )
-            if view_model_post.redirect_url is None:
-                return not_found_view.get_response()
-            else:
-                return redirect(view_model_post.redirect_url)
-        return FlaskResponse(
-            render_template(
-                "company/create_draft.html",
-                form=form,
-                view_model=dict(
-                    load_draft_url=url_index.get_my_plan_drafts_url(),
-                    save_draft_url=url_index.get_create_draft_url(),
-                    cancel_url=url_index.get_create_draft_url(),
-                ),
-            ),
-            status=400,
-        )
+    uc_request = controller.create_use_case_request(plan_id)
+    uc_response = use_case.create_draft_from_plan(uc_request)
+    view_model = presenter.render_response(uc_response)
+    return redirect(view_model.redirect_url)
 
 
 @CompanyRoute("/company/create_draft", methods=["GET", "POST"])

--- a/arbeitszeit_flask/templates/company/my_plans.html
+++ b/arbeitszeit_flask/templates/company/my_plans.html
@@ -163,7 +163,12 @@
         </div>
         <div class="media-right">
           <div class="content pt-1">
-            <a href="{{ plan.renew_plan_url }}"><i class="fas fa-redo"></i></a>
+            <form method="post" action="{{ plan.renew_plan_url }}">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+              <button class="button is-ghost" type="submit" title="{{ gettext('Renew plan') }}">
+                <i class="fas fa-redo"></i>
+              </button>
+            </form>
             &nbsp;
             <a href="{{ plan.hide_plan_url }}"><i class="fas fa-trash"></i></a>
           </div>

--- a/arbeitszeit_web/www/controllers/create_draft_from_plan_controller.py
+++ b/arbeitszeit_web/www/controllers/create_draft_from_plan_controller.py
@@ -1,0 +1,19 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.use_cases import create_draft_from_plan as use_case
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class CreateDraftFromPlanController:
+    session: Session
+
+    def create_use_case_request(self, plan: UUID) -> use_case.Request:
+        assert self.session.get_user_role() == UserRole.company
+        user = self.session.get_current_user()
+        assert user
+        return use_case.Request(
+            plan=plan,
+            company=user,
+        )

--- a/arbeitszeit_web/www/presenters/create_draft_from_plan_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_from_plan_presenter.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import create_draft_from_plan as use_case
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.request import Request
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirect_url: str
+
+
+@dataclass
+class CreateDraftFromPlanPresenter:
+    url_index: UrlIndex
+    request: Request
+    notifier: Notifier
+    translator: Translator
+
+    def render_response(self, response: use_case.Response) -> ViewModel:
+        self.notifier.display_info(
+            self.translator.gettext("A new draft was created from an expired plan.")
+        )
+        if response.draft:
+            return ViewModel(
+                redirect_url=self.url_index.get_draft_details_url(response.draft)
+            )
+        else:
+            return ViewModel(
+                redirect_url=self.request.get_header("Referer")
+                or self.url_index.get_my_plans_url()
+            )

--- a/tests/flask_integration/test_create_draft_from_plan_view.py
+++ b/tests/flask_integration/test_create_draft_from_plan_view.py
@@ -1,4 +1,4 @@
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from tests.data_generators import PlanGenerator
 
@@ -9,23 +9,17 @@ class ViewTests(ViewTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.plan_generator = self.injector.get(PlanGenerator)
+        self.company = self.login_company()
 
     def test_can_create_render_creation_page_from_existing_plan(self) -> None:
-        company = self.login_company()
-        plan = self.plan_generator.create_plan(planner=company.id)
+        plan = self.plan_generator.create_plan(planner=self.company.id)
+        response = self.client.post(self._get_url(plan.id))
+        self.assertEqual(response.status_code, 302)
+
+    def test_get_405_method_not_allowed_when_trying_to_get_the_route(self) -> None:
+        plan = self.plan_generator.create_plan(planner=self.company.id)
         response = self.client.get(self._get_url(plan.id))
-        self.assertEqual(response.status_code, 200)
-
-    def test_get_404_for_from_non_existing_plan_id(self) -> None:
-        self.login_company()
-        response = self.client.get(self._get_url(uuid4()))
-        self.assertEqual(response.status_code, 404)
-
-    def test_get_400_when_posting_random_form_data(self) -> None:
-        company = self.login_company()
-        plan = self.plan_generator.create_plan(planner=company.id)
-        response = self.client.post(self._get_url(plan.id), data={"test": "1"})
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 405)
 
     def _get_url(self, plan: UUID) -> str:
         return f"/company/draft/from-plan/{plan}"

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -357,8 +357,8 @@ class GeneralUrlIndexTests(ViewTestCase):
         self.login_company()
         plan = self.plan_generator.create_plan()
         url = self.url_index.get_renew_plan_url(plan.id)
-        response = self.client.get(url)
-        self.assertEqual(response.status_code, 200)
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 302)
 
     def test_hide_plan_url_for_existing_plan_leads_to_functional_url(
         self,

--- a/tests/request.py
+++ b/tests/request.py
@@ -25,8 +25,12 @@ class FakeRequest:
     def set_form(self, key: str, value: str) -> None:
         self._form[key] = value
 
-    def set_header(self, key: str, value: str) -> None:
-        self._environ[key] = value
+    def set_header(self, key: str, value: Optional[str]) -> None:
+        if value is None:
+            if key in self._environ:
+                del self._environ[key]
+        else:
+            self._environ[key] = value
 
     def get_request_target(self) -> str:
         return "/"

--- a/tests/use_cases/test_create_draft_from_plan.py
+++ b/tests/use_cases/test_create_draft_from_plan.py
@@ -1,0 +1,229 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit import records
+from arbeitszeit.use_cases import create_draft_from_plan as use_case
+from arbeitszeit.use_cases import get_draft_details, show_my_plans
+
+from .base_test_case import BaseTestCase
+
+
+class CreateDraftFromPlanTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(use_case.CreateDraftFromPlanUseCase)
+        self.my_plans_use_case = self.injector.get(show_my_plans.ShowMyPlansUseCase)
+        self.get_draft_details_use_case = self.injector.get(
+            get_draft_details.GetDraftDetails
+        )
+
+    def test_creating_draft_from_random_uuids_produces_rejection_response(self) -> None:
+        response = self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=uuid4(),
+                company=uuid4(),
+            )
+        )
+        assert response.is_rejected()
+
+    def test_that_creating_draft_from_existing_plan_for_existing_company_is_not_rejected(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(approved=True).id
+        company = self.company_generator.create_company()
+        response = self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=plan,
+                company=company,
+            )
+        )
+        assert not response.is_rejected()
+
+    def test_creating_draft_from_existing_plan_for_non_existing_company_produces_rejection_response(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(approved=True).id
+        response = self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=plan,
+                company=uuid4(),
+            )
+        )
+        assert response.is_rejected()
+
+    def test_that_company_has_an_additional_draft_after_succesful_request(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(approved=True).id
+        company = self.company_generator.create_company()
+        drafts_before_request = self.count_drafts_for_company(company)
+        self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=plan,
+                company=company,
+            )
+        )
+        drafts_after_request = self.count_drafts_for_company(company)
+        assert drafts_after_request == drafts_before_request + 1
+
+    def test_that_creating_draft_from_random_plan_id_for_existing_company_does_not_create_a_new_draft_for_that_company(
+        self,
+    ) -> None:
+        company = self.company_generator.create_company()
+        drafts_before_request = self.count_drafts_for_company(company)
+        self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=uuid4(),
+                company=company,
+            )
+        )
+        drafts_after_request = self.count_drafts_for_company(company)
+        assert drafts_after_request == drafts_before_request
+
+    @parameterized.expand([("testname1",), ("testname2",)])
+    def test_that_newly_created_draft_has_same_product_name_as_pre_existing_plan(
+        self, expected_name: str
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True, product_name=expected_name
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.product_name == expected_name
+
+    @parameterized.expand([("description test",), ("test2",)])
+    def test_that_newly_created_draft_has_same_description_as_pre_existing_plan(
+        self, expected_description: str
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True, description=expected_description
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.description == expected_description
+
+    @parameterized.expand([(Decimal(0),), (Decimal(1),)])
+    def test_that_newly_created_draft_has_same_means_cost_as_pre_existing_plan(
+        self, expected_cost: Decimal
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True,
+            costs=records.ProductionCosts(
+                means_cost=expected_cost,
+                labour_cost=Decimal(0),
+                resource_cost=Decimal(0),
+            ),
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.means_cost == expected_cost
+
+    @parameterized.expand([(Decimal(0),), (Decimal(1),)])
+    def test_that_newly_created_draft_has_same_labour_cost_as_pre_existing_plan(
+        self, expected_cost: Decimal
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True,
+            costs=records.ProductionCosts(
+                labour_cost=expected_cost,
+                means_cost=Decimal(0),
+                resource_cost=Decimal(0),
+            ),
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.labour_cost == expected_cost
+
+    @parameterized.expand([(Decimal(0),), (Decimal(1),)])
+    def test_that_newly_created_draft_has_same_resource_cost_as_pre_existing_plan(
+        self, expected_cost: Decimal
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True,
+            costs=records.ProductionCosts(
+                resource_cost=expected_cost,
+                means_cost=Decimal(0),
+                labour_cost=Decimal(0),
+            ),
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.resources_cost == expected_cost
+
+    @parameterized.expand([("test unit 1",), ("test unit 2",)])
+    def test_that_newly_created_draft_has_same_production_unit_as_pre_existing_plan(
+        self, expected_unit: str
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True, production_unit=expected_unit
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.production_unit == expected_unit
+
+    @parameterized.expand([(123,), (321,)])
+    def test_that_newly_created_draft_has_same_amount_as_pre_existing_plan(
+        self, expected_amount: int
+    ) -> None:
+        plan = self.plan_generator.create_plan(approved=True, amount=expected_amount).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.amount == expected_amount
+
+    @parameterized.expand([(123,), (321,)])
+    def test_that_newly_created_draft_has_same_timeframe_as_pre_existing_plan(
+        self, expected_timeframe: int
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True, timeframe=expected_timeframe
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.timeframe == expected_timeframe
+
+    @parameterized.expand([(True,), (False,)])
+    def test_that_newly_created_draft_for_public_plan_if_and_only_if_original_plan_was_also_public(
+        self, expected_is_public: bool
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            approved=True, is_public_service=expected_is_public
+        ).id
+        summary = self.create_draft_and_get_details(plan)
+        assert summary.is_public_service == expected_is_public
+
+    @parameterized.expand([(datetime(2000, 1, 1),), (datetime(2001, 2, 3),)])
+    def test_that_creating_timestamp_of_draft_is_the_time_of_request(
+        self, expected_timestamp: datetime
+    ) -> None:
+        self.datetime_service.freeze_time(expected_timestamp - timedelta(days=1))
+        plan = self.plan_generator.create_plan(approved=True).id
+        self.datetime_service.freeze_time(expected_timestamp)
+        company = self.company_generator.create_company()
+        response = self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=plan,
+                company=company,
+            )
+        )
+        assert response.draft
+        self.datetime_service.freeze_time(expected_timestamp + timedelta(days=1))
+        summary = self.get_draft_details(response.draft)
+        assert summary.creation_timestamp == expected_timestamp
+
+    def create_draft_and_get_details(
+        self, plan: UUID
+    ) -> get_draft_details.DraftDetailsSuccess:
+        company = self.company_generator.create_company()
+        response = self.use_case.create_draft_from_plan(
+            request=use_case.Request(
+                plan=plan,
+                company=company,
+            )
+        )
+        assert response.draft
+        return self.get_draft_details(response.draft)
+
+    def count_drafts_for_company(self, company: UUID) -> int:
+        request = show_my_plans.ShowMyPlansRequest(company_id=company)
+        response = self.my_plans_use_case.show_company_plans(request)
+        return len(response.drafts)
+
+    def get_draft_details(self, draft: UUID) -> get_draft_details.DraftDetailsSuccess:
+        response = self.get_draft_details_use_case(draft)
+        assert response
+        return response

--- a/tests/use_cases/test_get_draft_details.py
+++ b/tests/use_cases/test_get_draft_details.py
@@ -1,6 +1,9 @@
+from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Callable
 from uuid import uuid4
+
+from parameterized import parameterized
 
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases.get_draft_details import (
@@ -10,6 +13,7 @@ from arbeitszeit.use_cases.get_draft_details import (
 )
 from tests.data_generators import CompanyGenerator, PlanGenerator
 
+from .base_test_case import BaseTestCase
 from .dependency_injection import injection_test
 
 
@@ -94,7 +98,7 @@ def test_that_correct_amount_is_shown(
 def test_that_correct_public_service_is_shown(
     plan_generator: PlanGenerator,
     get_draft_details: GetDraftDetails,
-):
+) -> None:
     draft = plan_generator.draft_plan(is_public_service=True)
     details = get_draft_details(draft)
     assert_success(details, lambda s: s.is_public_service == True)
@@ -105,6 +109,27 @@ def test_that_none_is_returned_when_draft_does_not_exist(
     get_draft_details: GetDraftDetails,
 ) -> None:
     assert get_draft_details(uuid4()) is None
+
+
+class GetDraftDetailsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.get_draft_details = self.injector.get(GetDraftDetails)
+
+    @parameterized.expand(
+        [
+            (datetime(2000, 1, 2),),
+            (datetime(2039, 1, 3),),
+        ]
+    )
+    def test_that_creation_timestamp_is_time_of_request_1(
+        self, expected_timestamp: datetime
+    ) -> None:
+        self.datetime_service.freeze_time(expected_timestamp)
+        draft = self.plan_generator.draft_plan(is_public_service=True)
+        self.datetime_service.advance_time(timedelta(days=1))
+        details = self.get_draft_details(draft)
+        assert_success(details, lambda s: s.creation_timestamp == expected_timestamp)
 
 
 def assert_success(

--- a/tests/www/controllers/test_create_draft_from_plan_controller.py
+++ b/tests/www/controllers/test_create_draft_from_plan_controller.py
@@ -1,0 +1,29 @@
+from uuid import uuid4
+
+from arbeitszeit_web.www.controllers.create_draft_from_plan_controller import (
+    CreateDraftFromPlanController,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+# It is okay (for now) to run the tests only for authenticated
+# companies since other users are not able to call to the controller
+# under test. We don't have any specific code to handle those cases
+# anyway.
+class AuthenticatedCompanyTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(CreateDraftFromPlanController)
+        self.company = uuid4()
+        self.session.login_company(self.company)
+
+    def test_that_provided_uuid_is_forwarded_to_use_case_request(self) -> None:
+        expected_plan = uuid4()
+        request = self.controller.create_use_case_request(plan=expected_plan)
+        assert request.plan == expected_plan
+
+    def test_that_currently_logged_in_company_is_forwared_to_use_case_request(
+        self,
+    ) -> None:
+        request = self.controller.create_use_case_request(plan=uuid4())
+        assert request.company == self.company

--- a/tests/www/presenters/test_create_draft_from_plan_presenter.py
+++ b/tests/www/presenters/test_create_draft_from_plan_presenter.py
@@ -1,0 +1,58 @@
+from uuid import uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.use_cases import create_draft_from_plan as use_case
+from arbeitszeit_web.www.presenters.create_draft_from_plan_presenter import (
+    CreateDraftFromPlanPresenter,
+)
+from tests.request import FakeRequest
+from tests.www.base_test_case import BaseTestCase
+
+
+class CreateDraftFromPlanPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(CreateDraftFromPlanPresenter)
+        self.request = self.injector.get(FakeRequest)
+
+    def test_that_user_is_redirected_to_plan_details_view_on_success(self) -> None:
+        expected_draft_id = uuid4()
+        response = use_case.Response(draft=expected_draft_id)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url == self.url_index.get_draft_details_url(
+            expected_draft_id
+        )
+
+    @parameterized.expand(
+        [
+            ("test",),
+            ("other/test"),
+        ]
+    )
+    def test_that_user_is_redirected_to_last_visited_page_on_failure(
+        self, expected_url: str
+    ) -> None:
+        response = use_case.Response(draft=None)
+        self.request.set_header("Referer", expected_url)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url == expected_url
+
+    def test_that_user_is_redirected_to_company_plans_list_if_referer_is_not_set(
+        self,
+    ) -> None:
+        response = use_case.Response(draft=None)
+        self.request.set_header("Referer", None)
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirect_url == self.url_index.get_my_plans_url()
+
+    def test_that_user_is_notified_about_successful_draft_creation_on_success(
+        self,
+    ) -> None:
+        expected_draft_id = uuid4()
+        response = use_case.Response(draft=expected_draft_id)
+        self.presenter.render_response(response)
+        assert (
+            self.translator.gettext("A new draft was created from an expired plan.")
+            in self.notifier.infos
+        )

--- a/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from decimal import Decimal
 from uuid import uuid4
 
@@ -21,6 +22,7 @@ TEST_DRAFT_SUMMARY_SUCCESS = DraftDetailsSuccess(
     resources_cost=Decimal(7),
     labour_cost=Decimal(7),
     is_public_service=False,
+    creation_timestamp=datetime(2000, 1, 1),
 )
 
 


### PR DESCRIPTION
Before this change the "renew plan" button would load the "create draft" form and only after the user would click the "save draft" button a new draft would be saved.

After this change a new draft will immediately be created when user clicks "renew plan" button. The user will then be redirected to the draft details view for that newly created draft.

This change allows us to extend the "renew plan" feature easily to other plans then just expired ones from the planning company. It would be very easy to allow the user to "clone" plans from other companies or create drafts from currently active plans via the means provided by this change. Also the individual parts of this implementation can be tested more easily and rigorously as there is a clear separation between the draft creation and the draft editing features of the application. The coupling between those two systems is minimal.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (3x)