### PR TITLE
Add AcceptCoordinationTransferPresenter

### DIFF
--- a/arbeitszeit/use_cases/accept_coordination_transfer.py
+++ b/arbeitszeit/use_cases/accept_coordination_transfer.py
@@ -19,7 +19,6 @@ class AcceptCoordinationTransferUseCase:
 
     @dataclass
     class Response:
-        @dataclass
         class RejectionReason(Exception, Enum):
             transfer_request_not_found = auto()
             transfer_request_closed = auto()
@@ -53,7 +52,7 @@ class AcceptCoordinationTransferUseCase:
         if result is None:
             raise self.Response.RejectionReason.transfer_request_not_found
         transfer_request, cooperation = result
-        if self._cooperation_has_a_coordination_tenure_after_transfer_request(
+        if self._cooperation_has_a_coordination_tenure_starting_after_transfer_request(
             cooperation=cooperation, transfer_request=transfer_request
         ):
             raise self.Response.RejectionReason.transfer_request_closed
@@ -69,7 +68,7 @@ class AcceptCoordinationTransferUseCase:
         )
         return new_tenure.cooperation
 
-    def _cooperation_has_a_coordination_tenure_after_transfer_request(
+    def _cooperation_has_a_coordination_tenure_starting_after_transfer_request(
         self, transfer_request: CoordinationTransferRequest, cooperation: Cooperation
     ) -> bool:
         latest_coordination_tenure_of_cooperation = (

--- a/arbeitszeit_web/www/presenters/accept_coordination_transfer_presenter.py
+++ b/arbeitszeit_web/www/presenters/accept_coordination_transfer_presenter.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from typing_extensions import assert_never
+
+from arbeitszeit.use_cases.accept_coordination_transfer import (
+    AcceptCoordinationTransferUseCase,
+)
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.session import UserRole
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    status_code: int
+    redirect_url: Optional[str]
+
+
+@dataclass
+class AcceptCoordinationTransferPresenter:
+    translator: Translator
+    notifier: Notifier
+    url_index: UrlIndex
+
+    def present(
+        self, use_case_response: AcceptCoordinationTransferUseCase.Response
+    ) -> ViewModel:
+        if use_case_response.is_rejected:
+            assert use_case_response.rejection_reason
+            warning, status_code = self._evaluate_rejection_reason(
+                use_case_response.rejection_reason
+            )
+            self.notifier.display_warning(warning)
+            return ViewModel(status_code=status_code, redirect_url=None)
+        else:
+            assert use_case_response.cooperation_id
+            self.notifier.display_info(
+                self.translator.gettext(
+                    "Successfully accepted the request. You are now coordinator of the cooperation."
+                )
+            )
+            return ViewModel(
+                status_code=304,
+                redirect_url=self.url_index.get_coop_summary_url(
+                    coop_id=use_case_response.cooperation_id, user_role=UserRole.company
+                ),
+            )
+
+    def _evaluate_rejection_reason(
+        self,
+        rejection_reason: AcceptCoordinationTransferUseCase.Response.RejectionReason,
+    ) -> tuple[str, int]:
+        if (
+            rejection_reason
+            is AcceptCoordinationTransferUseCase.Response.RejectionReason.transfer_request_not_found
+        ):
+            warning = self.translator.gettext("Transfer request not found.")
+            status_code = 404
+            return warning, status_code
+        elif (
+            rejection_reason
+            is AcceptCoordinationTransferUseCase.Response.RejectionReason.transfer_request_closed
+        ):
+            warning = self.translator.gettext("This request is not valid anymore.")
+            status_code = 409
+            return warning, status_code
+        assert_never(rejection_reason)

--- a/arbeitszeit_web/www/presenters/request_coordination_transfer_presenter.py
+++ b/arbeitszeit_web/www/presenters/request_coordination_transfer_presenter.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from uuid import UUID
 
+from typing_extensions import assert_never
+
 from arbeitszeit.use_cases.request_coordination_transfer import (
     RequestCoordinationTransferUseCase as UseCase,
 )
@@ -85,13 +87,7 @@ class RequestCoordinationTransferPresenter:
                     self.translator.gettext("Cooperation not found.")
                 )
                 return RequestCoordinationTransferViewModel(status_code=404)
-            else:
-                self.notifier.display_warning(
-                    self.translator.gettext(
-                        "Unknown error ocurred. Request has not been sent."
-                    )
-                )
-                return RequestCoordinationTransferViewModel(status_code=500)
+            assert_never(use_case_response.rejection_reason)
         else:
             self.notifier.display_info(
                 self.translator.gettext("Request has been sent.")

--- a/tests/www/presenters/test_accept_coordination_transfer_presenter.py
+++ b/tests/www/presenters/test_accept_coordination_transfer_presenter.py
@@ -1,0 +1,111 @@
+from typing import Optional
+from uuid import UUID, uuid4
+
+from arbeitszeit.use_cases.accept_coordination_transfer import (
+    AcceptCoordinationTransferUseCase,
+)
+from arbeitszeit_web.session import UserRole
+from arbeitszeit_web.www.presenters.accept_coordination_transfer_presenter import (
+    AcceptCoordinationTransferPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+rejection_reason = AcceptCoordinationTransferUseCase.Response.RejectionReason
+
+
+class AcceptCoordinationTransferPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(AcceptCoordinationTransferPresenter)
+
+    def test_that_no_redirect_url_is_returned_if_transfer_request_was_not_found(
+        self,
+    ) -> None:
+        response = self.presenter.present(
+            self.uc_response(
+                rejection_reason=rejection_reason.transfer_request_not_found
+            )
+        )
+        self.assertIsNone(response.redirect_url)
+
+    def test_that_status_code_is_404_if_transfer_request_was_not_found(self) -> None:
+        response = self.presenter.present(
+            self.uc_response(
+                rejection_reason=rejection_reason.transfer_request_not_found
+            )
+        )
+        self.assertEqual(404, response.status_code)
+
+    def test_that_correct_warning_is_displayed_if_transfer_request_was_not_found(
+        self,
+    ) -> None:
+        self.presenter.present(
+            self.uc_response(
+                rejection_reason=rejection_reason.transfer_request_not_found
+            )
+        )
+        expected = self.translator.gettext("Transfer request not found.")
+        self.assertEqual(self.notifier.warnings[0], expected)
+
+    def test_that_no_redirect_url_is_returned_if_transfer_request_was_closed(
+        self,
+    ) -> None:
+        response = self.presenter.present(
+            self.uc_response(rejection_reason=rejection_reason.transfer_request_closed)
+        )
+        self.assertIsNone(response.redirect_url)
+
+    def test_that_status_code_is_409_if_transfer_request_was_closed(self) -> None:
+        response = self.presenter.present(
+            self.uc_response(rejection_reason=rejection_reason.transfer_request_closed)
+        )
+        self.assertEqual(409, response.status_code)
+
+    def test_that_correct_warning_is_displayed_if_transfer_request_was_closed(
+        self,
+    ) -> None:
+        self.presenter.present(
+            self.uc_response(rejection_reason=rejection_reason.transfer_request_closed)
+        )
+        expected = self.translator.gettext("This request is not valid anymore.")
+        self.assertEqual(self.notifier.warnings[0], expected)
+
+    def test_that_a_redirect_url_is_returned_if_transfer_request_was_accepted(
+        self,
+    ) -> None:
+        response = self.presenter.present(self.uc_response(cooperation_id=uuid4()))
+        self.assertIsNotNone(response.redirect_url)
+
+    def test_that_status_code_is_304_if_transfer_request_was_accepted(self) -> None:
+        response = self.presenter.present(self.uc_response(cooperation_id=uuid4()))
+        self.assertEqual(304, response.status_code)
+
+    def test_that_correct_info_is_displayed_if_transfer_request_was_accepted(
+        self,
+    ) -> None:
+        self.presenter.present(self.uc_response(cooperation_id=uuid4()))
+        expected = self.translator.gettext(
+            "Successfully accepted the request. You are now coordinator of the cooperation."
+        )
+        self.assertEqual(self.notifier.infos[0], expected)
+
+    def test_that_redirect_url_is_correct_if_transfer_request_was_accepted(
+        self,
+    ) -> None:
+        cooperation_id = uuid4()
+        response = self.presenter.present(
+            self.uc_response(cooperation_id=cooperation_id)
+        )
+        expected_url = self.url_index.get_coop_summary_url(
+            coop_id=cooperation_id, user_role=UserRole.company
+        )
+        self.assertEqual(response.redirect_url, expected_url)
+
+    def uc_response(
+        self,
+        rejection_reason: Optional[rejection_reason] = None,
+        cooperation_id: Optional[UUID] = None,
+    ) -> AcceptCoordinationTransferUseCase.Response:
+        return AcceptCoordinationTransferUseCase.Response(
+            rejection_reason=rejection_reason, cooperation_id=cooperation_id
+        )


### PR DESCRIPTION
Add AcceptCoordinationTransferPresenter

In order to make sure that all rejection reasons from the use case response are handled, an exhaustiveness check (`assert_never`)  is introduced in this new presenter and as well in the RequestCoordinationTransferPresenter.

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c (3x)