### PR TITLE
Fix babel.cfg which prevented msgid extraction

### DIFF
--- a/babel.cfg
+++ b/babel.cfg
@@ -1,5 +1,2 @@
-[python: arbeitszeit/**.py]
-[python: arbeitszeit_flask/**.py]
-[python: arbeitszeit_web/**.py]
-
+[python: **.py]
 [jinja2: **/templates/**.html]


### PR DESCRIPTION
This change was made because of bug in `pybabel` which we hit.

https://github.com/python-babel/babel/issues/71

fixes #884 

I did not update the `.pot` file. "It worked on my machine" but feel free to test this yourself.

_No labor time registration needed_