### PR TITLE
Remove nix flake dependency on nixos-23.05

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -61,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4.5.0
       with:
-        python-version: '3.10'
+        python-version: '3.11'
         cache: 'pip'
     - name: Install dependencies
       run: |
@@ -101,7 +101,7 @@ jobs:
   unittests-nixpkgs:
     strategy:
       matrix:
-        devShell: [nixos-unstable, nixos-23-05, nixos-23-11]
+        devShell: [nixos-unstable, nixos-23-11]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -112,7 +112,7 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     # One might be tempted to run all the tests from `./run-checks`
     # but this could be a bad idea.  The python packages used with
-    # nixos-23-05 are older then nixos-unstable.  This means that
+    # nixos-23-11 are older then nixos-unstable.  This means that
     # there might be incompatibilities between different versions of
     # the tools used, e.g. mypy, flake8, black and so on. To avoid
     # running into these incompatibilities we simply don't run

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
 
 sphinx:
    configuration: docs/conf.py

--- a/arbeitszeit/email_notifications.py
+++ b/arbeitszeit/email_notifications.py
@@ -3,10 +3,8 @@ the arbeitszeitapp can issue and the interface by which the use cases
 request those notifications to be sent.
 """
 from dataclasses import dataclass
-from typing import Protocol, Type, Union, get_args
+from typing import Protocol, Type, TypeAlias, Union, get_args
 from uuid import UUID
-
-from typing_extensions import TypeAlias
 
 
 @dataclass

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -2,10 +2,18 @@ from __future__ import annotations
 
 from datetime import datetime
 from decimal import Decimal
-from typing import Generic, Iterable, Iterator, List, Optional, Protocol, Tuple, TypeVar
+from typing import (
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    Self,
+    Tuple,
+    TypeVar,
+)
 from uuid import UUID
-
-from typing_extensions import Self
 
 from arbeitszeit import records
 

--- a/arbeitszeit/transactions/transaction_type.py
+++ b/arbeitszeit/transactions/transaction_type.py
@@ -1,9 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum, auto
-from typing import Iterable, Optional, Tuple
-
-from typing_extensions import TypeAlias
+from typing import Iterable, Optional, Tuple, TypeAlias
 
 from arbeitszeit.records import AccountTypes
 

--- a/arbeitszeit_benchmark/__main__.py
+++ b/arbeitszeit_benchmark/__main__.py
@@ -3,9 +3,7 @@ from __future__ import annotations
 import argparse
 import timeit
 from dataclasses import dataclass
-from typing import Dict, Optional
-
-from typing_extensions import Self
+from typing import Dict, Optional, Self
 
 from .get_company_summary_benchmark import GetCompanySummaryBenchmark
 from .get_company_transactions import GetCompanyTransactionsBenchmark

--- a/arbeitszeit_flask/database/repositories.py
+++ b/arbeitszeit_flask/database/repositories.py
@@ -11,6 +11,7 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Self,
     Tuple,
     TypeVar,
 )
@@ -21,7 +22,6 @@ from sqlalchemy.dialects.postgresql import INTERVAL
 from sqlalchemy.orm import aliased
 from sqlalchemy.sql.expression import and_, case, func, or_, update
 from sqlalchemy.sql.functions import concat
-from typing_extensions import Self
 
 from arbeitszeit import records
 from arbeitszeit_flask.database import models

--- a/arbeitszeit_web/www/formfield_parsers.py
+++ b/arbeitszeit_web/www/formfield_parsers.py
@@ -1,7 +1,6 @@
 from copy import copy
+from typing import Self
 from uuid import UUID
-
-from typing_extensions import Self
 
 from arbeitszeit_web.fields import ParsingFailure, ParsingSuccess
 from arbeitszeit_web.translator import Translator

--- a/arbeitszeit_web/www/presenters/accept_coordination_transfer_presenter.py
+++ b/arbeitszeit_web/www/presenters/accept_coordination_transfer_presenter.py
@@ -1,7 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional
-
-from typing_extensions import assert_never
+from typing import Optional, assert_never
 
 from arbeitszeit.use_cases.accept_coordination_transfer import (
     AcceptCoordinationTransferUseCase,

--- a/arbeitszeit_web/www/presenters/request_coordination_transfer_presenter.py
+++ b/arbeitszeit_web/www/presenters/request_coordination_transfer_presenter.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
+from typing import assert_never
 from uuid import UUID
-
-from typing_extensions import assert_never
 
 from arbeitszeit.use_cases.request_coordination_transfer import (
     RequestCoordinationTransferUseCase as UseCase,

--- a/constraints.txt
+++ b/constraints.txt
@@ -41,7 +41,7 @@ installer==0.7.0
 is-safe-url==1.0
 isort==5.12.0
 itsdangerous==2.1.2
-Jinja2==3.1.2
+Jinja2==3.1.3
 jsonschema-specifications==2023.11.2
 kiwisolver==1.4.5
 Mako==1.3.0
@@ -57,7 +57,6 @@ orjson==3.9.10
 packaging==23.2
 parameterized==0.9.0
 pathspec==0.11.2
-pbr==6.0.0
 Pillow==10.1.0
 pip==23.3.1
 platformdirs==4.0.0
@@ -76,6 +75,7 @@ pytz==2023.3.post1
 referencing==0.31.1
 requests==2.31.0
 rpds-py==0.10.6
+setuptools==69.0.2
 six==1.16.0
 snowballstemmer==2.2.0
 Sphinx==7.2.6
@@ -91,7 +91,7 @@ SQLAlchemy==2.0.21
 toml==0.10.2
 types-python-dateutil==2.8.19
 types-pytz==2023.3.1
-types-setuptools==68.2.0
+types-setuptools==69.0.0
 typing_extensions==4.8.0
 urllib3==2.1.0
 Werkzeug==2.3.8

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
         "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1689068808,
-        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -42,42 +42,26 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1699454682,
-        "narHash": "sha256-YGW4PWk840MiY75lxZfCUR3nbOqLcocr9YC9jvsu1Os=",
+        "lastModified": 1706954289,
+        "narHash": "sha256-iEKEKtafWR1OH+KLQ/FsCbwMY4CcDN/tDOqUH4WyTcg=",
         "owner": "seppeljordan",
         "repo": "flask-profiler",
-        "rev": "a88f9be6d5d3292dd7064d1c5c7044fe4d3556ee",
+        "rev": "ef914e2b16d81ca32b24268c11407c9fd04c2660",
         "type": "github"
       },
       "original": {
         "owner": "seppeljordan",
         "repo": "flask-profiler",
-        "type": "github"
-      }
-    },
-    "nixos-23-05": {
-      "locked": {
-        "lastModified": 1704290814,
-        "narHash": "sha256-LWvKHp7kGxk/GEtlrGYV68qIvPHkU9iToomNFGagixU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "70bdadeb94ffc8806c0570eb5c2695ad29f0e421",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.05",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixos-23-11": {
       "locked": {
-        "lastModified": 1705641746,
-        "narHash": "sha256-D6c2aH8HQbWc7ZWSV0BUpFpd94ImFyCP8jFIsKQ4Slg=",
+        "lastModified": 1707514827,
+        "narHash": "sha256-Y+wqFkvikpE1epCx57PsGw+M1hX5aY5q/xgk+ebDwxI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d2003f2223cbb8cd95134e4a0541beea215c1073",
+        "rev": "20f65b86b6485decb43c5498780c223571dd56ef",
         "type": "github"
       },
       "original": {
@@ -89,11 +73,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1689534811,
-        "narHash": "sha256-jnSUdzD/414d94plCyNlvTJJtiTogTep6t7ZgIKIHiE=",
+        "lastModified": 1706732774,
+        "narHash": "sha256-hqJlyJk4MRpcItGYMF+3uHe8HvxNETWvlGtLuVpqLU0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6cee3b5893090b0f5f0a06b4cf42ca4e60e5d222",
+        "rev": "b8b232ae7b8b144397fdb12d20f592e5e7c1a64d",
         "type": "github"
       },
       "original": {
@@ -105,11 +89,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1705697961,
-        "narHash": "sha256-XepT3WS516evSFYkme3GrcI3+7uwXHqtHbip+t24J7E=",
+        "lastModified": 1707451808,
+        "narHash": "sha256-UwDBUNHNRsYKFJzyTMVMTF5qS4xeJlWoeyJf+6vvamU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e5d1c87f5813afde2dda384ac807c57a105721cc",
+        "rev": "442d407992384ed9c0e6d352de75b69079904e4e",
         "type": "github"
       },
       "original": {
@@ -123,7 +107,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-23-05": "nixos-23-05",
         "nixos-23-11": "nixos-23-11",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,23 +2,17 @@
   description = "Arbeitszeitapp";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-23-05.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixos-23-11.url = "github:NixOS/nixpkgs/nixos-23.11";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
 
-  outputs =
-    { self, nixpkgs, flake-utils, flask-profiler, nixos-23-05, nixos-23-11 }:
+  outputs = { self, nixpkgs, flake-utils, flask-profiler, nixos-23-11 }:
     let
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
       systemDependent = flake-utils.lib.eachSystem supportedSystems (system:
         let
           pkgs = import nixpkgs {
-            inherit system;
-            overlays = [ self.overlays.default ];
-          };
-          pkgs-23-05 = import nixos-23-05 {
             inherit system;
             overlays = [ self.overlays.default ];
           };
@@ -29,11 +23,8 @@
         in {
           devShells = rec {
             default = nixos-unstable;
-            nixos-23-05 = pkgs-23-05.callPackage nix/devShell.nix { };
             nixos-23-11 = pkgs-23-11.callPackage nix/devShell.nix { };
             nixos-unstable = pkgs.callPackage nix/devShell.nix { };
-            python310 =
-              pkgs.callPackage nix/devShell.nix { python3 = pkgs.python310; };
             python311 =
               pkgs.callPackage nix/devShell.nix { python3 = pkgs.python311; };
           };
@@ -49,7 +40,6 @@
             # versions we want to support.
             arbeitszeit-python3 = pkgs.python3.pkgs.arbeitszeitapp;
             arbeitszeit-python311 = pkgs.python311.pkgs.arbeitszeitapp;
-            arbeitszeit-python310 = pkgs.python310.pkgs.arbeitszeitapp;
           };
         });
       systemIndependent = {

--- a/nix/pythonPackages/arbeitszeitapp.nix
+++ b/nix/pythonPackages/arbeitszeitapp.nix
@@ -3,7 +3,7 @@
 # python packages
 , deepdiff, email_validator, flask, flask-babel, flask-talisman, flask_login
 , flask_mail, flask_migrate, flask-restx, flask_wtf, is_safe_url, matplotlib
-, sphinx, flask-profiler, typing-extensions, parameterized, Babel, setuptools }:
+, sphinx, flask-profiler, parameterized, Babel, setuptools }:
 buildPythonPackage {
   pname = "arbeitszeitapp";
   version = "0.0.0";
@@ -25,7 +25,6 @@ buildPythonPackage {
     flask_wtf
     is_safe_url
     matplotlib
-    typing-extensions
   ];
   buildDocsPhase = ''
     mkdir -p $doc/share/doc/arbeitszeitapp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ name = "arbeitszeitapp"
 version = "0.0.0"
 classifiers = [
     "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
 
@@ -22,7 +21,7 @@ include-package-data = true
 find = {}
 
 [tool.black]
-target-version = ['py310']
+target-version = ['py311']
 extend-exclude = '''
 (
   ^/arbeitszeit_flask/development_settings\.py |

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Generic, List, Optional, TypeVar
+from typing import Generic, List, Optional, Self, TypeVar
 from uuid import uuid4
-
-from typing_extensions import Self
 
 T = TypeVar("T")
 

--- a/tests/use_cases/repositories.py
+++ b/tests/use_cases/repositories.py
@@ -16,13 +16,12 @@ from typing import (
     List,
     Optional,
     Protocol,
+    Self,
     Set,
     Tuple,
     TypeVar,
 )
 from uuid import UUID, uuid4
-
-from typing_extensions import Self
 
 from arbeitszeit import records
 from arbeitszeit.decimal import decimal_sum


### PR DESCRIPTION
This change will remove the dependency on the NixOS 23.05 package set as this version of NixOS is deprecated.  The instances that are operated by us were already migrated to NixOS 23.11 in the past. Discontinuing support for allows us to drop support for python 3.10, therefore allowing us to use python language & library features that were introduced with version 3.11. 

With this we can leverage one of those features by using the newly introduced type `typing.Self`. In the past we had to rely on a third-party library to get same functionality. Now we can drop that reliance on the library typing_extensions and simply use the pythons core library for that purpose. A result of this change is that we require less computing ressources for running our CI setup as there is now one less version of python/nixos that needs to be checked.