### PR TITLE
Refactor create_plan_draft use case

### DIFF
--- a/arbeitszeit_web/www/controllers/create_draft_controller.py
+++ b/arbeitszeit_web/www/controllers/create_draft_controller.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from arbeitszeit.records import ProductionCosts
-from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraftRequest
+from arbeitszeit.use_cases.create_plan_draft import Request
 from arbeitszeit_web.forms import DraftForm
 from arbeitszeit_web.session import Session
 
@@ -10,10 +10,10 @@ from arbeitszeit_web.session import Session
 class CreateDraftController:
     session: Session
 
-    def import_form_data(self, draft_form: DraftForm) -> CreatePlanDraftRequest:
+    def import_form_data(self, draft_form: DraftForm) -> Request:
         planner = self.session.get_current_user()
         assert planner
-        return CreatePlanDraftRequest(
+        return Request(
             costs=ProductionCosts(
                 labour_cost=draft_form.labour_cost_field().get_value(),
                 resource_cost=draft_form.resource_cost_field().get_value(),

--- a/arbeitszeit_web/www/presenters/create_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_presenter.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 from arbeitszeit.plan_details import PlanDetails
-from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraftResponse
+from arbeitszeit.use_cases.create_plan_draft import Response
 from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess
 from arbeitszeit_web.forms import DraftForm
 from arbeitszeit_web.notification import Notifier
@@ -51,7 +51,7 @@ class CreateDraftPresenter:
     notifier: Notifier
     translator: Translator
 
-    def present_plan_creation(self, response: CreatePlanDraftResponse) -> ViewModel:
+    def present_plan_creation(self, response: Response) -> ViewModel:
         redirect_url: Optional[str]
         if response.draft_id is None:
             redirect_url = None

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -24,10 +24,7 @@ from arbeitszeit.use_cases.create_cooperation import (
     CreateCooperation,
     CreateCooperationRequest,
 )
-from arbeitszeit.use_cases.create_plan_draft import (
-    CreatePlanDraft,
-    CreatePlanDraftRequest,
-)
+from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraft, Request
 from arbeitszeit.use_cases.file_plan_with_accounting import FilePlanWithAccounting
 from arbeitszeit.use_cases.register_accountant import RegisterAccountantUseCase
 from arbeitszeit.use_cases.register_company import RegisterCompany
@@ -315,7 +312,7 @@ class PlanGenerator:
         if timeframe is None:
             timeframe = 14
         response = self.create_plan_draft_use_case(
-            request=CreatePlanDraftRequest(
+            request=Request(
                 costs=costs,
                 product_name=product_name,
                 production_unit=production_unit,

--- a/tests/use_cases/test_create_plan_draft.py
+++ b/tests/use_cases/test_create_plan_draft.py
@@ -6,13 +6,13 @@ from arbeitszeit.records import ProductionCosts
 from arbeitszeit.use_cases import get_draft_details
 from arbeitszeit.use_cases.create_plan_draft import (
     CreatePlanDraft,
-    CreatePlanDraftRequest,
-    CreatePlanDraftResponse,
+    RejectionReason,
+    Request,
 )
 
 from .base_test_case import BaseTestCase
 
-REQUEST = CreatePlanDraftRequest(
+REQUEST = Request(
     planner=uuid4(),
     costs=ProductionCosts(
         Decimal(1),
@@ -57,10 +57,7 @@ class UseCaseTests(BaseTestCase):
         )
         response = self.create_plan_draft(request)
         assert response.is_rejected
-        assert (
-            response.rejection_reason
-            == CreatePlanDraftResponse.RejectionReason.planner_does_not_exist
-        )
+        assert response.rejection_reason == RejectionReason.planner_does_not_exist
         assert not response.draft_id
 
     def test_that_create_plan_gets_rejected_with_negative_production_costs(
@@ -74,10 +71,7 @@ class UseCaseTests(BaseTestCase):
         )
         response = self.create_plan_draft(request)
         assert response.is_rejected
-        assert (
-            response.rejection_reason
-            == CreatePlanDraftResponse.RejectionReason.negative_plan_input
-        )
+        assert response.rejection_reason == RejectionReason.negative_plan_input
         assert not response.draft_id
 
     def test_that_create_plan_gets_rejected_with_negative_production_amount(

--- a/tests/www/controllers/test_prefilled_draft_data_controller.py
+++ b/tests/www/controllers/test_prefilled_draft_data_controller.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
 from uuid import uuid4
 
-from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraftRequest
+from arbeitszeit.use_cases.create_plan_draft import Request
 from arbeitszeit_web.www.controllers.create_draft_controller import (
     CreateDraftController,
 )
@@ -28,7 +28,7 @@ class ControllerTests(BaseTestCase):
 
     def test_import_of_data_returns_a_request_object(self):
         request = self.controller.import_form_data(self.fake_form)
-        assert isinstance(request, CreatePlanDraftRequest)
+        assert isinstance(request, Request)
 
     def test_import_of_data_transforms_prd_name_string_to_correct_string(self):
         request = self.controller.import_form_data(self.fake_form)

--- a/tests/www/presenters/test_create_draft_presenter.py
+++ b/tests/www/presenters/test_create_draft_presenter.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 
-from arbeitszeit.use_cases.create_plan_draft import CreatePlanDraftResponse
+from arbeitszeit.use_cases.create_plan_draft import RejectionReason, Response
 from arbeitszeit_web.www.presenters.create_draft_presenter import CreateDraftPresenter
 from tests.www.base_test_case import BaseTestCase
 
@@ -12,29 +12,29 @@ class PresenterTests(BaseTestCase):
 
     def test_on_successful_draft_creation_redirect_to_my_drafts_page(self) -> None:
         draft_id = uuid4()
-        response = CreatePlanDraftResponse(draft_id=draft_id, rejection_reason=None)
+        response = Response(draft_id=draft_id, rejection_reason=None)
         view_model = self.presenter.present_plan_creation(response)
         self.assertEqual(
             self.url_index.get_my_plan_drafts_url(), view_model.redirect_url
         )
 
     def test_on_failed_plan_creation_dont_redirect(self) -> None:
-        response = CreatePlanDraftResponse(
+        response = Response(
             draft_id=None,
-            rejection_reason=CreatePlanDraftResponse.RejectionReason.planner_does_not_exist,
+            rejection_reason=RejectionReason.planner_does_not_exist,
         )
         view_model = self.presenter.present_plan_creation(response)
         self.assertIsNone(view_model.redirect_url)
 
     def test_on_successful_creation_show_message(self) -> None:
         draft_id = uuid4()
-        response = CreatePlanDraftResponse(draft_id=draft_id, rejection_reason=None)
+        response = Response(draft_id=draft_id, rejection_reason=None)
         self.presenter.present_plan_creation(response)
         self.assertTrue(self.notifier.infos)
 
     def test_on_successful_creation_show_proper_message_text(self) -> None:
         draft_id = uuid4()
-        response = CreatePlanDraftResponse(draft_id=draft_id, rejection_reason=None)
+        response = Response(draft_id=draft_id, rejection_reason=None)
         self.presenter.present_plan_creation(response)
         self.assertEqual(
             self.notifier.infos[0],


### PR DESCRIPTION
This change aims to make the code around the CreatePlanDraft use case easier to handle and read. This was implemented in 2 ways. 

1) Move the RejectionReason class to the module level. 
2) Shorten the request and response class names.

*No registration of consumption required*