### PR TITLE
Use unsafe, unsecure password hasher in tests

### DIFF
--- a/arbeitszeit/injector.py
+++ b/arbeitszeit/injector.py
@@ -23,7 +23,15 @@ TypeT = TypeVar("TypeT", bound=Type)
 
 class Injector:
     def __init__(self, modules: List[Module]) -> None:
+        class _RecursionModule(Module):
+            def configure(module_self, binder: Binder) -> None:
+                super().configure(binder)
+                binder[Injector] = InstanceProvider(self)
+
+        recursion_module = _RecursionModule()
+
         self.binder: Binder = Binder(Injector.default_provider)
+        recursion_module.configure(self.binder)
         for module in modules:
             module.configure(self.binder)
 

--- a/arbeitszeit_flask/configuration_base.py
+++ b/arbeitszeit_flask/configuration_base.py
@@ -23,3 +23,4 @@ FLASK_PROFILER = {
 }
 
 RESTX_MASK_SWAGGER = False
+ARBEITSZEIT_PASSWORD_HASHER = "arbeitszeit_flask.password_hasher:PasswordHasherImpl"

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -32,7 +32,7 @@ from arbeitszeit_flask.mail_service import (
     get_mail_service,
 )
 from arbeitszeit_flask.notifications import FlaskFlashNotifier
-from arbeitszeit_flask.password_hasher import PasswordHasherImpl
+from arbeitszeit_flask.password_hasher import provide_password_hasher
 from arbeitszeit_flask.text_renderer import TextRendererImpl
 from arbeitszeit_flask.token import FlaskTokenService
 from arbeitszeit_flask.translator import FlaskTranslator
@@ -95,7 +95,7 @@ class FlaskModule(Module):
         )
         binder.bind(
             PasswordHasher,
-            to=AliasProvider(PasswordHasherImpl),
+            to=CallableProvider(provide_password_hasher),
         )
         binder.bind(
             TokenService,

--- a/arbeitszeit_flask/password_hasher.py
+++ b/arbeitszeit_flask/password_hasher.py
@@ -1,4 +1,10 @@
+import importlib
+
+from flask import current_app
 from werkzeug.security import check_password_hash, generate_password_hash
+
+from arbeitszeit.injector import Injector
+from arbeitszeit.password_hasher import PasswordHasher
 
 
 class PasswordHasherImpl:
@@ -14,3 +20,11 @@ class PasswordHasherImpl:
         except ValueError:
             return True
         return method == "sha256"
+
+
+def provide_password_hasher(injector: Injector) -> PasswordHasher:
+    config = current_app.config["ARBEITSZEIT_PASSWORD_HASHER"]
+    module_name, klass_name = config.split(":", maxsplit=1)
+    module = importlib.import_module(module_name)
+    klass = getattr(module, klass_name)
+    return injector.get(klass)

--- a/tests/flask_integration/dependency_injection.py
+++ b/tests/flask_integration/dependency_injection.py
@@ -35,6 +35,7 @@ class FlaskConfiguration(dict):
                 "MAIL_DEFAULT_SENDER": "test_sender@cp.org",
                 "MAIL_BACKEND": "flask_mail",
                 "LANGUAGES": {"en": "English", "de": "Deutsch"},
+                "ARBEITSZEIT_PASSWORD_HASHER": "tests.password_hasher:PasswordHasherImpl",
             }
         )
 
@@ -82,6 +83,10 @@ class SqliteModule(Module):
 def get_dependency_injector(
     additional_modules: Optional[List[Module]] = None,
 ) -> Injector:
+    # Please be aware that the get_dependency_injector function is only called
+    # from the testing side. The app itself is used with its default dependency
+    # injector. Influencing the dependency injector used by the app is
+    # currently only possible via configuration options.
     modules: List[Module] = [
         FlaskModule(),
         TestingModule(),


### PR DESCRIPTION
The time it takes to execute all tests increased since commit 778769e135b26c1fdc2a7f1f5de4cd32dde2dc93 significantly. The reason for this increase is the password hashing algorithm that was introduces. The more secure password hashing alogrithm that we used is very slow. This slowness is one of the reasons why it is secure. Security is not required when running the tests. This is why after this commit we can configure differnt PasswordHasher classes to be used with the app. In the tests we now load a trivial password hasher class whereas the default configuration of the arbeitszeitapp makes use of the same class as we provided before this change (e.g. the slow secure one).

Plan-ID: b412d2bb-074a-489b-86f6-90b87077c17a (1x)