### PR TITLE
Don't generate transactions for 0 fixed or liquid means planned

### DIFF
--- a/arbeitszeit/use_cases/approve_plan.py
+++ b/arbeitszeit/use_cases/approve_plan.py
@@ -35,12 +35,14 @@ class ApprovePlanUseCase:
         matching_plans.update().set_approval_date(now).set_activation_timestamp(
             now
         ).perform()
-        self._create_transaction_from_social_accounting(
-            plan, planner.means_account, plan.production_costs.means_cost
-        )
-        self._create_transaction_from_social_accounting(
-            plan, planner.raw_material_account, plan.production_costs.resource_cost
-        )
+        if plan.production_costs.means_cost:
+            self._create_transaction_from_social_accounting(
+                plan, planner.means_account, plan.production_costs.means_cost
+            )
+        if plan.production_costs.resource_cost:
+            self._create_transaction_from_social_accounting(
+                plan, planner.raw_material_account, plan.production_costs.resource_cost
+            )
         self._create_transaction_from_social_accounting(
             plan, planner.product_account, -plan.expected_sales_value
         )


### PR DESCRIPTION
Before this commit the application would generate transactions with a volume of 0 hours when plans did not include any fixed or liquid means planned. This commit only generates those transactions in cases where the planning company actually plans to use fixed or liquid means.

fixes #337 