### PR TITLE
Minor change in /member/consumptions route

### DIFF
--- a/arbeitszeit_flask/member/routes.py
+++ b/arbeitszeit_flask/member/routes.py
@@ -12,7 +12,6 @@ from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
 from arbeitszeit.use_cases.list_coordinations_of_cooperation import (
     ListCoordinationsOfCooperationUseCase,
 )
-from arbeitszeit.use_cases.query_private_consumptions import QueryPrivateConsumptions
 from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.forms import (
     AnswerCompanyWorkInviteForm,
@@ -24,9 +23,7 @@ from arbeitszeit_flask.views import (
     RegisterPrivateConsumptionView,
 )
 from arbeitszeit_flask.views.http_error_view import http_404
-from arbeitszeit_web.www.controllers.query_private_consumptions_controller import (
-    QueryPrivateConsumptionsController,
-)
+from arbeitszeit_flask.views.query_private_consumptions import consumptions
 from arbeitszeit_web.www.presenters.get_coop_summary_presenter import (
     GetCoopSummarySuccessPresenter,
 )
@@ -45,30 +42,10 @@ from arbeitszeit_web.www.presenters.get_statistics_presenter import (
 from arbeitszeit_web.www.presenters.list_coordinations_of_cooperation_presenter import (
     ListCoordinationsOfCooperationPresenter,
 )
-from arbeitszeit_web.www.presenters.private_consumptions_presenter import (
-    PrivateConsumptionsPresenter,
-)
 
 from .blueprint import MemberRoute
 
-
-@MemberRoute("/consumptions")
-def consumptions(
-    controller: QueryPrivateConsumptionsController,
-    use_case: QueryPrivateConsumptions,
-    presenter: PrivateConsumptionsPresenter,
-) -> Response:
-    uc_request = controller.process_request()
-    if not uc_request:
-        return FlaskResponse(status=403)
-    response = use_case.query_private_consumptions(uc_request)
-    view_model = presenter.present_private_consumptions(response)
-    return FlaskResponse(
-        render_template(
-            "member/consumptions.html",
-            view_model=view_model,
-        )
-    )
+MemberRoute("/consumptions")(consumptions)
 
 
 @MemberRoute("/register_private_consumption", methods=["GET", "POST"])

--- a/arbeitszeit_flask/views/query_private_consumptions.py
+++ b/arbeitszeit_flask/views/query_private_consumptions.py
@@ -1,0 +1,30 @@
+import flask
+
+from arbeitszeit.use_cases.query_private_consumptions import QueryPrivateConsumptions
+from arbeitszeit_flask.types import Response
+from arbeitszeit_web.www.controllers.query_private_consumptions_controller import (
+    InvalidRequest,
+    QueryPrivateConsumptionsController,
+)
+from arbeitszeit_web.www.presenters.private_consumptions_presenter import (
+    PrivateConsumptionsPresenter,
+)
+
+
+def consumptions(
+    controller: QueryPrivateConsumptionsController,
+    use_case: QueryPrivateConsumptions,
+    presenter: PrivateConsumptionsPresenter,
+) -> Response:
+    uc_request = controller.process_request()
+    match uc_request:
+        case InvalidRequest(status_code=status_code):
+            return flask.Response(status=status_code)
+    response = use_case.query_private_consumptions(uc_request)
+    view_model = presenter.present_private_consumptions(response)
+    return flask.Response(
+        flask.render_template(
+            "member/consumptions.html",
+            view_model=view_model,
+        )
+    )

--- a/arbeitszeit_web/www/controllers/query_private_consumptions_controller.py
+++ b/arbeitszeit_web/www/controllers/query_private_consumptions_controller.py
@@ -5,14 +5,19 @@ from arbeitszeit_web.session import Session, UserRole
 
 
 @dataclass
+class InvalidRequest:
+    status_code: int
+
+
+@dataclass
 class QueryPrivateConsumptionsController:
     session: Session
 
-    def process_request(self) -> use_case.Request | None:
+    def process_request(self) -> use_case.Request | InvalidRequest:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            return InvalidRequest(status_code=401)
         match self.session.get_user_role():
             case UserRole.member:
-                user_id = self.session.get_current_user()
-                assert user_id
                 return use_case.Request(member=user_id)
-            case _:
-                return None
+        return InvalidRequest(status_code=403)


### PR DESCRIPTION
Before this change we decided on the status code to reply with in the flask route itself. After this change this decision is made in the controller associated with this route.

*No registration of consumption required*