### PR TITLE
Implement basic mechanism to update password hashes in DB

### DIFF
--- a/arbeitszeit/password_hasher.py
+++ b/arbeitszeit/password_hasher.py
@@ -7,3 +7,6 @@ class PasswordHasher(Protocol):
 
     def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
         ...
+
+    def is_regeneration_needed(self, password_hash: str) -> bool:
+        ...

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -556,6 +556,9 @@ class AccountCredentialsUpdate(DatabaseUpdate, Protocol):
     def change_email_address(self, new_email_address: str) -> Self:
         ...
 
+    def change_password_hash(self, new_password_hash: str) -> Self:
+        ...
+
 
 class LanguageRepository(Protocol):
     def get_available_language_codes(self) -> Iterable[str]:

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -16,7 +16,7 @@ def generate_uuid() -> str:
 
 class User(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
-    password = db.Column(db.String(100), nullable=False)
+    password = db.Column(db.String(300), nullable=False)
     email_address = db.Column(
         db.ForeignKey("email.address"), nullable=False, unique=True
     )

--- a/arbeitszeit_flask/migrations/versions/5f80baed0e16_extend_size_of_password_hash_field.py
+++ b/arbeitszeit_flask/migrations/versions/5f80baed0e16_extend_size_of_password_hash_field.py
@@ -1,0 +1,33 @@
+"""Extend size of password hash field
+
+Revision ID: 5f80baed0e16
+Revises: c389d9c0145e
+Create Date: 2024-01-10 16:44:07.597883
+"""
+import sqlalchemy as sa
+from alembic import op
+
+revision = "5f80baed0e16"
+down_revision = "c389d9c0145e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column(
+            "password",
+            existing_type=sa.VARCHAR(length=100),
+            type_=sa.String(length=300),
+            existing_nullable=False,
+        )
+
+
+def downgrade():
+    with op.batch_alter_table("user", schema=None) as batch_op:
+        batch_op.alter_column(
+            "password",
+            existing_type=sa.String(length=300),
+            type_=sa.VARCHAR(length=100),
+            existing_nullable=False,
+        )

--- a/arbeitszeit_flask/password_hasher.py
+++ b/arbeitszeit_flask/password_hasher.py
@@ -3,7 +3,14 @@ from werkzeug.security import check_password_hash, generate_password_hash
 
 class PasswordHasherImpl:
     def calculate_password_hash(self, password: str) -> str:
-        return generate_password_hash(password, method="sha256")
+        return generate_password_hash(password)
 
     def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
         return check_password_hash(password_hash, password)
+
+    def is_regeneration_needed(self, password_hash: str) -> bool:
+        try:
+            method, _ = password_hash.split("$", maxsplit=1)
+        except ValueError:
+            return True
+        return method == "sha256"

--- a/tests/flask_integration/test_password_hasher.py
+++ b/tests/flask_integration/test_password_hasher.py
@@ -20,3 +20,17 @@ class PasswordHasherTests(FlaskTestCase):
         assert not self.password_hasher.is_password_matching_hash(
             password="random string", password_hash=hashed
         )
+
+    def test_that_sha256_hashes_are_considered_to_need_regeneration(self) -> None:
+        example_hash = "sha256$TKh78RuuHtoNJyrk$75b108cb18648faebd476eee401441b5b62d81eee855631d209503f393e1440e"
+        assert self.password_hasher.is_regeneration_needed(example_hash)
+
+    def test_that_scrypt_hashes_are_not_considered_to_need_regeneration(self) -> None:
+        example_hash = "pbkdf2:sha256:600000$XUBVbwrkdN0vFmG0$52c0b0c95101315e5167f7219487beb890c5b1d4dfa9af33015815eb4f945568"
+        assert not self.password_hasher.is_regeneration_needed(example_hash)
+
+    def test_that_hashes_generated_by_the_password_hasher_are_not_considered_to_be_in_need_of_regeneration(
+        self,
+    ) -> None:
+        example_hash = self.password_hasher.calculate_password_hash("test123")
+        assert not self.password_hasher.is_regeneration_needed(example_hash)

--- a/tests/password_hasher.py
+++ b/tests/password_hasher.py
@@ -4,3 +4,6 @@ class PasswordHasherImpl:
 
     def is_password_matching_hash(self, password: str, password_hash: str) -> bool:
         return password == password_hash[4:]
+
+    def is_regeneration_needed(self, password_hash: str) -> bool:
+        return False

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -1481,6 +1481,12 @@ class AccountCredentialsUpdate:
 
         return replace(self, actions=self.actions + [_change_action])
 
+    def change_password_hash(self, new_password_hash: str) -> Self:
+        def _change_action(db: MockDatabase, item: records.AccountCredentials) -> None:
+            item.password_hash = new_password_hash
+
+        return replace(self, actions=self.actions + [_change_action])
+
 
 @singleton
 class FakeLanguageRepository:


### PR DESCRIPTION
EDIT: Improve commit message

# commit message

Starting with this commit users will automatically update the password
hash stored in our database whenever they log in successfully,
provided that the old hashing algorithm/implementation was considered
out of date by our security provided "werkzeug". This includes
currently only the "sha256" method. All future password hashes will be
generated by using the default method provided by "werkzeug".

With the introduction of a new hashing algorithm it became necessary to extend the length of the `password` field in our database from 100 characters to 300 characters. The length of 300 for this field is based on a lazy guess and some manual experiments.

# Some more context

Since some time we get a bunch of warnings printed to the screen whenever we run tests that touch the database implementation and the authentication logic. Here is an example that I captured from current `master` (10.1.2024).

```
$ pytest tests/flask_integration/test_login_member_view.py 
========================================================= test session starts ==========================================================
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/me/src/arbeitszeitapp
collected 2 items                                                                                                                      

tests/flask_integration/test_login_member_view.py ..                                                                             [100%]

=========================================================== warnings summary ===========================================================
tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
  /nix/store/z6cf296q7hayayll7j3xbrl0m1hgq7rl-python3.11-flask-restx-1.3.0/lib/python3.11/site-packages/flask_restx/api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import RefResolver

tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
tests/flask_integration/test_login_member_view.py::StartViewTests::test_that_user_gets_redirected_to_original_target_url_after_successful_login
  /home/me/src/arbeitszeitapp/arbeitszeit_flask/password_hasher.py:6: UserWarning: The 'sha256' password method is deprecated and will be removed in Werkzeug 3.0. Migrate to the 'scrypt' method.
    return generate_password_hash(password, method="sha256")

tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
tests/flask_integration/test_login_member_view.py::StartViewTests::test_that_user_gets_redirected_to_original_target_url_after_successful_login
  /home/me/src/arbeitszeitapp/arbeitszeit_flask/password_hasher.py:9: UserWarning: The 'sha256' password method is deprecated and will be removed in Werkzeug 3.0. Migrate to the 'scrypt' method.
    return check_password_hash(password_hash, password)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 2 passed, 6 warnings in 1.72s =====================================================

```

Among the warnings in the output above we can see some deprecation warnings regarding the 'sha256' password hashing method that is provided by the `werkzeug` library. It is recommended by the library authors that we switch to the "scrypt" method. Unfortunately the "scrypt" method is not supported on nixos-23.05 which is currently used to host an arbeitszeitapp installation. That's the reason why we use the default method provided by `werkzeug`, it works an older platforms as well as `nixos-unstable`. Since we explicitly used the "sha256" method we can blacklist that password hashing method explicitly and calculate a new hash during login attempts. I tested the password migration process locally multiple times and it seems to work as intended (TM). Since all credentials during test execution now use the default password hashing method (which is considered secure by werkzeug) all the warnings regarding this issue "disappeared".

Here is the same test run with the changes from this commit:

```
$ pytest tests/flask_integration/test_login_member_view.py 
========================================================= test session starts ==========================================================
platform linux -- Python 3.11.6, pytest-7.4.3, pluggy-1.3.0
rootdir: /home/me/src/arbeitszeitapp
collected 2 items                                                                                                                      

tests/flask_integration/test_login_member_view.py ..                                                                             [100%]

=========================================================== warnings summary ===========================================================
tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
tests/flask_integration/test_login_member_view.py::StartViewTests::test_member_can_login_after_having_attempted_to_visit_a_company_route_before
  /nix/store/z6cf296q7hayayll7j3xbrl0m1hgq7rl-python3.11-flask-restx-1.3.0/lib/python3.11/site-packages/flask_restx/api.py:19: DeprecationWarning: jsonschema.RefResolver is deprecated as of v4.18.0, in favor of the https://github.com/python-jsonschema/referencing library, which provides more compliant referencing behavior as well as more flexible APIs for customization. A future release will remove RefResolver. Please file a feature request (on referencing) if you are missing an API for the kind of customization you need.
    from jsonschema import RefResolver

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 2 passed, 2 warnings in 2.13s =====================================================

```

# Future work

It is debatable if there is more work that needs to be done regarding the deprecation of the `sha256` password hashing method. It is currently very unlikely (though unknown) that there is any "production" instance of the app running in the world. Even the instance that is running at "app.arbeitszeitrechnung.org" is only used by 2 people who log in regularly and thus will updated their password hashes soon after merging this into master.
Should this deprecation become an issue it is likely that we will have a "forgot password" feature by then. This commit makes this feature easier to implement as it provides the basic data selectors and mutators necessary for a "forgot password" feature.

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (2x)