### PR TITLE
Fix html layout of most pages

### DIFF
--- a/arbeitszeit_flask/templates/auth/start.html
+++ b/arbeitszeit_flask/templates/auth/start.html
@@ -12,6 +12,10 @@
 </div>
 {% endblock %}
 
+{% block content_class %}
+hero-body
+{% endblock %}
+
 {% block content %}
 <div class="hero-body">
   <div class="container has-text-centered">

--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -48,8 +48,10 @@
 
   {{ show_notifications() }}
 
-  {% block content %}
-  {% endblock content %}
+  <div class="{% block content_class %}container{% endblock %}">
+    {% block content %}
+    {% endblock content %}
+  </div>
   {% endblock body %}
 </body>
 


### PR DESCRIPTION
Before this change the layout of most pages was messed up. The content would usually span the whole width of the viewport. After this change most of those pages will only span the whole viewport of the browser for small and medium sized browser windows.

_No registration of labour time needed_