### PR TITLE
Use new nixpkgs.nixfmt-rfc-style instead of nixpkgs.nixfmt

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,10 +7,22 @@
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
 
-  outputs = { self, nixpkgs, flake-utils, flask-profiler, nixos-23-11 }:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      flask-profiler,
+      nixos-23-11,
+    }:
     let
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
-      systemDependent = flake-utils.lib.eachSystem supportedSystems (system:
+      supportedSystems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      systemDependent = flake-utils.lib.eachSystem supportedSystems (
+        system:
         let
           isMacOs = !builtins.isNull (builtins.match ".*-darwin" system);
           pkgs = import nixpkgs {
@@ -21,14 +33,14 @@
             inherit system;
             overlays = [ self.overlays.default ];
           };
-        in {
+        in
+        {
           devShells = rec {
             default = nixos-unstable;
-            nixos-23-11 = pkgs-23-11.callPackage nix/devShell.nix {
-              includeGlibcLocales = !isMacOs;
-            };
+            nixos-23-11 = pkgs-23-11.callPackage nix/devShell.nix { includeGlibcLocales = !isMacOs; };
             nixos-unstable = pkgs.callPackage nix/devShell.nix {
               includeGlibcLocales = !isMacOs;
+              nixfmt = pkgs.nixfmt-rfc-style;
             };
             python311 = pkgs.callPackage nix/devShell.nix {
               python3 = pkgs.python311;
@@ -48,19 +60,21 @@
             arbeitszeit-python3 = pkgs.python3.pkgs.arbeitszeitapp;
             arbeitszeit-python311 = pkgs.python311.pkgs.arbeitszeitapp;
           };
-        });
+        }
+      );
       systemIndependent = {
         overlays = {
           # The default overlay provides the arbeitszeitapp to
           # nixpkgs.
-          default = let
-            ourOverlay = final: prev: {
-              pythonPackagesExtensions = prev.pythonPackagesExtensions
-                ++ [ (import nix/pythonPackages.nix) ];
-            };
-          in nixpkgs.lib.composeExtensions ourOverlay
-          flask-profiler.overlays.default;
+          default =
+            let
+              ourOverlay = final: prev: {
+                pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [ (import nix/pythonPackages.nix) ];
+              };
+            in
+            nixpkgs.lib.composeExtensions ourOverlay flask-profiler.overlays.default;
         };
       };
-    in systemDependent // systemIndependent;
+    in
+    systemDependent // systemIndependent;
 }

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,21 +1,37 @@
-{ mkShell, python3, nixfmt, sqlite, glibcLocales, includeGlibcLocales, lib }:
-mkShell ({
-  packages = (with python3.pkgs; [
-    black
-    build
-    coverage
-    flake8
-    gunicorn
-    isort
-    mypy
-    pip
-    psycopg2
-    types-dateutil
-    types-pytz
-    types-setuptools
-  ]) ++ [ nixfmt sqlite ]
-    ++ python3.pkgs.arbeitszeitapp.optional-dependencies.profiling;
-  inputsFrom = [ python3.pkgs.arbeitszeitapp ];
-} // lib.optionalAttrs includeGlibcLocales {
-  LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
-})
+{
+  mkShell,
+  python3,
+  nixfmt,
+  sqlite,
+  glibcLocales,
+  includeGlibcLocales,
+  lib,
+}:
+mkShell (
+  {
+    packages =
+      (with python3.pkgs; [
+        black
+        build
+        coverage
+        flake8
+        gunicorn
+        isort
+        mypy
+        pip
+        psycopg2
+        types-dateutil
+        types-pytz
+        types-setuptools
+      ])
+      ++ [
+        nixfmt
+        sqlite
+      ]
+      ++ python3.pkgs.arbeitszeitapp.optional-dependencies.profiling;
+    inputsFrom = [ python3.pkgs.arbeitszeitapp ];
+  }
+  // lib.optionalAttrs includeGlibcLocales {
+    LOCALE_ARCHIVE = "${glibcLocales}/lib/locale/locale-archive";
+  }
+)

--- a/nix/pythonPackages/arbeitszeitapp.nix
+++ b/nix/pythonPackages/arbeitszeitapp.nix
@@ -1,17 +1,43 @@
-{ buildPythonPackage, pytestCheckHook
+{
+  buildPythonPackage,
+  pytestCheckHook,
 
-# python packages
-, deepdiff, email_validator, flask, flask-babel, flask-talisman, flask_login
-, flask_mail, flask_migrate, flask-restx, flask_wtf, is_safe_url, matplotlib
-, sphinx, flask-profiler, parameterized, Babel, setuptools }:
+  # python packages
+  deepdiff,
+  email_validator,
+  flask,
+  flask-babel,
+  flask-talisman,
+  flask_login,
+  flask_mail,
+  flask_migrate,
+  flask-restx,
+  flask_wtf,
+  is_safe_url,
+  matplotlib,
+  sphinx,
+  flask-profiler,
+  parameterized,
+  Babel,
+  setuptools,
+}:
 buildPythonPackage {
   pname = "arbeitszeitapp";
   version = "0.0.0";
   src = ../..;
-  outputs = [ "out" "doc" ];
+  outputs = [
+    "out"
+    "doc"
+  ];
   postPhases = [ "buildDocsPhase" ];
   format = "pyproject";
-  buildInputs = [ pytestCheckHook sphinx parameterized Babel setuptools ];
+  buildInputs = [
+    pytestCheckHook
+    sphinx
+    parameterized
+    Babel
+    setuptools
+  ];
   propagatedBuildInputs = [
     deepdiff
     email_validator
@@ -30,6 +56,8 @@ buildPythonPackage {
     mkdir -p $doc/share/doc/arbeitszeitapp
     python -m sphinx -a $src/docs $doc/share/doc/arbeitszeitapp
   '';
-  passthru.optional-dependencies = { profiling = [ flask-profiler ]; };
+  passthru.optional-dependencies = {
+    profiling = [ flask-profiler ];
+  };
   DISABLED_TESTS = "database_required";
 }

--- a/nix/pythonPackages/flask-restx.nix
+++ b/nix/pythonPackages/flask-restx.nix
@@ -1,12 +1,29 @@
-{ lib, buildPythonPackage, fetchPypi, flask, aniso8601, jsonschema, pytz
-, werkzeug, importlib-resources }:
-let pypiSource = (builtins.fromJSON (builtins.readFile ./flask-restx.json));
-in buildPythonPackage rec {
+{
+  lib,
+  buildPythonPackage,
+  fetchPypi,
+  flask,
+  aniso8601,
+  jsonschema,
+  pytz,
+  werkzeug,
+  importlib-resources,
+}:
+let
+  pypiSource = (builtins.fromJSON (builtins.readFile ./flask-restx.json));
+in
+buildPythonPackage rec {
   pname = pypiSource.pname;
   version = pypiSource.version;
   format = "setuptools";
   src = fetchPypi pypiSource;
-  propagatedBuildInputs =
-    [ flask aniso8601 jsonschema pytz werkzeug importlib-resources ];
+  propagatedBuildInputs = [
+    flask
+    aniso8601
+    jsonschema
+    pytz
+    werkzeug
+    importlib-resources
+  ];
   doCheck = false;
 }

--- a/nix/pythonPackages/is_safe_url.nix
+++ b/nix/pythonPackages/is_safe_url.nix
@@ -1,6 +1,8 @@
 { buildPythonPackage, fetchPypi }:
-let pypiSource = (builtins.fromJSON (builtins.readFile ./is-safe-url.json));
-in buildPythonPackage rec {
+let
+  pypiSource = (builtins.fromJSON (builtins.readFile ./is-safe-url.json));
+in
+buildPythonPackage rec {
   pname = pypiSource.pname;
   version = pypiSource.version;
   src = fetchPypi pypiSource;


### PR DESCRIPTION
The old source code formatter `nixfmt` is basically deprecated and was replaced by a new version of it in the NixOS/nixpkgs github repository. We switch over to the new version to stay up to date with improvements to the code formatter.