### PR TITLE
Introduce ReviewRegisteredConsumptionsUseCase

### DIFF
--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -287,10 +287,25 @@ class PrivateConsumptionResult(QueryResult[records.PrivateConsumption], Protocol
     def where_consumer_is_member(self, member: UUID) -> Self:
         ...
 
+    def where_provider_is_company(self, company: UUID) -> Self:
+        ...
+
     def joined_with_transactions_and_plan(
         self,
     ) -> QueryResult[
         Tuple[records.PrivateConsumption, records.Transaction, records.Plan]
+    ]:
+        ...
+
+    def joined_with_transaction_and_plan_and_consumer(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.PrivateConsumption,
+            records.Transaction,
+            records.Plan,
+            records.Member,
+        ]
     ]:
         ...
 
@@ -300,6 +315,9 @@ class ProductiveConsumptionResult(QueryResult[records.ProductiveConsumption], Pr
         ...
 
     def where_consumer_is_company(self, company: UUID) -> Self:
+        ...
+
+    def where_provider_is_company(self, company: UUID) -> Self:
         ...
 
     def joined_with_transactions_and_plan(
@@ -319,6 +337,18 @@ class ProductiveConsumptionResult(QueryResult[records.ProductiveConsumption], Pr
     def joined_with_transaction(
         self,
     ) -> QueryResult[Tuple[records.ProductiveConsumption, records.Transaction]]:
+        ...
+
+    def joined_with_transaction_and_plan_and_consumer(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.PrivateConsumption,
+            records.Transaction,
+            records.Plan,
+            records.Company,
+        ]
+    ]:
         ...
 
 

--- a/arbeitszeit/use_cases/review_registered_consumptions.py
+++ b/arbeitszeit/use_cases/review_registered_consumptions.py
@@ -1,0 +1,82 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class RegisteredConsumption:
+    date: datetime
+    is_private_consumption: bool
+    consumer_name: str
+    consumer_id: UUID
+    product_name: str
+    plan_id: UUID
+    volume: Decimal
+
+
+@dataclass
+class RewiewRegisteredConsumptionsUseCase:
+    @dataclass
+    class Request:
+        providing_company: UUID
+
+    @dataclass
+    class Response:
+        consumptions: list[RegisteredConsumption]
+
+    database: DatabaseGateway
+
+    def review_registered_consumptions(self, request: Request) -> Response:
+        private_consumptions = self._get_private_consumptions(request)
+        productive_consumptions = self._get_productive_consumptions(request)
+        consumptions = private_consumptions + productive_consumptions
+        consumptions_ordered_by_date_in_descending_order = sorted(
+            consumptions, key=lambda consumption: consumption.date, reverse=True
+        )
+        return self.Response(
+            consumptions=consumptions_ordered_by_date_in_descending_order
+        )
+
+    def _get_private_consumptions(
+        self, request: Request
+    ) -> list[RegisteredConsumption]:
+        return [
+            RegisteredConsumption(
+                date=transaction.date,
+                is_private_consumption=True,
+                consumer_name=member.name,
+                consumer_id=member.id,
+                product_name=plan.prd_name,
+                plan_id=plan.id,
+                volume=transaction.amount_sent,
+            )
+            for _, transaction, plan, member in self.database.get_private_consumptions()
+            .where_provider_is_company(request.providing_company)
+            .joined_with_transaction_and_plan_and_consumer()
+        ]
+
+    def _get_productive_consumptions(
+        self, request: Request
+    ) -> list[RegisteredConsumption]:
+        productive_consumptions: list[RegisteredConsumption] = []
+        productive_consumptions_result = (
+            self.database.get_productive_consumptions()
+            .where_provider_is_company(request.providing_company)
+            .joined_with_transaction_and_plan_and_consumer()
+        )
+        for _, transaction, plan, company in productive_consumptions_result:
+            productive_consumptions.append(
+                RegisteredConsumption(
+                    date=transaction.date,
+                    is_private_consumption=False,
+                    consumer_name=company.name,
+                    consumer_id=company.id,
+                    product_name=plan.prd_name,
+                    plan_id=plan.id,
+                    volume=transaction.amount_sent,
+                )
+            )
+        return productive_consumptions

--- a/tests/use_cases/test_review_registered_consumptions.py
+++ b/tests/use_cases/test_review_registered_consumptions.py
@@ -1,0 +1,336 @@
+from datetime import datetime
+from decimal import Decimal
+from math import isclose
+
+from arbeitszeit.records import ProductionCosts
+from arbeitszeit.use_cases.review_registered_consumptions import (
+    RewiewRegisteredConsumptionsUseCase as UseCase,
+)
+from tests.use_cases.base_test_case import BaseTestCase
+
+
+class ReviewRegisteredConsumptionsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(UseCase)
+        self.providing_company = self.company_generator.create_company()
+
+    def test_empty_list_is_returned_when_no_consumptions_exist(self) -> None:
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert not response.consumptions
+
+    def test_empty_list_is_returned_when_no_consumptions_of_product_of_specified_company_exist(
+        self,
+    ) -> None:
+        self.plan_generator.create_plan()
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert not response.consumptions
+
+    def test_one_consumption_is_returned_when_one_private_consumption_exists(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert len(response.consumptions) == 1
+
+    def test_one_consumption_is_returned_when_one_fixed_means_consumption_exists(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert len(response.consumptions) == 1
+
+    def test_one_consumption_is_returned_when_one_resource_consumption_exists(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_resource_consumption_by_company(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert len(response.consumptions) == 1
+
+    def test_two_consumptions_are_returned_when_one_private_and_one_fixed_means_consumption_exist(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert len(response.consumptions) == 2
+
+    def test_three_consumptions_are_returned_in_descending_order_of_date(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        self.consumption_generator.create_resource_consumption_by_company(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert (
+            response.consumptions[0].date
+            > response.consumptions[1].date
+            > response.consumptions[2].date
+        )
+
+
+class PrivateConsumptionDetailsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(UseCase)
+        self.providing_company = self.company_generator.create_company()
+
+    def test_private_consumption_shows_date_of_when_consumption_was_registered(
+        self,
+    ) -> None:
+        expected_date = datetime(2019, 5, 1)
+        self.datetime_service.freeze_time(expected_date)
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].date == expected_date
+
+    def test_private_consumption_is_shown_as_private_consumption(self) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].is_private_consumption
+
+    def test_private_consumer_name_is_shown(self) -> None:
+        expected_consumer_name = "Test private consumer name"
+        consumer = self.member_generator.create_member(name=expected_consumer_name)
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(
+            plan=plan.id, consumer=consumer
+        )
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].consumer_name == expected_consumer_name
+
+    def test_private_consumer_id_is_shown(self) -> None:
+        expected_consumer_id = self.member_generator.create_member()
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_private_consumption(
+            plan=plan.id, consumer=expected_consumer_id
+        )
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].consumer_id == expected_consumer_id
+
+    def test_product_name_is_shown(self) -> None:
+        expected_product_name = "Test Product"
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company, product_name=expected_product_name
+        )
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].product_name == expected_product_name
+
+    def test_plan_id_is_shown(self) -> None:
+        expected_plan_id = self.plan_generator.create_plan(
+            planner=self.providing_company
+        ).id
+        self.consumption_generator.create_private_consumption(plan=expected_plan_id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].plan_id == expected_plan_id
+
+    def test_volume_is_shown_that_equals_the_labour_costs_of_the_product(self) -> None:
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        self.consumption_generator.create_private_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].volume == Decimal(6)
+
+    def test_volume_is_shown_that_equals_the_labour_costs_of_the_product_times_the_amount_consumed(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        self.consumption_generator.create_private_consumption(plan=plan.id, amount=2)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].volume == Decimal(12)
+
+    def test_volume_is_shown_that_equals_the_cooperation_price_of_the_product_when_plan_is_cooperating(
+        self,
+    ) -> None:
+        plan1 = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        plan2 = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(4), Decimal(4), Decimal(4)),
+            amount=1,
+        )
+        self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+
+        self.consumption_generator.create_private_consumption(plan=plan1.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert isclose(response.consumptions[0].volume, Decimal(9))
+
+
+class ProductiveConsumptionDetailsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(UseCase)
+        self.providing_company = self.company_generator.create_company()
+
+    def test_productive_consumption_shows_date_of_when_consumption_was_registered(
+        self,
+    ) -> None:
+        expected_date = datetime(2019, 5, 1)
+        self.datetime_service.freeze_time(expected_date)
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].date == expected_date
+
+    def test_consumption_of_fixed_means_of_production_shows_not_as_private_consumption(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert not response.consumptions[0].is_private_consumption
+
+    def test_consumption_of_resources_shows_not_as_private_consumption(self) -> None:
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_resource_consumption_by_company(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert not response.consumptions[0].is_private_consumption
+
+    def test_consumer_name_is_shown(self) -> None:
+        expected_consumer_name = "Test consumer name"
+        consumer = self.company_generator.create_company(name=expected_consumer_name)
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_fixed_means_consumption(
+            plan=plan.id, consumer=consumer
+        )
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].consumer_name == expected_consumer_name
+
+    def test_consumer_id_is_shown(self) -> None:
+        expected_consumer_id = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(planner=self.providing_company)
+        self.consumption_generator.create_fixed_means_consumption(
+            plan=plan.id, consumer=expected_consumer_id
+        )
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].consumer_id == expected_consumer_id
+
+    def test_product_name_is_shown(self) -> None:
+        expected_product_name = "Test Product"
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company, product_name=expected_product_name
+        )
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].product_name == expected_product_name
+
+    def test_plan_id_is_shown(self) -> None:
+        expected_plan_id = self.plan_generator.create_plan(
+            planner=self.providing_company
+        ).id
+        self.consumption_generator.create_fixed_means_consumption(plan=expected_plan_id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].plan_id == expected_plan_id
+
+    def test_volume_is_shown_that_equals_the_labour_costs_of_the_product(self) -> None:
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        self.consumption_generator.create_fixed_means_consumption(plan=plan.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].volume == Decimal(6)
+
+    def test_volume_is_shown_that_equals_the_labour_costs_of_the_product_times_the_amount_consumed(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        self.consumption_generator.create_fixed_means_consumption(
+            plan=plan.id, amount=2
+        )
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert response.consumptions[0].volume == Decimal(12)
+
+    def test_volume_is_shown_that_equals_the_cooperation_price_of_the_product_when_plan_is_cooperating(
+        self,
+    ) -> None:
+        plan1 = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(2), Decimal(2), Decimal(2)),
+            amount=1,
+        )
+        plan2 = self.plan_generator.create_plan(
+            planner=self.providing_company,
+            costs=ProductionCosts(Decimal(4), Decimal(4), Decimal(4)),
+            amount=1,
+        )
+        self.cooperation_generator.create_cooperation(plans=[plan1, plan2])
+
+        self.consumption_generator.create_fixed_means_consumption(plan=plan1.id)
+        response = self.use_case.review_registered_consumptions(
+            request=UseCase.Request(providing_company=self.providing_company)
+        )
+        assert isclose(response.consumptions[0].volume, Decimal(9))


### PR DESCRIPTION
This use case should be accessible only to an authenticated company and provides itself an overview over the registered consumptions of its products or services ("sales"). This use case is necessary because in the public prd account overview of companies the private consumer details should be anonymized. With this new use case a company can see the details of its customers.

See https://github.com/arbeitszeit/arbeitszeitapp/pull/903#issuecomment-1873423659

Plan: fd00d0bb-0ea3-4338-b097-dfa605278f1c (4x)