### PR TITLE
Reformat company account html files

### DIFF
--- a/arbeitszeit_flask/templates/company/account_a.html
+++ b/arbeitszeit_flask/templates/company/account_a.html
@@ -8,34 +8,27 @@
 {% block content %}
 {% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="mt-3 has-text-centered">
-    <h1 class="title">
-        {{ gettext("Account a") }}
-    </h1>
-</div>
-<div class="mt-5 has-text-centered">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
-            <div class="box has-background-info-light has-text-info-dark">
-                <div class="icon"><i class="fas fa-info-circle"></i></div>
-                <p>{{ gettext("Your account for work certificates") }}</p>
-            </div>
-            <p>{{ gettext("Balance:") }}</p>
-            <p
-                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
-                {{ view_model.account_balance }}
-            </p>
+<section class="section columns has-text-centered">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <div class="pb-5">
+            <h1 class="title">
+                {{ gettext("Account a") }}
+            </h1>
         </div>
-    </div>
-</div>
-<div class="has-text-centered">
-    <div>
-        <img src="{{ view_model.plot_url }}" alt="plot of a account">
-    </div>
-</div>
-<div class="section">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+        <div class="box has-background-info-light has-text-info-dark">
+            <div class="icon"><i class="fas fa-info-circle"></i></div>
+            <p>{{ gettext("The account for work certificates") }}</p>
+        </div>
+        <p>{{ gettext("Balance:") }}</p>
+        <p
+            class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+            {{ view_model.account_balance }}
+        </p>
+        <div>
+            <img src="{{ view_model.plot_url }}" alt="plot of a account">
+        </div>
+        <div class="section has-text-left">
             {% if view_model.transactions is defined and view_model.transactions|length %}
             {% for trans_info in view_model.transactions %}
             {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
@@ -43,5 +36,6 @@
             {% endif %}
         </div>
     </div>
-</div>
+    <div class="column"></div>
+</section>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/account_p.html
+++ b/arbeitszeit_flask/templates/company/account_p.html
@@ -8,34 +8,27 @@
 {% block content %}
 {% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="mt-3 has-text-centered">
-    <h1 class="title">
-        {{ gettext("Account p") }}
-    </h1>
-</div>
-<div class="mt-5 has-text-centered">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+<section class="section has-text-centered columns">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <div class="pb-5">
+            <h1 class="title">
+                {{ gettext("Account p") }}
+            </h1>
+        </div>
             <div class="box has-background-info-light has-text-info-dark">
                 <div class="icon"><i class="fas fa-info-circle"></i></div>
-                <p>{{ gettext("Your account for fixed means of production.") }}</p>
+                <p>{{ gettext("The account for fixed means of production.") }}</p>
             </div>
             <p>{{ gettext("Balance:") }}</p>
             <p
                 class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
                 {{ view_model.account_balance }}
             </p>
+        <div>
+            <img src="{{ view_model.plot_url }}" alt="plot of p account">
         </div>
-    </div>
-</div>
-<div class="has-text-centered">
-    <div>
-        <img src="{{ view_model.plot_url }}" alt="plot of p account">
-    </div>
-</div>
-<div class="section">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+        <div class="section has-text-left">
             {% if view_model.transactions is defined and view_model.transactions|length %}
             {% for trans_info in view_model.transactions %}
             {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
@@ -43,5 +36,6 @@
             {% endif %}
         </div>
     </div>
-</div>
+    <div class="column"></div>
+</section>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/account_prd.html
+++ b/arbeitszeit_flask/templates/company/account_prd.html
@@ -8,26 +8,27 @@
 {% block content %}
 {% from 'macros/transactions.html' import transaction_with_buyer %}
 
-<div class="section is-medium has-text-centered pb-0">
-    <h1 class="title">
-        {{ gettext("Account prd") }}
-    </h1>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("Your account for product transfers (sales).") }}</p>
-    </div>
-    <p>{{ gettext("Balance:") }}</p>
-    <p
-        class="py-2 has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
-        {{ view_model.account_balance }}</p>
-
-    <div>
-        <img src="{{ view_model.plot_url }}" alt="plot of prd account">
-    </div>
-</div>
-<div class="section">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+<section class="section columns has-text-centered">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <div class="pb-5">
+            <h1 class="title">
+                {{ gettext("Account prd") }}
+            </h1>
+            <div class="box has-background-info-light has-text-info-dark">
+                <div class="icon"><i class="fas fa-info-circle"></i></div>
+                <p>{{ gettext("The account for product transfers (sales).") }}</p>
+            </div>
+            <p>{{ gettext("Balance:") }}</p>
+            <p
+                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance|float >= 0 else 'has-text-danger' }}">
+                {{ view_model.account_balance }}</p>
+        
+            <div>
+                <img src="{{ view_model.plot_url }}" alt="plot of prd account">
+            </div>
+        </div>
+        <div class="section has-text-left">
             {% if view_model.show_transactions %}
             {% for trans_info in view_model.transactions %}
             {{ transaction_with_buyer(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume, trans_info.buyer_name, trans_info.buyer_type_icon) }}
@@ -35,5 +36,6 @@
             {% endif %}
         </div>
     </div>
-</div>
+    <div class="column"></div>
+</section>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/account_r.html
+++ b/arbeitszeit_flask/templates/company/account_r.html
@@ -8,34 +8,27 @@
 {% block content %}
 {% from 'macros/transactions.html' import basic_transaction %}
 
-<div class="mt-3 has-text-centered">
-    <h1 class="title">
-        {{ gettext("Account r") }}
-    </h1>
-</div>
-<div class="mt-5 has-text-centered">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
-            <div class="box has-background-info-light has-text-info-dark">
-                <div class="icon"><i class="fas fa-info-circle"></i></div>
-                <p>{{ gettext("Your account for liquid means of production") }}</p>
-            </div>
-            <p>{{ gettext("Balance:") }}</p>
-            <p
-                class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
-                {{ view_model.account_balance }}
-            </p>
+<section class="section has-text-centered columns">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <div class="pb-5">
+            <h1 class="title">
+                {{ gettext("Account r") }}
+            </h1>
         </div>
-    </div>
-</div>
-<div class="has-text-centered">
-    <div>
-        <img src="{{ view_model.plot_url }}" alt="plot of r account">
-    </div>
-</div>
-<div class="section">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+        <div class="box has-background-info-light has-text-info-dark">
+            <div class="icon"><i class="fas fa-info-circle"></i></div>
+            <p>{{ gettext("The account for liquid means of production") }}</p>
+        </div>
+        <p>{{ gettext("Balance:") }}</p>
+        <p
+            class="has-text-weight-bold {{ 'has-text-primary' if view_model.account_balance | float >= 0 else 'has-text-danger' }}">
+            {{ view_model.account_balance }}
+        </p>
+        <div>
+            <img src="{{ view_model.plot_url }}" alt="plot of r account">
+        </div>
+        <div class="section has-text-left">
             {% if view_model.transactions is defined and view_model.transactions|length %}
             {% for trans_info in view_model.transactions %}
             {{ basic_transaction(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume) }}
@@ -43,5 +36,6 @@
             {% endif %}
         </div>
     </div>
-</div>
+    <div class="column"></div>
+</section>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/list_all_transactions.html
+++ b/arbeitszeit_flask/templates/company/list_all_transactions.html
@@ -8,19 +8,18 @@
 {% block content %}
 {% from 'macros/transactions.html' import transaction_with_account %}
 
-<div class="section is-medium has-text-centered pb-0">
-    <h1 class="title">
-        {{ gettext("All transactions")
-        }}
-    </h1>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("Here are all transactions you have made or received so far.") }}</p>
-    </div>
-</div>
-<div class="section">
-    <div class="columns is-centered">
-        <div class="column is-two-thirds">
+<section class="section columns has-text-centered">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <h1 class="title">
+            {{ gettext("All transactions")
+            }}
+        </h1>
+        <div class="box has-background-info-light has-text-info-dark">
+            <div class="icon"><i class="fas fa-info-circle"></i></div>
+            <p>{{ gettext("All transactions made or received so far.") }}</p>
+        </div>
+        <div class="section has-text-left">
             {% if all_transactions is defined and all_transactions|length %}
             {% for trans_info in all_transactions %}
             {{ transaction_with_account(trans_info.date, trans_info.transaction_type, trans_info.purpose, trans_info.transaction_volume, trans_info.account) }}
@@ -28,5 +27,6 @@
             {% endif %}
         </div>
     </div>
-</div>
+    <div class="column"></div>
+</section>
 {% endblock %}

--- a/arbeitszeit_flask/templates/company/my_accounts.html
+++ b/arbeitszeit_flask/templates/company/my_accounts.html
@@ -6,76 +6,77 @@
 
 {% block content %}
 
-<div class="section has-text-centered">
-    <h1 class="title">
-        {{ gettext("Accounts") }}
-    </h1>
-    <br>
-    <div class="box has-background-info-light has-text-info-dark">
-        <div class="icon"><i class="fas fa-info-circle"></i></div>
-        <p>{{ gettext("You have four different accounts.") }}</p>
+<section class="section has-text-centered columns">
+    <div class="column"></div>
+    <div class="column is-two-thirds">
+        <h1 class="title">
+            {{ gettext("Accounts") }}
+        </h1>
+        <div class="box has-background-info-light has-text-info-dark">
+            <div class="icon"><i class="fas fa-info-circle"></i></div>
+            <p>{{ gettext("Each company has four accounts.") }}</p>
+        </div>
+        <div class="table-container has-text-left">
+            <table class="table mx-auto">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td class="py-2"><a href="{{ url_for('main_company.account_p') }}">{{
+                                        gettext("Account p") }}</a>
+                        </td>
+                        <td><i class="fas fa-industry"></i></td>
+                        <td class="is-italic">{{ gettext("Account for fixed means of production") }}
+                        </td>
+                        <td
+                            class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
+                            {{ view_model.balance_fixed }}</td>
+                    </tr>
+                    <tr>
+                        <td class="py-2"><a href="{{ url_for('main_company.account_r') }}">{{
+                                        gettext("Account r") }}</a>
+                        </td>
+                        <td><i class="fas fa-oil-can"></i></td>
+                        <td class="is-italic">{{ gettext("Account for liquid means of production")}}
+                        </td>
+                        <td
+                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
+                            {{ view_model.balance_liquid }}</td>
+                    </tr>
+                    <tr>
+                        <td class="py-2"><a href="{{ url_for('main_company.account_a') }}">{{
+                                        gettext("Account a") }}</a>
+                        </td>
+                        <td><i class="fas fa-users"></i></td>
+                        <td class="is-italic">{{ gettext("Account for work certificates (wages)") }}
+                        </td>
+                        <td
+                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
+                            {{ view_model.balance_work }}</td>
+                    </tr>
+                    <tr>
+                        <td class="py-2"><a href="{{ url_for('main_company.account_prd') }}">{{
+                                        gettext("Account prd") }}</a></td>
+                        <td><i class="fas fa-exchange-alt"></i></td>
+                        <td class="is-italic">{{ gettext("Account for product transfers (sales)") }}
+                        </td>
+                        <td
+                            class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
+                            {{ view_model.balance_product }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <p><a href="{{ url_for('main_company.list_all_transactions') }}">{{ gettext("List all transactions") }}</a>
+        </p>
     </div>
-    <br>
-    <div class="table-container">
-        <table class="table has-text-left mx-auto">
-            <thead>
-                <tr>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_p') }}">{{
-                                    gettext("Account p") }}</a>
-                    </td>
-                    <td><i class="fas fa-industry"></i></td>
-                    <td class="is-italic has-text-left">{{ gettext("Account for fixed means of production") }}
-                    </td>
-                    <td
-                        class="py-2  has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_fixed_positive else 'has-text-danger' }}">
-                        {{ view_model.balance_fixed }}</td>
-                </tr>
-                <tr>
-                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_r') }}">{{
-                                    gettext("Account r") }}</a>
-                    </td>
-                    <td><i class="fas fa-oil-can"></i></td>
-                    <td class="is-italic has-text-left">{{ gettext("Account for liquid means of production")}}
-                    </td>
-                    <td
-                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_liquid_positive else 'has-text-danger' }}">
-                        {{ view_model.balance_liquid }}</td>
-                </tr>
-                <tr>
-                    <td class="py-2  has-text-left"><a href="{{ url_for('main_company.account_a') }}">{{
-                                    gettext("Account a") }}</a>
-                    </td>
-                    <td><i class="fas fa-users"></i></td>
-                    <td class="is-italic has-text-left">{{ gettext("Account for work certificates (wages)") }}
-                    </td>
-                    <td
-                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_work_positive else 'has-text-danger' }}">
-                        {{ view_model.balance_work }}</td>
-                </tr>
-                <tr>
-                    <td class="py-2 has-text-left"><a href="{{ url_for('main_company.account_prd') }}">{{
-                                    gettext("Account prd") }}</a></td>
-                    <td><i class="fas fa-exchange-alt"></i></td>
-                    <td class="is-italic has-text-left">{{ gettext("Account for product transfers (sales)") }}
-                    </td>
-                    <td
-                        class="py-2 has-text-right has-text-weight-bold {{ 'has-text-primary' if view_model.is_product_positive else 'has-text-danger' }}">
-                        {{ view_model.balance_product }}</td>
-                </tr>
-            </tbody>
-        </table>
-    </div>
-    <p><a href="{{ url_for('main_company.list_all_transactions') }}">{{ gettext("List all transactions") }}</a>
-    </p>
-</div>
-</div>
+    <div class="column"></div>
+</section>
 
 {% endblock %}


### PR DESCRIPTION
Unify html structure of company account pages. Change second person address to neutral information (e.g. Your account for ... -> The account for ... ).

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c (1x)