### PR TITLE
Implement basic framework for parsing www form fields

### DIFF
--- a/arbeitszeit_web/fields.py
+++ b/arbeitszeit_web/fields.py
@@ -1,4 +1,5 @@
-from typing import Protocol, TypeVar
+from dataclasses import dataclass
+from typing import Generic, Optional, Protocol, TypeVar
 
 T = TypeVar("T")
 
@@ -12,3 +13,30 @@ class FormField(Protocol[T]):
 
     def set_value(self, value: T) -> None:
         ...
+
+
+@dataclass
+class ParsingSuccess(Generic[T]):
+    value: T
+
+
+@dataclass
+class ParsingFailure:
+    errors: list[str]
+
+
+class FieldParser(Protocol[T]):
+    def __call__(self, value: str, /) -> ParsingSuccess[T] | ParsingFailure:
+        ...
+
+
+def parse_formfield(
+    field: FormField[str], parser: FieldParser[T]
+) -> Optional[ParsingSuccess[T]]:
+    match parser(field.get_value()):
+        case ParsingFailure(errors):
+            for error in errors:
+                field.attach_error(error)
+        case ParsingSuccess() as result:
+            return result
+    return None

--- a/arbeitszeit_web/www/controllers/register_private_consumption_controller.py
+++ b/arbeitszeit_web/www/controllers/register_private_consumption_controller.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from uuid import UUID
 
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionRequest,
 )
+from arbeitszeit_web.fields import parse_formfield
 from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.www.formfield_parsers import PositiveIntegerParser, UuidParser
 
 
 @dataclass
@@ -13,30 +17,25 @@ class RegisterPrivateConsumptionController:
     class FormError(Exception):
         pass
 
+    positive_integer_parser: PositiveIntegerParser
+    uuid_parser: UuidParser
     translator: Translator
 
     def import_form_data(
         self, current_user: UUID, form: RegisterPrivateConsumptionForm
     ) -> RegisterPrivateConsumptionRequest:
-        try:
-            plan_id = UUID(form.plan_id_field().get_value())
-        except ValueError:
-            form.plan_id_field().attach_error(
+        plan_id = parse_formfield(
+            form.plan_id_field(),
+            self.uuid_parser.with_invalid_uuid_message(
                 self.translator.gettext("Plan ID is invalid.")
-            )
-            raise self.FormError()
-        try:
-            amount = int(form.amount_field().get_value())
-            if amount <= 0:
-                form.amount_field().attach_error(
-                    self.translator.gettext("Must be a number larger than zero.")
-                )
-                raise self.FormError()
-        except ValueError:
-            form.amount_field().attach_error(
-                self.translator.gettext("This is not an integer.")
-            )
+            ),
+        )
+        amount = parse_formfield(
+            form.amount_field(),
+            self.positive_integer_parser,
+        )
+        if not plan_id or not amount:
             raise self.FormError()
         return RegisterPrivateConsumptionRequest(
-            consumer=current_user, plan=plan_id, amount=amount
+            consumer=current_user, plan=plan_id.value, amount=amount.value
         )

--- a/arbeitszeit_web/www/controllers/request_coordination_transfer_controller.py
+++ b/arbeitszeit_web/www/controllers/request_coordination_transfer_controller.py
@@ -1,41 +1,34 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
-from uuid import UUID
 
 from arbeitszeit.use_cases.request_coordination_transfer import (
     RequestCoordinationTransferUseCase as UseCase,
 )
+from arbeitszeit_web.fields import parse_formfield
 from arbeitszeit_web.forms import RequestCoordinationTransferForm
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.session import Session
-from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.www.formfield_parsers import UuidParser
 
 
 @dataclass
 class RequestCoordinationTransferController:
     session: Session
     request: Request
-    translator: Translator
+    uuid_parser: UuidParser
 
     def import_form_data(
         self, form: RequestCoordinationTransferForm
     ) -> Optional[UseCase.Request]:
-        try:
-            candidate = UUID(form.candidate_field().get_value())
-        except ValueError:
-            form.candidate_field().attach_error(self.translator.gettext("Invalid UUID"))
-            return None
-        try:
-            cooperation = UUID(form.cooperation_field().get_value())
-        except ValueError:
-            form.cooperation_field().attach_error(
-                self.translator.gettext("Invalid UUID")
-            )
-            return None
+        candidate = parse_formfield(form.candidate_field(), self.uuid_parser)
+        cooperation = parse_formfield(form.cooperation_field(), self.uuid_parser)
         current_user = self.session.get_current_user()
-        assert current_user
+        if not (candidate and cooperation and current_user):
+            return None
         return UseCase.Request(
             requester=current_user,
-            cooperation=cooperation,
-            candidate=candidate,
+            cooperation=cooperation.value,
+            candidate=candidate.value,
         )

--- a/arbeitszeit_web/www/formfield_parsers.py
+++ b/arbeitszeit_web/www/formfield_parsers.py
@@ -1,0 +1,64 @@
+from copy import copy
+from uuid import UUID
+
+from typing_extensions import Self
+
+from arbeitszeit_web.fields import ParsingFailure, ParsingSuccess
+from arbeitszeit_web.translator import Translator
+
+
+class UuidParser:
+    def __init__(self, translator: Translator) -> None:
+        self.translator = translator
+        self._invalid_uuid_message: str | None = None
+
+    def __call__(self, candidate: str) -> ParsingSuccess[UUID] | ParsingFailure:
+        try:
+            value = UUID(candidate.strip())
+        except ValueError:
+            message = self._invalid_uuid_message or self.translator.gettext(
+                "Invalid UUID."
+            )
+            return ParsingFailure([message])
+        return ParsingSuccess(value)
+
+    def with_invalid_uuid_message(self, message: str) -> Self:
+        new_parser = copy(self)
+        new_parser._invalid_uuid_message = message
+        return new_parser
+
+
+class PositiveIntegerParser:
+    def __init__(self, translator: Translator) -> None:
+        self.translator = translator
+        self._not_positive_message: str | None = None
+        self._not_an_integer_message: str | None = None
+
+    def __call__(self, value: str) -> ParsingSuccess[int] | ParsingFailure:
+        try:
+            amount = int(value.strip())
+        except ValueError:
+            return ParsingFailure(
+                [
+                    self._not_an_integer_message
+                    or self.translator.gettext("This is not an integer.")
+                ]
+            )
+        if amount <= 0:
+            return ParsingFailure(
+                [
+                    self._not_positive_message
+                    or self.translator.gettext("Must be a number larger than zero.")
+                ]
+            )
+        return ParsingSuccess(amount)
+
+    def with_not_positive_message(self, message: str) -> Self:
+        new_parser = copy(self)
+        new_parser._not_positive_message = message
+        return new_parser
+
+    def with_not_an_integer_message(self, message: str) -> Self:
+        new_parser = copy(self)
+        new_parser._not_an_integer_message = message
+        return new_parser

--- a/tests/www/controllers/test_register_productive_consumption_controller.py
+++ b/tests/www/controllers/test_register_productive_consumption_controller.py
@@ -16,9 +16,7 @@ class AuthenticatedCompanyTests(BaseTestCase):
         super().setUp()
         self.expected_user_id = uuid4()
         self.session.login_company(self.expected_user_id)
-        self.controller = RegisterProductiveConsumptionController(
-            self.session, self.translator
-        )
+        self.controller = self.injector.get(RegisterProductiveConsumptionController)
 
     def test_use_case_request_gets_returned_when_correct_input_data(self):
         output = self.controller.process_input_data(self.get_fake_form())


### PR DESCRIPTION
Before this change there was no guidance nor a pattern one could follow to implement www form field parsing. With this change a basic framework for form field parsing is introduced.

The new functionality is located under `arbeitszeit_web.fields`. There is now a function `parse_formfield` that takes a `FormField` and a `FieldParser[T]` to produce an `Optional[T]` while attaching potential error messages to the form field. A `FieldParser` can be any `Callable` that receives a single string argument and produces `ParsingSuccess[T] | ParsingFailure`.

The newly introduced framework was used to rework some www controllers which already performed form field parsing.

One of the designs that were considered was an exception based control flow a la django with its
[ValidationError](https://docs.djangoproject.com/en/4.2/ref/forms/fields/#django.forms.Field.clean). This approach was rejected as it used exceptions as a control flow mechanism which is only slightly less footgun-y than GOTO. Exceptions as control flow also make it slightly awkward to handle cases where multiple error messages should be attached in a single parsing process as one would have to aggregate the individual messages and the raise a single exception based on those. This is counter intuitive for some developers as usually exceptions are raise immediately if a calculation/function cannot be continued. The approach take where the parser yields a result of one of two types (`ParsingResult[T]` or `ParsingFailure`) might look a little bit unsual at first glance but allows the reader to infer the specification of a form field parser by looking at its type signature. An exception based control flow would not allow that and neither would it allow a type checker to assist debugging.

It was also considered to remove the `ParsingResult` type and let `parse_formfield` return the parsed value directly. This would complicate cases where `None` is a valid parsing result though and was therefor rejected.

Currently a `FieldParser` is expected to be a callable. We considered changing the interface so that there must be a named method a la `parse_form_field(self, value: str, /) -> ParsingSuccess[T] | ParsingFailure`. This was rejected as utilizing the `__call__` procol allows users to pass in functions for parsing as well as instances of custom classes. The danger of accidentally passing a non-parser function into `parse_formfields` without the type checker noticing was considered very very low as such a function would need to yield a `ParsingSuccess[T] | ParsingFailure` to be accepted.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (3x)