### PR TITLE
Refactor authentication in company, member and accountant blueprints

### DIFF
--- a/arbeitszeit_flask/member/blueprint.py
+++ b/arbeitszeit_flask/member/blueprint.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, List, Optional
 from flask import Blueprint, redirect
 
 from arbeitszeit_flask import types
-from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_flask.dependency_injection import create_dependency_injector
 from arbeitszeit_web.www.authentication import MemberAuthenticator
 
 main_member = Blueprint("main_member", __name__)
@@ -21,27 +21,19 @@ class MemberRoute:
     def __call__(self, view_function: Callable[..., types.Response]):
         @wraps(view_function)
         def _wrapper(*args: Any, **kwargs: Any) -> types.Response:
-            return view_function(*args, **kwargs)
-
-        return self._apply_decorators(_wrapper)
-
-    def _apply_decorators(self, function):
-        return main_member.route(self.route_string, methods=self.methods)(
-            with_injection()((self._check_is_member_and_confirmed)(function))
-        )
-
-    @with_injection()
-    def _check_is_member_and_confirmed(
-        self,
-        func,
-        authenticator: MemberAuthenticator,
-    ):
-        @wraps(func)
-        def decorated_function(*args, **kwargs):
+            injector = create_dependency_injector()
+            authenticator = injector.get(MemberAuthenticator)
             redirect_url = authenticator.redirect_user_to_member_login()
             if redirect_url:
                 return redirect(redirect_url)
-            else:
-                return func(*args, **kwargs)
+            return injector.call_with_injection(
+                view_function,
+                args=args,
+                kwargs=kwargs,
+            )
 
-        return decorated_function
+        main_member.route(self.route_string, methods=self.methods)(_wrapper)
+        # We return the original view_function to mimic the behavior
+        # of flask itself in this regard. The flask @route decorator
+        # also returns the original function that was passed into it.
+        return view_function


### PR DESCRIPTION
Before the change code in the blueprint module for the company, member and accountant blueprints was hard to understand as it was using a lot of decorators. After this change the code in those modules should be way easier to understand then before.

*No labour time registration required*