### PR TITLE
Refactor QueryPrivateConsumptions

### DIFF
--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -34,6 +34,9 @@ from arbeitszeit_web.query_plans import QueryPlansController, QueryPlansPresente
 from arbeitszeit_web.www.controllers.query_companies_controller import (
     QueryCompaniesController,
 )
+from arbeitszeit_web.www.controllers.query_private_consumptions_controller import (
+    QueryPrivateConsumptionsController,
+)
 from arbeitszeit_web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
 )
@@ -67,10 +70,14 @@ from .blueprint import MemberRoute
 
 @MemberRoute("/consumptions")
 def consumptions(
-    query_consumptions: QueryPrivateConsumptions,
+    controller: QueryPrivateConsumptionsController,
+    use_case: QueryPrivateConsumptions,
     presenter: PrivateConsumptionsPresenter,
 ) -> Response:
-    response = query_consumptions(UUID(current_user.id))
+    uc_request = controller.process_request()
+    if not uc_request:
+        return FlaskResponse(status=403)
+    response = use_case.query_private_consumptions(uc_request)
     view_model = presenter.present_private_consumptions(response)
     return FlaskResponse(
         render_template(

--- a/arbeitszeit_web/www/controllers/query_private_consumptions_controller.py
+++ b/arbeitszeit_web/www/controllers/query_private_consumptions_controller.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases import query_private_consumptions as use_case
+from arbeitszeit_web.session import Session, UserRole
+
+
+@dataclass
+class QueryPrivateConsumptionsController:
+    session: Session
+
+    def process_request(self) -> use_case.Request | None:
+        match self.session.get_user_role():
+            case UserRole.member:
+                user_id = self.session.get_current_user()
+                assert user_id
+                return use_case.Request(member=user_id)
+            case _:
+                return None

--- a/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
@@ -1,10 +1,8 @@
 from dataclasses import dataclass
-from typing import Iterable, List
+from typing import List
 
 from arbeitszeit.datetime_service import DatetimeService
-from arbeitszeit.use_cases.query_private_consumptions import (
-    PrivateConsumptionsQueryResponse,
-)
+from arbeitszeit.use_cases.query_private_consumptions import Response
 
 
 @dataclass
@@ -25,12 +23,9 @@ class PrivateConsumptionsPresenter:
 
     datetime_service: DatetimeService
 
-    def present_private_consumptions(
-        self, use_case_response: Iterable[PrivateConsumptionsQueryResponse]
-    ) -> ViewModel:
-        consumptions = list(use_case_response)
+    def present_private_consumptions(self, response: Response) -> ViewModel:
         return self.ViewModel(
-            is_consumptions_visible=bool(consumptions),
+            is_consumptions_visible=bool(response.consumptions),
             consumptions=[
                 self.ViewModel.Consumption(
                     consumption_date=self.datetime_service.format_datetime(
@@ -43,6 +38,6 @@ class PrivateConsumptionsPresenter:
                     consumption_amount=str(consumption.amount),
                     price_total=str(consumption.price_total),
                 )
-                for consumption in consumptions
+                for consumption in response.consumptions
             ],
         )

--- a/tests/use_cases/test_query_private_consumptions.py
+++ b/tests/use_cases/test_query_private_consumptions.py
@@ -1,6 +1,9 @@
 from datetime import datetime, timedelta
 
-from arbeitszeit.use_cases.query_private_consumptions import QueryPrivateConsumptions
+from arbeitszeit.use_cases.query_private_consumptions import (
+    QueryPrivateConsumptions,
+    Request,
+)
 from tests.use_cases.base_test_case import BaseTestCase
 
 
@@ -12,8 +15,10 @@ class TestQueryPrivateConsumptions(BaseTestCase):
 
     def test_that_no_consumption_is_returned_when_searching_an_empty_repo(self) -> None:
         member = self.member_generator.create_member()
-        results = list(self.query_consumptions(member))
-        assert not results
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert not response.consumptions
 
     def test_that_correct_consumptions_are_returned(self) -> None:
         expected_plan = self.plan_generator.create_plan().id
@@ -21,9 +26,11 @@ class TestQueryPrivateConsumptions(BaseTestCase):
         self.consumption_generator.create_private_consumption(
             consumer=member, plan=expected_plan
         )
-        results = list(self.query_consumptions(member))
-        assert len(results) == 1
-        assert results[0].plan_id == expected_plan
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert len(response.consumptions) == 1
+        assert response.consumptions[0].plan_id == expected_plan
 
     def test_that_consumptions_are_returned_in_correct_order(self) -> None:
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
@@ -37,6 +44,8 @@ class TestQueryPrivateConsumptions(BaseTestCase):
         self.consumption_generator.create_private_consumption(
             consumer=member, plan=second_plan
         )
-        results = list(self.query_consumptions(member))
-        assert results[0].plan_id == second_plan
-        assert results[1].plan_id == first_plan
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert response.consumptions[0].plan_id == second_plan
+        assert response.consumptions[1].plan_id == first_plan

--- a/tests/www/controllers/test_query_private_consumptions_controller.py
+++ b/tests/www/controllers/test_query_private_consumptions_controller.py
@@ -1,0 +1,33 @@
+from uuid import uuid4
+
+from arbeitszeit_web.www.controllers.query_private_consumptions_controller import (
+    QueryPrivateConsumptionsController,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class QueryPrivateConsumptionsControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(QueryPrivateConsumptionsController)
+
+    def test_that_resulting_request_contains_currently_logged_in_member_id(
+        self,
+    ) -> None:
+        expected_member_id = uuid4()
+        self.session.login_member(expected_member_id)
+        request = self.controller.process_request()
+        assert request
+        assert request.member == expected_member_id
+
+    def test_that_no_request_is_returned_if_user_is_logged_in_as_company(self) -> None:
+        self.session.login_company(uuid4())
+        request = self.controller.process_request()
+        assert request is None
+
+    def test_that_no_request_is_returned_if_user_is_logged_in_as_accountant(
+        self,
+    ) -> None:
+        self.session.login_accountant(uuid4())
+        request = self.controller.process_request()
+        assert request is None

--- a/tests/www/presenters/test_private_consumptions_presenter.py
+++ b/tests/www/presenters/test_private_consumptions_presenter.py
@@ -1,11 +1,8 @@
 from datetime import datetime
 from decimal import Decimal
-from typing import List
 from uuid import uuid4
 
-from arbeitszeit.use_cases.query_private_consumptions import (
-    PrivateConsumptionsQueryResponse,
-)
+from arbeitszeit.use_cases import query_private_consumptions as use_case
 from arbeitszeit_web.www.presenters.private_consumptions_presenter import (
     PrivateConsumptionsPresenter,
 )
@@ -32,15 +29,17 @@ class PresenterTests(BaseTestCase):
 
     def create_response_with_one_consumption(
         self, consumption_timestamp: datetime = datetime(2020, 1, 1)
-    ) -> List[PrivateConsumptionsQueryResponse]:
-        return [
-            PrivateConsumptionsQueryResponse(
-                consumption_date=consumption_timestamp,
-                plan_id=uuid4(),
-                product_name="test product",
-                product_description="test product description",
-                price_per_unit=Decimal("1"),
-                amount=1,
-                price_total=Decimal("1"),
-            )
-        ]
+    ) -> use_case.Response:
+        return use_case.Response(
+            consumptions=[
+                use_case.Consumption(
+                    consumption_date=consumption_timestamp,
+                    plan_id=uuid4(),
+                    product_name="test product",
+                    product_description="test product description",
+                    price_per_unit=Decimal("1"),
+                    amount=1,
+                    price_total=Decimal("1"),
+                )
+            ]
+        )


### PR DESCRIPTION
Before this change the QueryPrivateConsumptions use case and its associated web logic did not conform to our design guidelines. We addressed this issue by introducing a proper controller `QueryPrivateConsumptionsController` and updating the call conventions of the use case to accept a `Request` object, return a `Response` object and have a named method for calling into the use case instead of making the use case a callable object.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a