### PR TITLE
Implement flask layer of email change request

### DIFF
--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -397,3 +397,18 @@ class RequestCoordinationTransferForm(Form):
 
     def cooperation_field(self) -> WtFormField[str]:
         return WtFormField(form=self, field_name="cooperation")
+
+
+class RequestEmailAddressChangeForm(Form):
+    new_email = StringField(
+        default="",
+        validators=[
+            validators.InputRequired(
+                message=trans.lazy_gettext("Email address is required.")
+            )
+        ],
+    )
+
+    @property
+    def new_email_field(self) -> WtFormField[str]:
+        return WtFormField(form=self, field_name="new_email")

--- a/arbeitszeit_flask/templates/user/request_email_address_change.html
+++ b/arbeitszeit_flask/templates/user/request_email_address_change.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="section has-text-centered">
+  <h1 class="title">{{ gettext('Change email address') }}</h1>
+  <form method="post">
+    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+    <div class="field">
+      <div class="control">
+        {{ form.new_email() }}
+      </div>
+      {% for error in form.errors['new_email'] %}
+      <p class="help is-danger">{{ error }}</p>
+      {% endfor %}
+    </div>
+    <div class="field">
+      <div class="control">
+        <button class="button is-primary" type="submit">
+          {{ gettext("Submit")}}
+        </button>
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/arbeitszeit_flask/templates/user/request_email_change_notification.html
+++ b/arbeitszeit_flask/templates/user/request_email_change_notification.html
@@ -1,0 +1,5 @@
+{{ gettext("Dear Arbeitszeitapp user,
+
+someone tried to change the email address for your user account. If this was you please visit the following link to confirm this change.") }}
+
+<a href="{{ change_email_url }}">{{ change_email_url }}</a>

--- a/arbeitszeit_flask/text_renderer.py
+++ b/arbeitszeit_flask/text_renderer.py
@@ -30,3 +30,9 @@ class TextRendererImpl:
             "member/notification-about-work-invitation.html",
             invitation_url=invitation_url,
         )
+
+    def render_email_change_notification(self, *, change_email_url: str) -> str:
+        return render_template(
+            "user/request_email_change_notification.html",
+            change_email_url=change_email_url,
+        )

--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -241,3 +241,6 @@ class GeneralUrlIndex:
             transfer_request=transfer_request,
             _external=True,
         )
+
+    def get_change_email_url(self, *, token: str) -> str:
+        return url_for("main_user.change_email_address", token=token, _external=True)

--- a/arbeitszeit_flask/user/blueprint.py
+++ b/arbeitszeit_flask/user/blueprint.py
@@ -1,9 +1,10 @@
 from functools import wraps
 from typing import Callable, List, Optional, TypeVar
 
-from flask import Blueprint, redirect, url_for
+from flask import Blueprint, redirect, request, url_for
 
 from arbeitszeit_flask.dependency_injection import create_dependency_injector
+from arbeitszeit_flask.views.http_error_view import http_403
 from arbeitszeit_web.www.authentication import UserAuthenticator
 
 ViewFunction = TypeVar("ViewFunction", bound=Callable)
@@ -23,7 +24,10 @@ class AuthenticatedUserRoute:
             injector = create_dependency_injector()
             authenticator = injector.get(UserAuthenticator)
             if not authenticator.is_user_authenticated():
-                return redirect(url_for("auth.start"))
+                if request.method == "GET":
+                    return redirect(url_for("auth.start"))
+                else:
+                    return http_403()
             return injector.call_with_injection(
                 view_function,
                 args=args,

--- a/arbeitszeit_flask/user/routes.py
+++ b/arbeitszeit_flask/user/routes.py
@@ -1,19 +1,30 @@
 from uuid import UUID
 
-from flask import render_template
+from flask import Response as FlaskResponse
+from flask import redirect, render_template, request
 
 from arbeitszeit.use_cases.get_company_summary import (
     GetCompanySummary,
     GetCompanySummarySuccess,
 )
 from arbeitszeit.use_cases.get_user_account_details import GetUserAccountDetailsUseCase
+from arbeitszeit.use_cases.request_email_address_change import (
+    RequestEmailAddressChangeUseCase,
+)
+from arbeitszeit_flask.forms import RequestEmailAddressChangeForm
 from arbeitszeit_flask.types import Response
-from arbeitszeit_flask.views.http_error_view import http_404
+from arbeitszeit_flask.views.http_error_view import http_404, http_501
+from arbeitszeit_web.www.controllers.request_email_address_change_controller import (
+    RequestEmailAddressChangeController,
+)
 from arbeitszeit_web.www.controllers.user_account_details_controller import (
     UserAccountDetailsController,
 )
 from arbeitszeit_web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
+)
+from arbeitszeit_web.www.presenters.request_email_address_change_presenter import (
+    RequestEmailAddressChangePresenter,
 )
 from arbeitszeit_web.www.presenters.user_account_details_presenter import (
     UserAccountDetailsPresenter,
@@ -49,3 +60,35 @@ def company_summary(
         )
     else:
         return http_404()
+
+
+@AuthenticatedUserRoute("/request-email-change", methods=["GET", "POST"])
+def request_email_change(
+    controller: RequestEmailAddressChangeController,
+    presenter: RequestEmailAddressChangePresenter,
+    use_case: RequestEmailAddressChangeUseCase,
+) -> Response:
+    template_name = "user/request_email_address_change.html"
+    form = RequestEmailAddressChangeForm(request.form)
+    match request.method:
+        case "POST":
+            if not form.validate():
+                return FlaskResponse(
+                    render_template(template_name, form=form), status=400
+                )
+            uc_request = controller.process_email_address_change_request(form)
+            uc_response = use_case.request_email_address_change(uc_request)
+            view_model = presenter.render_response(uc_response, form)
+            if view_model.redirect_url:
+                return redirect(view_model.redirect_url)
+            else:
+                return FlaskResponse(
+                    render_template(template_name, form=form), status=400
+                )
+        case _:
+            return FlaskResponse(render_template(template_name, form=form), status=200)
+
+
+@AuthenticatedUserRoute("/change-email/<token>")
+def change_email_address(token: str) -> Response:
+    return http_501()

--- a/arbeitszeit_flask/views/http_error_view.py
+++ b/arbeitszeit_flask/views/http_error_view.py
@@ -21,3 +21,7 @@ def http_403() -> Response:
 
 def http_409() -> Response:
     return http_error(code=409, reason="CONFLICT")
+
+
+def http_501() -> Response:
+    return http_error(code=501, reason="NOT IMPLEMENTED")

--- a/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
+++ b/arbeitszeit_web/www/presenters/request_email_address_change_presenter.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from arbeitszeit.use_cases import request_email_address_change as use_case
+from arbeitszeit_web.forms import RequestEmailAddressChangeForm
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
@@ -20,9 +21,16 @@ class RequestEmailAddressChangePresenter:
     notifier: Notifier
     translator: Translator
 
-    def render_response(self, uc_response: use_case.Response) -> ViewModel:
+    def render_response(
+        self, uc_response: use_case.Response, form: RequestEmailAddressChangeForm
+    ) -> ViewModel:
         redirect_url: Optional[str]
         if uc_response.is_rejected:
+            form.new_email_field.attach_error(
+                self.translator.gettext(
+                    "The email address seems to be invalid or already taken."
+                )
+            )
             redirect_url = None
             self.notifier.display_warning(
                 self.translator.gettext(

--- a/tests/flask_integration/test_change_email_address_view.py
+++ b/tests/flask_integration/test_change_email_address_view.py
@@ -1,0 +1,37 @@
+from parameterized import parameterized
+
+from .flask import LogInUser, ViewTestCase
+
+
+class ChangeEmailAddressViewTests(ViewTestCase):
+    @parameterized.expand(
+        [
+            (LogInUser.member,),
+            (LogInUser.company,),
+            (LogInUser.accountant,),
+            (LogInUser.unconfirmed_member,),
+            (LogInUser.unconfirmed_company,),
+        ]
+    )
+    def test_that_the_route_returns_not_implemented_status(
+        self, login: LogInUser
+    ) -> None:
+        # This test must be removed as soon as the proper functionality to
+        # change ones emails address is implemented.
+        self.assert_response_has_expected_code(
+            url=self._construct_url("abc"),
+            method="GET",
+            expected_code=501,
+            login=login,
+        )
+
+    def test_that_anonymous_users_get_redirected(self) -> None:
+        self.assert_response_has_expected_code(
+            url=self._construct_url("abc"),
+            method="GET",
+            expected_code=302,
+            login=None,
+        )
+
+    def _construct_url(self, token: str) -> str:
+        return f"/user/change-email/{token}"

--- a/tests/flask_integration/test_request_email_change_view.py
+++ b/tests/flask_integration/test_request_email_change_view.py
@@ -1,0 +1,66 @@
+from parameterized import parameterized
+
+from .flask import LogInUser, ViewTestCase
+
+URL = "/user/request-email-change"
+AUTHENTICATED_USER_LOGINS = [
+    (LogInUser.member,),
+    (LogInUser.unconfirmed_member,),
+    (LogInUser.company,),
+    (LogInUser.unconfirmed_company,),
+    (LogInUser.accountant,),
+]
+
+
+class RequestEmailChangeViewTests(ViewTestCase):
+    @parameterized.expand(AUTHENTICATED_USER_LOGINS)
+    def test_that_authenticated_users_get_400_response_on_post_without_data(
+        self, login: LogInUser
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=URL,
+            method="POST",
+            expected_code=400,
+            login=login,
+        )
+
+    def test_that_member_gets_redirected_when_posting_with_new_email_address(
+        self,
+    ) -> None:
+        self.login_member()
+        response = self.client.post(
+            URL,
+            data={
+                "new_email": "new_email@test.test",
+            },
+        )
+        assert response.status_code == 302
+
+    def test_that_unauthenticated_users_get_redirect_response_on_post_without_data(
+        self,
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=URL,
+            method="POST",
+            expected_code=403,
+            login=None,
+        )
+
+    @parameterized.expand(AUTHENTICATED_USER_LOGINS)
+    def test_that_authenticated_users_get_a_200_response_with_get_request(
+        self, login: LogInUser
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=URL,
+            method="GET",
+            expected_code=200,
+            login=login,
+        )
+
+    def test_that_unauthenticated_user_gets_redirect_with_get_requests(self) -> None:
+        self.assert_response_has_expected_code(
+            url=URL,
+            method="GET",
+            expected_code=302,
+            login=None,
+        )

--- a/tests/www/presenters/test_request_email_address_change_presenter.py
+++ b/tests/www/presenters/test_request_email_address_change_presenter.py
@@ -2,6 +2,7 @@ from arbeitszeit.use_cases import request_email_address_change as use_case
 from arbeitszeit_web.www.presenters import (
     request_email_address_change_presenter as presenter,
 )
+from tests.forms import RequestEmailAddressChangeFormImpl
 
 from ..base_test_case import BaseTestCase
 
@@ -13,13 +14,13 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
 
     def test_on_success_redirect_to_non_empty_target(self) -> None:
         response = use_case.Response(is_rejected=False)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url
 
     def test_on_success_redirect_logged_in_member_to_account_details_page(self) -> None:
         self.session.login_member(self.member_generator.create_member())
         response = use_case.Response(is_rejected=False)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url == self.url_index.get_user_account_details_url()
 
     def test_on_success_redirect_logged_in_company_to_account_details_page(
@@ -27,7 +28,7 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
     ) -> None:
         self.session.login_company(self.company_generator.create_company())
         response = use_case.Response(is_rejected=False)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url == self.url_index.get_user_account_details_url()
 
     def test_on_success_redirect_logged_in_accountant_to_account_details_page(
@@ -35,13 +36,13 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
     ) -> None:
         self.session.login_accountant(self.accountant_generator.create_accountant())
         response = use_case.Response(is_rejected=False)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url == self.url_index.get_user_account_details_url()
 
     def test_on_failure_dont_redirect_logged_in_member(self) -> None:
         self.session.login_member(self.member_generator.create_member())
         response = use_case.Response(is_rejected=True)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url is None
 
     def test_on_failure_dont_redirect_logged_in_company(
@@ -49,7 +50,7 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
     ) -> None:
         self.session.login_company(self.company_generator.create_company())
         response = use_case.Response(is_rejected=True)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url is None
 
     def test_on_failure_dont_redirect_logged_in_accountant(
@@ -57,13 +58,13 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
     ) -> None:
         self.session.login_accountant(self.accountant_generator.create_accountant())
         response = use_case.Response(is_rejected=True)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, self._create_form())
         assert view_model.redirect_url is None
 
     def test_on_failure_show_a_warning_that_the_request_was_denied(self) -> None:
         self.session.login_member(self.member_generator.create_member())
         response = use_case.Response(is_rejected=True)
-        self.presenter.render_response(response)
+        self.presenter.render_response(response, self._create_form())
         expected_message = self.translator.gettext(
             "Your request for an email address change was rejected."
         )
@@ -72,8 +73,32 @@ class RequestEmailAddressChangePresenterTests(BaseTestCase):
     def test_on_success_dont_show_a_warning_that_the_request_was_denied(self) -> None:
         self.session.login_member(self.member_generator.create_member())
         response = use_case.Response(is_rejected=False)
-        self.presenter.render_response(response)
+        self.presenter.render_response(response, self._create_form())
         expected_message = self.translator.gettext(
             "Your request for an email address change was rejected."
         )
         assert expected_message not in self.notifier.warnings
+
+    def test_that_error_message_is_added_to_new_email_field_on_rejection(self) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=True)
+        form = self._create_form()
+        self.presenter.render_response(response, form)
+        assert form.new_email_field.errors
+
+    def test_for_correct_error_message_on_new_email_field_when_request_was_rejected(
+        self,
+    ) -> None:
+        self.session.login_member(self.member_generator.create_member())
+        response = use_case.Response(is_rejected=True)
+        form = self._create_form()
+        self.presenter.render_response(response, form)
+        assert (
+            self.translator.gettext(
+                "The email address seems to be invalid or already taken."
+            )
+            in form.new_email_field.errors
+        )
+
+    def _create_form(self) -> RequestEmailAddressChangeFormImpl:
+        return RequestEmailAddressChangeFormImpl.from_values("test@test.test")


### PR DESCRIPTION
Before this change we had no http routing and rendering in place to handle request to change a users email address. This commit addresses this issue. Please note that changing ones email address is still not possible since the confirmation logic is not yet in place.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (3x)