### PR TITLE
Changed semantics when changing users email address

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -464,6 +464,9 @@ class EmailAddressUpdate(DatabaseUpdate, Protocol):
 
 
 class AccountCredentialsResult(QueryResult[records.AccountCredentials], Protocol):
+    def for_user_account_with_id(self, user_id: UUID) -> Self:
+        ...
+
     def with_email_address(self, address: str) -> Self:
         ...
 

--- a/arbeitszeit/use_cases/change_user_email_address.py
+++ b/arbeitszeit/use_cases/change_user_email_address.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from uuid import UUID
 
 from arbeitszeit.email import is_possibly_an_email_address
 from arbeitszeit.repositories import DatabaseGateway
@@ -12,15 +13,17 @@ class ChangeUserEmailAddressUseCase:
 
     def change_user_email_address(self, request: Request) -> Response:
         if (
-            self.database.get_email_addresses().with_address(request.old_email)
-            and not self.database.get_email_addresses().with_address(request.new_email)
+            not self.database.get_email_addresses().with_address(request.new_email)
             and is_possibly_an_email_address(request.new_email)
+            and self.database.get_account_credentials().for_user_account_with_id(
+                request.user
+            )
         ):
             self.database.create_email_address(
                 address=request.new_email, confirmed_on=None
             )
-            self.database.get_account_credentials().with_email_address(
-                request.old_email
+            self.database.get_account_credentials().for_user_account_with_id(
+                request.user
             ).update().change_email_address(request.new_email).perform()
             return Response(is_rejected=False)
         return Response(is_rejected=True)
@@ -28,7 +31,7 @@ class ChangeUserEmailAddressUseCase:
 
 @dataclass
 class Request:
-    old_email: str
+    user: UUID
     new_email: str
 
 

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -1418,6 +1418,20 @@ class EmailAddressUpdate:
 
 
 class AccountCredentialsResult(FlaskQueryResult[records.AccountCredentials]):
+    def for_user_account_with_id(self, user_id: UUID) -> Self:
+        id_ = str(user_id)
+        member = aliased(models.Member)
+        company = aliased(models.Company)
+        accountant = aliased(models.Accountant)
+        return self._with_modified_query(
+            lambda query: query.join(
+                member, member.user_id == models.User.id, isouter=True
+            )
+            .join(company, company.user_id == models.User.id, isouter=True)
+            .join(accountant, accountant.user_id == models.User.id, isouter=True)
+            .filter(or_(member.id == id_, company.id == id_, accountant.id == id_))
+        )
+
     def with_email_address(self, address: str) -> Self:
         return self._with_modified_query(
             lambda query: query.filter(

--- a/tests/flask_integration/database_gateway_impl/test_account_credentials_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_account_credentials_result.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from parameterized import parameterized
 
 from arbeitszeit import records
@@ -305,4 +307,34 @@ class WithEmailAddressTests(AccountCredentialsResultTests):
         )
         assert not self.database_gateway.get_account_credentials().with_email_address(
             filter_text
+        )
+
+
+class ForUserAccountWithIdTests(AccountCredentialsResultTests):
+    def test_that_result_includes_credentials_for_matching_member(self) -> None:
+        member = self.member_generator.create_member()
+        assert self.database_gateway.get_account_credentials().for_user_account_with_id(
+            member
+        )
+
+    def test_that_result_includes_credentials_for_matching_accountant(self) -> None:
+        accountant = self.accountant_generator.create_accountant()
+        assert self.database_gateway.get_account_credentials().for_user_account_with_id(
+            accountant
+        )
+
+    def test_that_result_includes_credentials_for_matching_company(self) -> None:
+        company = self.company_generator.create_company()
+        assert self.database_gateway.get_account_credentials().for_user_account_with_id(
+            company
+        )
+
+    def test_that_when_filtering_for_random_user_id_no_results_are_returned(
+        self,
+    ) -> None:
+        self.member_generator.create_member()
+        self.company_generator.create_company()
+        self.accountant_generator.create_accountant()
+        assert not self.database_gateway.get_account_credentials().for_user_account_with_id(
+            uuid4()
         )

--- a/tests/use_cases/test_change_user_email_address.py
+++ b/tests/use_cases/test_change_user_email_address.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from parameterized import parameterized
 
 from arbeitszeit.use_cases import log_in_member
@@ -18,7 +20,7 @@ class ChangeUserEmailAddressTests(BaseTestCase):
         )
 
     def test_that_request_for_email_with_no_existing_user_is_rejected(self) -> None:
-        request = Request(old_email="test@test.test", new_email="new@test.test")
+        request = Request(user=uuid4(), new_email="new@test.test")
         response = self.use_case.change_user_email_address(request)
         assert response.is_rejected
 
@@ -31,8 +33,8 @@ class ChangeUserEmailAddressTests(BaseTestCase):
     def test_that_request_for_email_with_existing_member_is_accepted(
         self, old_email: str
     ) -> None:
-        self.member_generator.create_member(email=old_email)
-        request = Request(old_email=old_email, new_email="new@test.test")
+        member = self.member_generator.create_member(email=old_email)
+        request = Request(user=member, new_email="new@test.test")
         response = self.use_case.change_user_email_address(request)
         assert not response.is_rejected
 
@@ -45,8 +47,8 @@ class ChangeUserEmailAddressTests(BaseTestCase):
     def test_that_request_for_email_with_existing_company_is_accepted(
         self, old_email: str
     ) -> None:
-        self.company_generator.create_company(email=old_email)
-        request = Request(old_email=old_email, new_email="new@test.test")
+        company = self.company_generator.create_company(email=old_email)
+        request = Request(user=company, new_email="new@test.test")
         response = self.use_case.change_user_email_address(request)
         assert not response.is_rejected
 
@@ -59,8 +61,10 @@ class ChangeUserEmailAddressTests(BaseTestCase):
     def test_that_request_for_email_with_existing_accountant_is_accepted(
         self, old_email: str
     ) -> None:
-        self.accountant_generator.create_accountant(email_address=old_email)
-        request = Request(old_email=old_email, new_email="new@test.test")
+        accountant = self.accountant_generator.create_accountant(
+            email_address=old_email
+        )
+        request = Request(user=accountant, new_email="new@test.test")
         response = self.use_case.change_user_email_address(request)
         assert not response.is_rejected
 
@@ -74,53 +78,52 @@ class ChangeUserEmailAddressTests(BaseTestCase):
     def test_that_changing_the_email_address_to_something_that_is_definitly_not_an_email_address_is_rejected(
         self, new_email: str
     ) -> None:
-        old_email = "test@test.test"
-        self.accountant_generator.create_accountant(email_address=old_email)
-        request = Request(old_email=old_email, new_email=new_email)
+        accountant = self.accountant_generator.create_accountant(
+            email_address="test@test.test"
+        )
+        request = Request(user=accountant, new_email=new_email)
         response = self.use_case.change_user_email_address(request)
         assert response.is_rejected
 
     def test_that_request_is_rejected_if_new_email_is_already_in_use_by_other_member(
         self,
     ) -> None:
-        old_email = "test@test.test"
         new_email = "new@test.test"
-        self.member_generator.create_member(email=old_email)
+        member = self.member_generator.create_member(email="test@test.test")
         self.member_generator.create_member(email=new_email)
-        request = Request(old_email=old_email, new_email=new_email)
+        request = Request(user=member, new_email=new_email)
         response = self.use_case.change_user_email_address(request)
         assert response.is_rejected
 
     def test_that_request_is_rejected_if_new_email_is_already_in_use_by_other_company(
         self,
     ) -> None:
-        old_email = "test@test.test"
         new_email = "new@test.test"
-        self.member_generator.create_member(email=old_email)
+        member = self.member_generator.create_member(email="test@test.test")
         self.company_generator.create_company(email=new_email)
-        request = Request(old_email=old_email, new_email=new_email)
+        request = Request(user=member, new_email=new_email)
         response = self.use_case.change_user_email_address(request)
         assert response.is_rejected
 
     def test_that_request_is_rejected_if_new_email_is_already_in_use_by_other_accountant(
         self,
     ) -> None:
-        old_email = "test@test.test"
         new_email = "new@test.test"
-        self.member_generator.create_member(email=old_email)
+        member = self.member_generator.create_member(email="test@test.test")
         self.accountant_generator.create_accountant(email_address=new_email)
-        request = Request(old_email=old_email, new_email=new_email)
+        request = Request(user=member, new_email=new_email)
         response = self.use_case.change_user_email_address(request)
         assert response.is_rejected
 
     def test_that_member_can_log_in_with_new_email_after_address_change(
         self,
     ) -> None:
-        old_email = "test@test.test"
         new_email = "new@test.test"
         password = "test1234"
-        self.member_generator.create_member(email=old_email, password=password)
-        request = Request(old_email=old_email, new_email=new_email)
+        member = self.member_generator.create_member(
+            email="test@test.test", password=password
+        )
+        request = Request(user=member, new_email=new_email)
         self.use_case.change_user_email_address(request)
         assert self.can_log_in_member(email_address=new_email, password=password)
 


### PR DESCRIPTION
Before this change a change in a users email address would be requested by specifying the old email address of that account and the new email address that should be associated with that account. After this change we change the email address of a user by specifying their user id and the new email address in question.

The reason for this change is that our current authentication model is based on user ids instead of email addresses. Having the old email address as an authentication token would introduce a syncronization problem. If somebody would change their email address to an address that was previously taken by another user they could potentially authenticated as the previous owner of that email address. This is true at least as long as we store the email address of a user in the session cookie. With user ids we will never run into such a problem because we will never reuse old user ids.

Another way to deal with this problem would have been to check if the email address that was stored in the session cookie of a user is still current but that would introduce a lot of overhead and at least one additional database query for every request.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (1x)