### PR TITLE
Fix semantics of test_cancel_cooperation_request test suite

### DIFF
--- a/tests/use_cases/test_cancel_cooperation_request.py
+++ b/tests/use_cases/test_cancel_cooperation_request.py
@@ -1,3 +1,6 @@
+from uuid import UUID
+
+from arbeitszeit.use_cases import list_outbound_coop_requests
 from arbeitszeit.use_cases.cancel_cooperation_solicitation import (
     CancelCooperationSolicitation,
     CancelCooperationSolicitationRequest,
@@ -10,6 +13,9 @@ class UseCaseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.use_case = self.injector.get(CancelCooperationSolicitation)
+        self.list_outbound_coop_requests_use_case = self.injector.get(
+            list_outbound_coop_requests.ListOutboundCoopRequests
+        )
 
     def test_that_false_is_returned_when_requester_is_not_planner(self) -> None:
         plan = self.plan_generator.create_plan()
@@ -17,13 +23,24 @@ class UseCaseTests(BaseTestCase):
         response = self.use_case(
             CancelCooperationSolicitationRequest(company.id, plan.id)
         )
-        assert response == False
+        assert not response
 
     def test_that_false_is_returned_when_plan_has_no_pending_requests(self) -> None:
         company = self.company_generator.create_company()
         plan = self.plan_generator.create_plan(planner=company)
         response = self.use_case(CancelCooperationSolicitationRequest(company, plan.id))
-        assert response == False
+        assert not response
+
+    def test_that_plan_is_not_requesting_cooperation_after_cancelation_was_requested(
+        self,
+    ) -> None:
+        coop = self.cooperation_generator.create_cooperation()
+        company = self.company_generator.create_company()
+        plan = self.plan_generator.create_plan(
+            planner=company, requested_cooperation=coop
+        )
+        self.use_case(CancelCooperationSolicitationRequest(company, plan.id))
+        assert not self._is_plan_requesting_cooperation(plan=plan.id, planner=company)
 
     def test_that_true_is_returned_when_coop_request_gets_canceled(self) -> None:
         coop = self.cooperation_generator.create_cooperation()
@@ -31,7 +48,16 @@ class UseCaseTests(BaseTestCase):
         plan = self.plan_generator.create_plan(
             planner=company, requested_cooperation=coop
         )
-        assert plan.requested_cooperation is not None
         response = self.use_case(CancelCooperationSolicitationRequest(company, plan.id))
-        assert response == True
-        assert plan.requested_cooperation is None
+        assert response
+
+    def _is_plan_requesting_cooperation(self, plan: UUID, planner: UUID) -> bool:
+        response = self.list_outbound_coop_requests_use_case(
+            list_outbound_coop_requests.ListOutboundCoopRequestsRequest(
+                requester_id=planner
+            )
+        )
+        return any(
+            plan == coop_request.plan_id
+            for coop_request in response.cooperation_requests
+        )


### PR DESCRIPTION
Before this commit the tests for the CancelCooperationRequest use case were partly testing internals of the implementation. After this pretty minor change the tests are made against the interface of the business logic layer instead.

*No registration of consumption required*