### PR TITLE
Remove create_member_record from MemberGenerator

### DIFF
--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -58,22 +58,18 @@ from tests.datetime_service import FakeDatetimeService
 
 @dataclass
 class MemberGenerator:
-    account_generator: AccountGenerator
     email_generator: EmailGenerator
-    database: DatabaseGateway
-    datetime_service: FakeDatetimeService
     register_member_use_case: RegisterMemberUseCase
     confirm_member_use_case: confirm_member.ConfirmMemberUseCase
-    password_hasher: PasswordHasher
 
-    def create_member_record(
+    def create_member(
         self,
         *,
         email: Optional[str] = None,
         name: str = "test member name",
         password: str = "password",
         confirmed: bool = True,
-    ) -> records.Member:
+    ) -> UUID:
         if email is None:
             email = self.email_generator.get_random_email()
         register_response = self.register_member_use_case.register_member(
@@ -89,25 +85,7 @@ class MemberGenerator:
                 )
             )
             assert confirm_response.is_confirmed
-        member = self.database.get_members().with_id(register_response.user_id).first()
-        assert member
-        return member
-
-    def create_member(
-        self,
-        *,
-        email: Optional[str] = None,
-        name: str = "test member name",
-        password: str = "password",
-        confirmed: bool = True,
-    ) -> UUID:
-        member = self.create_member_record(
-            email=email,
-            name=name,
-            password=password,
-            confirmed=confirmed,
-        )
-        return member.id
+        return register_response.user_id
 
 
 @dataclass

--- a/tests/use_cases/test_show_company_work_invite.py
+++ b/tests/use_cases/test_show_company_work_invite.py
@@ -34,20 +34,20 @@ class TestExistingMemberWithNonMatchingInvite(TestCase):
         self.member_generator = self.injector.get(MemberGenerator)
         self.company_generator = self.injector.get(CompanyGenerator)
         self.invite_worker = self.injector.get(InviteWorkerToCompanyUseCase)
-        self.invited_member = self.member_generator.create_member_record()
-        self.other_member = self.member_generator.create_member_record()
+        self.invited_member = self.member_generator.create_member()
+        self.other_member = self.member_generator.create_member()
         self.company = self.company_generator.create_company_record()
         invite_response = self.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company.id,
-                worker=self.invited_member.id,
+                worker=self.invited_member,
             )
         )
         self.invite_id = invite_response.invite_id
         assert self.invite_id
         request = ShowCompanyWorkInviteDetailsRequest(
             invite=self.invite_id,
-            member=self.other_member.id,
+            member=self.other_member,
         )
         self.response = self.use_case.show_company_work_invite_details(request)
 
@@ -60,10 +60,10 @@ class TestExistingMemberWithoutAnyInviteTest(TestCase):
         self.injector = get_dependency_injector()
         self.use_case = self.injector.get(ShowCompanyWorkInviteDetailsUseCase)
         self.member_generator = self.injector.get(MemberGenerator)
-        self.invited_member = self.member_generator.create_member_record()
+        self.invited_member = self.member_generator.create_member()
         request = ShowCompanyWorkInviteDetailsRequest(
             invite=uuid4(),
-            member=self.invited_member.id,
+            member=self.invited_member,
         )
         self.response = self.use_case.show_company_work_invite_details(request)
 
@@ -79,21 +79,21 @@ class TestExistingMemberWithMatchingInvite(TestCase):
         self.member_generator = self.injector.get(MemberGenerator)
         self.company_generator = self.injector.get(CompanyGenerator)
         self.invite_worker = self.injector.get(InviteWorkerToCompanyUseCase)
-        self.member = self.member_generator.create_member_record()
+        self.member = self.member_generator.create_member()
         self.company = self.company_generator.create_company_record(
             name=self.expected_company_name
         )
         invite_response = self.invite_worker(
             InviteWorkerToCompanyUseCase.Request(
                 company=self.company.id,
-                worker=self.member.id,
+                worker=self.member,
             )
         )
         self.invite_id = invite_response.invite_id
         assert self.invite_id
         request = ShowCompanyWorkInviteDetailsRequest(
             invite=self.invite_id,
-            member=self.member.id,
+            member=self.member,
         )
         self.response = self.use_case.show_company_work_invite_details(request)
 

--- a/tests/use_cases/test_show_p_account_details.py
+++ b/tests/use_cases/test_show_p_account_details.py
@@ -38,18 +38,17 @@ class UseCaseTester(BaseTestCase):
         assert response.company_id == company.id
 
     def test_that_no_info_is_generated_after_selling_of_consumer_product(self) -> None:
-        member = self.member_generator.create_member_record()
-        company = self.company_generator.create_company_record()
-
-        self.transaction_generator.create_transaction(
-            sending_account=member.account,
-            receiving_account=company.product_account,
-            amount_sent=Decimal(10),
-            amount_received=Decimal(8.5),
+        member = self.member_generator.create_member()
+        company = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=company)
+        transactions_before_consumption = len(
+            self.show_p_account_details(company).transactions
         )
-
-        response = self.show_p_account_details(company.id)
-        assert len(response.transactions) == 0
+        self.consumption_generator.create_private_consumption(
+            consumer=member, plan=plan.id
+        )
+        response = self.show_p_account_details(company)
+        assert len(response.transactions) == transactions_before_consumption
 
     def test_that_no_info_is_generated_when_company_sells_p(self) -> None:
         company1 = self.company_generator.create_company_record()

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -243,18 +243,19 @@ class UseCaseTester(BaseTestCase):
     def test_that_correct_consumer_info_is_shown_when_company_sold_to_member(
         self,
     ) -> None:
+        expected_consumer_name = "test 123 name"
         planner = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=planner)
-        consumer = self.member_generator.create_member_record()
+        consumer = self.member_generator.create_member(name=expected_consumer_name)
         self.consumption_generator.create_private_consumption(
-            plan=plan.id, consumer=consumer.id
+            plan=plan.id, consumer=consumer
         )
         response = self.show_prd_account_details(planner)
         transaction_of_sale = response.transactions[0]
         assert transaction_of_sale.buyer
         assert transaction_of_sale.buyer.buyer_is_member == True
-        assert transaction_of_sale.buyer.buyer_id == consumer.id
-        assert transaction_of_sale.buyer.buyer_name == consumer.name
+        assert transaction_of_sale.buyer.buyer_id == consumer
+        assert transaction_of_sale.buyer.buyer_name == expected_consumer_name
 
     def test_that_correct_consumer_info_is_shown_when_company_sold_to_company(
         self,

--- a/tests/use_cases/test_show_r_account_details.py
+++ b/tests/use_cases/test_show_r_account_details.py
@@ -37,18 +37,17 @@ class UseCaseTester(BaseTestCase):
         assert response.company_id == company.id
 
     def test_that_no_info_is_generated_after_selling_of_consumer_product(self) -> None:
-        member = self.member_generator.create_member_record()
-        company = self.company_generator.create_company_record()
-
-        self.transaction_generator.create_transaction(
-            sending_account=member.account,
-            receiving_account=company.product_account,
-            amount_sent=Decimal(10),
-            amount_received=Decimal(8.5),
+        member = self.member_generator.create_member()
+        company = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=company)
+        transactions_before_consumption = len(
+            self.show_r_account_details(company).transactions
         )
-
-        response = self.show_r_account_details(company.id)
-        assert len(response.transactions) == 0
+        self.consumption_generator.create_private_consumption(
+            consumer=member, plan=plan.id
+        )
+        response = self.show_r_account_details(company)
+        assert len(response.transactions) == transactions_before_consumption
 
     def test_that_no_info_is_generated_when_company_sells_p(self) -> None:
         company1 = self.company_generator.create_company_record()


### PR DESCRIPTION
Before this commit we relied on creating and handling `Member` records directly in our use case tests. This change removes this reliance and deletes the `create_member_record` method from the `MemberGenerator` class.

_No registration of consumption required_