### PR TITLE
Fix bug in email confirmation timestamp

### DIFF
--- a/arbeitszeit/use_cases/confirm_member.py
+++ b/arbeitszeit/use_cases/confirm_member.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
+from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.repositories import DatabaseGateway
 
 
@@ -18,6 +18,7 @@ class ConfirmMemberUseCase:
         member: Optional[UUID] = None
 
     database: DatabaseGateway
+    datetime_service: DatetimeService
 
     def confirm_member(self, request: Request) -> Response:
         record = (
@@ -34,5 +35,5 @@ class ConfirmMemberUseCase:
         else:
             self.database.get_email_addresses().with_address(
                 request.email_address
-            ).update().set_confirmation_timestamp(datetime.min).perform()
+            ).update().set_confirmation_timestamp(self.datetime_service.now()).perform()
             return self.Response(is_confirmed=True, member=member.id)

--- a/arbeitszeit/use_cases/get_user_account_details.py
+++ b/arbeitszeit/use_cases/get_user_account_details.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Optional, Tuple, Union
 from uuid import UUID
 
@@ -31,10 +32,18 @@ class GetUserAccountDetailsUseCase:
             return self._create_failure_model()
         else:
             user, mail = record
-            return self._create_success_model(user.id, mail.address)
+            return self._create_success_model(user.id, mail)
 
-    def _create_success_model(self, user_id: UUID, email_address: str) -> Response:
-        return Response(user_info=UserInfo(id=user_id, email_address=email_address))
+    def _create_success_model(
+        self, user_id: UUID, email_address: records.EmailAddress
+    ) -> Response:
+        return Response(
+            user_info=UserInfo(
+                id=user_id,
+                email_address=email_address.address,
+                email_address_confirmation_timestamp=email_address.confirmed_on,
+            )
+        )
 
     def _create_failure_model(self) -> Response:
         return Response(user_info=None)
@@ -54,3 +63,4 @@ class Response:
 class UserInfo:
     id: UUID
     email_address: str
+    email_address_confirmation_timestamp: Optional[datetime] = None


### PR DESCRIPTION
Before this change we had a bug when it came to confirming member email addresses. The bug was that we would set the email confirmation timestamp for confirmed members unconditionally to datetime.min. This change addresses this bug and sets it to the actual time of confirmation according to the DatetimeService implementation (which relies on datetime.datetime.now).

We also extended the response model for the
GetUserAccountDetailsUseCase to show the time of confirmation for a users email address. This was done to create test for the bug addressed here. In the future this extension could be used to show the email confirmation timestamp to users.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (1x)