### PR TITLE
Delete unnecessary argument of data generator

### DIFF
--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -544,18 +544,13 @@ class CoordinationTransferRequestGenerator:
     def create_coordination_transfer_request(
         self,
         requester: Optional[UUID] = None,
-        coordinator: Optional[UUID] = None,
         cooperation: Optional[UUID] = None,
         candidate: Optional[UUID] = None,
     ) -> UUID:
         if requester is None:
             requester = self.company_generator.create_company()
         if cooperation is None:
-            if coordinator is None:
-                coordinator = self.company_generator.create_company()
-            cooperation = self.cooperation_generator.create_cooperation(
-                coordinator=coordinator
-            )
+            cooperation = self.cooperation_generator.create_cooperation()
         if candidate is None:
             candidate = self.company_generator.create_company()
         request_response = self.request_transfer_use_case.request_transfer(

--- a/tests/use_cases/test_get_coordination_transfer_request_details.py
+++ b/tests/use_cases/test_get_coordination_transfer_request_details.py
@@ -35,9 +35,7 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         expected_date = datetime(2020, 1, 4)
         self.datetime_service.freeze_time(expected_date)
         response = self.use_case.get_details(
-            self.use_case_request(
-                requester=requester, coordinator=coordinator, cooperation=cooperation
-            )
+            self.use_case_request(requester=requester, cooperation=cooperation)
         )
         assert response
         self.assertEqual(expected_date, response.request_date)
@@ -53,7 +51,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         response = self.use_case.get_details(
             self.use_case_request(
                 requester=requester,
-                coordinator=coordinator,
                 cooperation=cooperation,
             )
         )
@@ -73,7 +70,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         response = self.use_case.get_details(
             self.use_case_request(
                 requester=requester,
-                coordinator=coordinator,
                 cooperation=cooperation,
             )
         )
@@ -90,7 +86,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         response = self.use_case.get_details(
             self.use_case_request(
                 requester=requester,
-                coordinator=coordinator,
                 cooperation=cooperation,
                 candidate=candidate,
             )
@@ -110,7 +105,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         response = self.use_case.get_details(
             self.use_case_request(
                 requester=requester,
-                coordinator=coordinator,
                 cooperation=cooperation,
                 candidate=candidate,
             )
@@ -125,9 +119,7 @@ class GetTransferRequestDetailsTests(BaseTestCase):
             coordinator=coordinator
         )
         response = self.use_case.get_details(
-            self.use_case_request(
-                requester=requester, coordinator=coordinator, cooperation=cooperation
-            )
+            self.use_case_request(requester=requester, cooperation=cooperation)
         )
         assert response
         self.assertTrue(response.request_is_pending)
@@ -141,7 +133,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
         candidate = self.company_generator.create_company()
         transfer_request = self.coordination_transfer_request_generator.create_coordination_transfer_request(
             requester=requester,
-            coordinator=coordinator,
             cooperation=cooperation,
             candidate=candidate,
         )
@@ -160,7 +151,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
     def use_case_request(
         self,
         requester: UUID,
-        coordinator: UUID,
         cooperation: UUID,
         candidate: Optional[UUID] = None,
     ) -> UseCase.Request:
@@ -168,7 +158,6 @@ class GetTransferRequestDetailsTests(BaseTestCase):
             candidate = self.company_generator.create_company()
         transfer_request = self.coordination_transfer_request_generator.create_coordination_transfer_request(
             requester=requester,
-            coordinator=coordinator,
             cooperation=cooperation,
             candidate=candidate,
         )


### PR DESCRIPTION
The test data generator `CoordinationTransferRequestGenerator` expected an unnecessary argument, `coordinator`. It is unnecessary because it expects already the argument `cooperation`. If needed, the coordinator can be set on this cooperation.

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c