### PR TITLE
Forbid unconfirmed companies from filing plans

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -179,6 +179,11 @@ class PlanDraftResult(QueryResult[records.PlanDraft], Protocol):
     def update(self) -> PlanDraftUpdate:
         ...
 
+    def joined_with_planner_and_email_address(
+        self,
+    ) -> QueryResult[tuple[records.PlanDraft, records.Company, records.EmailAddress]]:
+        ...
+
     def delete(self) -> int:
         ...
 

--- a/tests/use_cases/test_file_plan_with_accounting.py
+++ b/tests/use_cases/test_file_plan_with_accounting.py
@@ -175,6 +175,13 @@ class UseCaseTests(BaseUseCaseTestCase):
             response.is_plan_successfully_filed,
         )
 
+    def test_cannot_file_plan_if_planner_is_not_confirmed(self) -> None:
+        planner = self.company_generator.create_company(confirmed=False)
+        draft = self.plan_generator.draft_plan(planner=planner)
+        request = self.create_request(draft=draft, filing_company=planner)
+        response = self.use_case.file_plan_with_accounting(request)
+        assert not response.is_plan_successfully_filed
+
 
 class NotificationTests(BaseUseCaseTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Before this change any company with an unconfirmed email address was able to file a plan with public accounting. After this change only companies with confirmed email addresses will be able to file plans.

This change was made separate authorization from authentication. Until now we handled authorization on the web layer which meant that companies with unconfirmed email addresses could do nothing useful with the app. Our current authorization approach also makes it necessary to do one additional call to the DB for every single request as need to look up the confirmation status of the users email address to decide whether we want to render the requested content of redirect them to the "unconfirmed page".

The approach taken in this change would allow us to render all pages unconditionally for any company and only discriminate confirmed and unconfirmed companies when they want to take an action that is "economically significant", e.g. filing a plan or registering the consumption of goods and services.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a