### PR TITLE
Drop python3.9

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 sphinx:
    configuration: docs/conf.py

--- a/README.rst
+++ b/README.rst
@@ -442,9 +442,9 @@ Developing with different python versions
 You can access a development environment with any of the supported
 python versions via ``nix develop``. Check `flake.nix` for the
 supported environments under the key ``devShells``. For example to
-enter a development shell with ``python3.9`` set as the default
-interpreter run ``nix develop .#python39``. This will drop you into a
-shell with python3.9 as the default python interpreter. This won't
+enter a development shell with ``python3.11`` set as the default
+interpreter run ``nix develop .#python311``. This will drop you into a
+shell with python3.11 as the default python interpreter. This won't
 change anything else on your machine and the respective python
 interpreter will be garbage collected the next time you run
 ``nix-collect-garbage``.

--- a/flake.nix
+++ b/flake.nix
@@ -25,8 +25,6 @@
             default = nixos-unstable;
             nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
             nixos-unstable = pkgs.callPackage nix/devShell.nix { };
-            python39 =
-              pkgs.callPackage nix/devShell.nix { python3 = pkgs.python39; };
             python310 =
               pkgs.callPackage nix/devShell.nix { python3 = pkgs.python310; };
             python311 =
@@ -45,7 +43,6 @@
             arbeitszeit-python3 = pkgs.python3.pkgs.arbeitszeitapp;
             arbeitszeit-python311 = pkgs.python311.pkgs.arbeitszeitapp;
             arbeitszeit-python310 = pkgs.python310.pkgs.arbeitszeitapp;
-            arbeitszeit-python39 = pkgs.python39.pkgs.arbeitszeitapp;
           };
         });
       systemIndependent = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,8 @@ name = "arbeitszeitapp"
 version = "0.0.0"
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 
 [project.optional-dependencies]
@@ -22,7 +22,7 @@ include-package-data = true
 find = {}
 
 [tool.black]
-target-version = ['py39']
+target-version = ['py310']
 extend-exclude = '''
 (
   ^/arbeitszeit_flask/development_settings\.py |


### PR DESCRIPTION
This change will disable all checks for python3.9 from the nix flake and auxilary tools, like readthedocs and black. Also the package metadata will not advertise compatibility with python3.9 anymore.