### PR TITLE
Remove cooperation data from Plan record

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -208,7 +208,6 @@ class Plan:
     approval_date: Optional[datetime]
     activation_date: Optional[datetime]
     requested_cooperation: Optional[UUID]
-    cooperation: Optional[UUID]
     hidden_by_user: bool
 
     @property

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -123,9 +123,21 @@ class PlanResult(QueryResult[records.Plan], Protocol):
         only contain plans that are not hidden.
         """
 
-    def joined_with_planner_and_cooperating_plans(
+    def joined_with_planner_and_cooperation_and_cooperating_plans(
         self, timestamp: datetime
-    ) -> QueryResult[Tuple[records.Plan, records.Company, List[records.PlanSummary]]]:
+    ) -> QueryResult[
+        Tuple[
+            records.Plan,
+            records.Company,
+            Optional[records.Cooperation],
+            List[records.PlanSummary],
+        ]
+    ]:
+        ...
+
+    def joined_with_cooperation(
+        self,
+    ) -> QueryResult[Tuple[records.Plan, Optional[records.Cooperation]]]:
         ...
 
     def joined_with_provided_product_amount(

--- a/arbeitszeit/use_cases/query_plans.py
+++ b/arbeitszeit/use_cases/query_plans.py
@@ -72,14 +72,16 @@ class QueryPlans:
         total_results = len(plans)
         plans = self._apply_filter(plans, request.query_string, request.filter_category)
         plans = self._apply_sorting(plans, request.sorting_category)
-        planning_info = plans.joined_with_planner_and_cooperating_plans(now)
+        planning_info = plans.joined_with_planner_and_cooperation_and_cooperating_plans(
+            now
+        )
         if request.offset is not None:
             planning_info = planning_info.offset(n=request.offset)
         if request.limit is not None:
             planning_info = planning_info.limit(n=request.limit)
         results = [
-            self._plan_to_response_model(plan, planner, cooperating_plans)
-            for plan, planner, cooperating_plans in planning_info
+            self._plan_to_response_model(plan, planner, cooperation, cooperating_plans)
+            for plan, planner, cooperation, cooperating_plans in planning_info
         ]
         return PlanQueryResponse(
             results=results, total_results=total_results, request=request
@@ -107,6 +109,7 @@ class QueryPlans:
         self,
         plan: records.Plan,
         planner: records.Company,
+        cooperation: Optional[records.Cooperation],
         cooperating_plans: List[records.PlanSummary],
     ) -> QueriedPlan:
         labour_cost_per_unit = individual_labour_cost(plan)
@@ -124,6 +127,6 @@ class QueryPlans:
             price_per_unit=price_per_unit,
             labour_cost_per_unit=labour_cost_per_unit,
             is_public_service=plan.is_public_service,
-            is_cooperating=bool(plan.cooperation),
+            is_cooperating=bool(cooperation),
             activation_date=plan.activation_date,
         )

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -110,10 +110,16 @@ class Plan(db.Model):
     requested_cooperation = db.Column(
         db.String, db.ForeignKey("cooperation.id"), nullable=True
     )
-    cooperation = db.Column(db.String, db.ForeignKey("cooperation.id"), nullable=True)
     hidden_by_user = db.Column(db.Boolean, nullable=False, default=False)
 
     review = db.relationship("PlanReview", uselist=False, back_populates="plan")
+
+
+class PlanCooperation(db.Model):
+    plan = db.Column(
+        db.String, db.ForeignKey("plan.id"), nullable=False, primary_key=True
+    )
+    cooperation = db.Column(db.String, db.ForeignKey("cooperation.id"), nullable=False)
 
 
 class PlanReview(db.Model):

--- a/arbeitszeit_flask/migrations/versions/1e58bf7b0729_move_plan_cooperation_info_into_.py
+++ b/arbeitszeit_flask/migrations/versions/1e58bf7b0729_move_plan_cooperation_info_into_.py
@@ -1,0 +1,66 @@
+"""Move plan cooperation info into association plan_cooperation table
+
+Revision ID: 1e58bf7b0729
+Revises: 809a9eb543c1
+Create Date: 2024-02-20 17:59:17.877444
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "1e58bf7b0729"
+down_revision = "809a9eb543c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "plan_cooperation",
+        sa.Column("plan", sa.String(), nullable=False),
+        sa.Column("cooperation", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["cooperation"],
+            ["cooperation.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["plan"],
+            ["plan.id"],
+        ),
+        sa.PrimaryKeyConstraint("plan"),
+    )
+    op.execute(
+        """
+        INSERT INTO "plan_cooperation" ("plan", "cooperation")
+        SELECT "plan"."id" AS "plan", "plan"."cooperation" AS cooperation
+        FROM "plan"
+        WHERE cooperation IS NOT NULL
+        """
+    )
+    with op.batch_alter_table("plan", schema=None) as batch_op:
+        batch_op.drop_column("cooperation")
+
+
+def downgrade():
+    with op.batch_alter_table("plan", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "cooperation",
+                sa.String(),
+                nullable=True,
+            )
+        )
+        batch_op.create_foreign_key(
+            constraint_name="plan_cooperation_fkey",
+            referent_table="cooperation",
+            local_cols=["cooperation"],
+            remote_cols=["id"],
+        )
+    op.execute("""
+        UPDATE "plan"
+        SET cooperation = "plan_cooperation".cooperation
+        FROM "plan_cooperation"
+        WHERE "plan_cooperation"."plan" = "plan"."id"
+    """)
+    op.drop_table("plan_cooperation")

--- a/tests/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/www/presenters/test_show_my_plans_presenter.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from arbeitszeit.records import Plan, PlanDraft
 from arbeitszeit.use_cases.show_my_plans import (
@@ -85,7 +85,9 @@ class ShowMyPlansPresenterTests(BaseTestCase):
         self.datetime_service.freeze_time(datetime(2000, 1, 1))
         coop = self.coop_generator.create_cooperation()
         plan = self.plan_generator.create_plan_record(cooperation=coop)
-        RESPONSE_WITH_COOPERATING_PLAN = self.response_with_one_active_plan(plan)
+        RESPONSE_WITH_COOPERATING_PLAN = self.response_with_one_active_plan(
+            plan, cooperation=coop
+        )
         presentation = self.presenter.present(RESPONSE_WITH_COOPERATING_PLAN)
         self.assertEqual(
             presentation.active_plans.rows[0].is_cooperating,
@@ -217,7 +219,9 @@ class ShowMyPlansPresenterTests(BaseTestCase):
             self.url_index.get_draft_details_url(draft_id),
         )
 
-    def _convert_into_plan_info(self, plan: Plan) -> PlanInfo:
+    def _convert_into_plan_info(
+        self, plan: Plan, cooperation: UUID | None = None
+    ) -> PlanInfo:
         return PlanInfo(
             id=plan.id,
             prd_name=plan.prd_name,
@@ -226,8 +230,8 @@ class ShowMyPlansPresenterTests(BaseTestCase):
             plan_creation_date=plan.plan_creation_date,
             activation_date=plan.activation_date,
             expiration_date=plan.expiration_date,
-            is_cooperating=bool(plan.cooperation),
-            cooperation=plan.cooperation,
+            is_cooperating=bool(cooperation),
+            cooperation=cooperation,
         )
 
     def _convert_draft_into_plan_info(self, plan: PlanDraft) -> PlanInfo:
@@ -274,8 +278,10 @@ class ShowMyPlansPresenterTests(BaseTestCase):
             drafts=[],
         )
 
-    def response_with_one_active_plan(self, plan: Plan) -> ShowMyPlansResponse:
-        plan_info = self._convert_into_plan_info(plan)
+    def response_with_one_active_plan(
+        self, plan: Plan, cooperation: UUID | None = None
+    ) -> ShowMyPlansResponse:
+        plan_info = self._convert_into_plan_info(plan, cooperation)
         return ShowMyPlansResponse(
             count_all_plans=1,
             non_active_plans=[],


### PR DESCRIPTION
Before this change we stored the `cooperation` that a plan was part as a field of the `Plan` record. This was also reflected in the database implementation where `cooperation` was a column in the `plan` table. After this change the `cooperation` attribute is removed from the `Plan` record. Also the DB implementation stores the cooperation data in a new separate table called `plan_cooperation`. The DB interface had to changed slightly because of this, which affected some use cases in a minor way.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (3x)