### PR TITLE
Move format_datetime method to new DatetimeFormatter interface

### DIFF
--- a/arbeitszeit/datetime_service.py
+++ b/arbeitszeit/datetime_service.py
@@ -1,22 +1,8 @@
-from abc import ABC, abstractmethod
 from datetime import date, datetime
-from typing import Optional
+from typing import Protocol
 
 
-class DatetimeService(ABC):
-    @abstractmethod
-    def today(self) -> date:
-        pass
+class DatetimeService(Protocol):
+    def today(self) -> date: ...
 
-    @abstractmethod
-    def now(self) -> datetime:
-        pass
-
-    @abstractmethod
-    def format_datetime(
-        self,
-        date: datetime,
-        zone: Optional[str] = ...,
-        fmt: Optional[str] = ...,
-    ) -> str:
-        pass
+    def now(self) -> datetime: ...

--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -46,6 +46,7 @@ from arbeitszeit_web.email.accountant_invitation_presenter import (
     AccountantInvitationEmailView,
 )
 from arbeitszeit_web.email.email_sender import EmailSender as EmailSenderImpl
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.plotter import Plotter
@@ -89,6 +90,7 @@ class FlaskModule(Module):
         binder[Plotter] = AliasProvider(FlaskPlotter)
         binder[Colors] = AliasProvider(FlaskColors)
         binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)
+        binder[DatetimeFormatter] = AliasProvider(RealtimeDatetimeService)
         binder.bind(
             AccountantInvitationEmailView,
             to=AliasProvider(AccountantInvitationEmailViewImpl),

--- a/arbeitszeit_web/formatters/datetime_formatter.py
+++ b/arbeitszeit_web/formatters/datetime_formatter.py
@@ -1,0 +1,11 @@
+from datetime import datetime
+from typing import Protocol
+
+
+class DatetimeFormatter(Protocol):
+    def format_datetime(
+        self,
+        date: datetime,
+        zone: str | None = ...,
+        fmt: str | None = ...,
+    ) -> str: ...

--- a/arbeitszeit_web/formatters/plan_details_formatter.py
+++ b/arbeitszeit_web/formatters/plan_details_formatter.py
@@ -2,10 +2,11 @@ from dataclasses import dataclass
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.plan_details import PlanDetails
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
+
+from .datetime_formatter import DatetimeFormatter
 
 
 @dataclass
@@ -34,7 +35,7 @@ class PlanDetailsWeb:
 class PlanDetailsFormatter:
     url_index: UrlIndex
     translator: Translator
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def format_plan_details(self, plan_details: PlanDetails) -> PlanDetailsWeb:
         return PlanDetailsWeb(
@@ -109,13 +110,13 @@ class PlanDetailsFormatter:
                 self.translator.gettext("Labour time (hours/unit)"),
                 self._format_price(plan_details.labour_cost_per_unit),
             ),
-            creation_date=self.datetime_service.format_datetime(
+            creation_date=self.datetime_formatter.format_datetime(
                 date=plan_details.creation_date,
                 zone="Europe/Berlin",
                 fmt="%d.%m.%Y %H:%M",
             ),
             approval_date=(
-                self.datetime_service.format_datetime(
+                self.datetime_formatter.format_datetime(
                     date=plan_details.approval_date,
                     zone="Europe/Berlin",
                     fmt="%d.%m.%Y %H:%M",
@@ -124,7 +125,7 @@ class PlanDetailsFormatter:
                 else "-"
             ),
             expiration_date=(
-                self.datetime_service.format_datetime(
+                self.datetime_formatter.format_datetime(
                     date=plan_details.expiration_date,
                     zone="Europe/Berlin",
                     fmt="%d.%m.%Y %H:%M",

--- a/arbeitszeit_web/www/presenters/company_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/company_consumptions_presenter.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 from typing import Iterator, List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.records import ConsumptionType
 from arbeitszeit.use_cases.query_company_consumptions import ConsumptionQueryResponse
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 
 
@@ -25,7 +25,7 @@ class ViewModel:
 
 @dataclass
 class CompanyConsumptionsPresenter:
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     translator: Translator
 
     def present(
@@ -41,7 +41,7 @@ class CompanyConsumptionsPresenter:
         self, consumption: ConsumptionQueryResponse
     ) -> ViewModel.Consumption:
         return ViewModel.Consumption(
-            consumption_date=self.datetime_service.format_datetime(
+            consumption_date=self.datetime_formatter.format_datetime(
                 date=consumption.consumption_date,
                 zone="Europe/Berlin",
                 fmt="%d.%m.%Y %H:%M",

--- a/arbeitszeit_web/www/presenters/get_company_dashboard_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_dashboard_presenter.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.get_company_dashboard import GetCompanyDashboardUseCase
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
@@ -36,7 +36,7 @@ class GetCompanyDashboardPresenter:
         accounts_tile: GetCompanyDashboardPresenter.Tile
 
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     translator: Translator
 
     def present(
@@ -61,7 +61,7 @@ class GetCompanyDashboardPresenter:
     ) -> PlanDetailsWeb:
         return self.PlanDetailsWeb(
             prd_name=plan.prd_name,
-            activation_date=self.datetime_service.format_datetime(
+            activation_date=self.datetime_formatter.format_datetime(
                 plan.activation_date, zone="Europe/Berlin", fmt="%d.%m."
             ),
             plan_details_url=self.url_index.get_plan_details_url(

--- a/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
@@ -2,12 +2,12 @@ from dataclasses import asdict, dataclass
 from typing import Any, Dict, List
 
 from arbeitszeit.control_thresholds import ControlThresholds
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.get_company_summary import (
     GetCompanySummarySuccess,
     PlanDetails,
     Supplier,
 )
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex, UserUrlIndex
 
@@ -59,7 +59,7 @@ class GetCompanySummarySuccessPresenter:
     translator: Translator
     url_index: UrlIndex
     control_thresholds: ControlThresholds
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(
         self, use_case_response: GetCompanySummarySuccess
@@ -71,7 +71,7 @@ class GetCompanySummarySuccessPresenter:
             id=str(use_case_response.id),
             name=use_case_response.name,
             email=use_case_response.email,
-            registered_on=self.datetime_service.format_datetime(
+            registered_on=self.datetime_formatter.format_datetime(
                 use_case_response.registered_on, zone="Europe/Berlin", fmt="%d.%m.%Y"
             ),
             expectations=[

--- a/arbeitszeit_web/www/presenters/get_company_transactions_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_transactions_presenter.py
@@ -3,10 +3,10 @@ from decimal import Decimal
 from typing import List
 from uuid import UUID
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.records import AccountTypes
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import get_company_transactions
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -30,7 +30,7 @@ class GetCompanyTransactionsViewModel:
 @dataclass
 class GetCompanyTransactionsPresenter:
     translator: Translator
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     url_index: UrlIndex
 
     def present(
@@ -53,7 +53,7 @@ class GetCompanyTransactionsPresenter:
         account = self._get_account(transaction.account_type)
         return ViewModelTransactionInfo(
             transaction_type=self._get_transaction_name(transaction.transaction_type),
-            date=self.datetime_service.format_datetime(
+            date=self.datetime_formatter.format_datetime(
                 transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
             transaction_volume=round(transaction.transaction_volume, 2),

--- a/arbeitszeit_web/www/presenters/get_coordination_transfer_request_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_coordination_transfer_request_details_presenter.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.get_coordination_transfer_request_details import (
     GetCoordinationTransferRequestDetailsUseCase as UseCase,
 )
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.session import Session
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
@@ -22,7 +22,7 @@ class GetCoordinationTransferRequestDetailsPresenter:
         request_is_pending: bool
         request_status: str
 
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     session: Session
     url_index: UrlIndex
     translator: Translator
@@ -31,7 +31,7 @@ class GetCoordinationTransferRequestDetailsPresenter:
         current_user = self.session.get_current_user()
         assert current_user
         return self.ViewModel(
-            request_date=self.datetime_service.format_datetime(response.request_date),
+            request_date=self.datetime_formatter.format_datetime(response.request_date),
             cooperation_url=self.url_index.get_coop_summary_url(
                 coop_id=response.cooperation_id
             ),

--- a/arbeitszeit_web/www/presenters/get_member_account_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_member_account_presenter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.get_member_account import GetMemberAccountResponse
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 
 
@@ -26,7 +26,7 @@ class GetMemberAccountPresenter:
         is_balance_positive: bool
         transactions: List[GetMemberAccountPresenter.Transaction]
 
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     translator: Translator
 
     def present_member_account(
@@ -34,7 +34,7 @@ class GetMemberAccountPresenter:
     ) -> ViewModel:
         transactions = [
             self.Transaction(
-                date=self.datetime_service.format_datetime(
+                date=self.datetime_formatter.format_datetime(
                     t.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
                 ),
                 type=(

--- a/arbeitszeit_web/www/presenters/get_member_dashboard_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_member_dashboard_presenter.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.get_member_dashboard import GetMemberDashboard
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
@@ -46,7 +46,7 @@ class GetMemberDashboardViewModel:
 class GetMemberDashboardPresenter:
     translator: Translator
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(
         self, use_case_response: GetMemberDashboard.Response
@@ -86,7 +86,7 @@ class GetMemberDashboardPresenter:
     ) -> PlanDetailsWeb:
         return PlanDetailsWeb(
             prd_name=plan_detail.prd_name,
-            activation_date=self.datetime_service.format_datetime(
+            activation_date=self.datetime_formatter.format_datetime(
                 date=plan_detail.activation_date,
                 zone="Europe/Berlin",
                 fmt="%d.%m.",

--- a/arbeitszeit_web/www/presenters/list_coordinations_of_cooperation_presenter.py
+++ b/arbeitszeit_web/www/presenters/list_coordinations_of_cooperation_presenter.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.list_coordinations_of_cooperation import (
     ListCoordinationsOfCooperationUseCase as UseCase,
 )
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -29,7 +29,7 @@ class ListCoordinationsOfCooperationPresenter:
         navbar_items: list[NavbarItem]
 
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     translator: Translator
 
     def list_coordinations_of_cooperation(
@@ -47,7 +47,7 @@ class ListCoordinationsOfCooperationPresenter:
                     coordinator_url=self.url_index.get_company_summary_url(
                         company_id=coordination.coordinator_id,
                     ),
-                    start_time=self.datetime_service.format_datetime(
+                    start_time=self.datetime_formatter.format_datetime(
                         date=coordination.start_time,
                         zone="Europe/Berlin",
                         fmt="%d.%m.%Y %H:%M",
@@ -55,7 +55,7 @@ class ListCoordinationsOfCooperationPresenter:
                     end_time=(
                         "-"
                         if coordination.end_time is None
-                        else self.datetime_service.format_datetime(
+                        else self.datetime_formatter.format_datetime(
                             date=coordination.end_time,
                             zone="Europe/Berlin",
                             fmt="%d.%m.%Y %H:%M",

--- a/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/private_consumptions_presenter.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.query_private_consumptions import Response
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 
 
 @dataclass
@@ -21,14 +21,14 @@ class PrivateConsumptionsPresenter:
         is_consumptions_visible: bool
         consumptions: List[Consumption]
 
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present_private_consumptions(self, response: Response) -> ViewModel:
         return self.ViewModel(
             is_consumptions_visible=bool(response.consumptions),
             consumptions=[
                 self.ViewModel.Consumption(
-                    consumption_date=self.datetime_service.format_datetime(
+                    consumption_date=self.datetime_formatter.format_datetime(
                         date=consumption.consumption_date,
                         fmt="%d.%m.%Y",
                     ),

--- a/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
+++ b/arbeitszeit_web/www/presenters/review_registered_consumptions_presenter.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
 from typing import Optional
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.review_registered_consumptions import RegisteredConsumption
 from arbeitszeit.use_cases.review_registered_consumptions import (
     ReviewRegisteredConsumptionsUseCase as UseCase,
 )
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.session import UserRole
 from arbeitszeit_web.url_index import UrlIndex
 
@@ -28,7 +28,7 @@ class ViewModel:
 
 @dataclass
 class ReviewRegisteredConsumptionsPresenter:
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     url_index: UrlIndex
 
     def present(self, use_case_response: UseCase.Response) -> ViewModel:
@@ -40,7 +40,7 @@ class ReviewRegisteredConsumptionsPresenter:
 
     def _create_consumption(self, consumption: RegisteredConsumption) -> Consumption:
         return Consumption(
-            date=self.datetime_service.format_datetime(consumption.date),
+            date=self.datetime_formatter.format_datetime(consumption.date),
             consumer_name=consumption.consumer_name,
             consumer_url=self._get_consumer_url(consumption),
             consumer_type_icon=self._get_consumer_type_icon(consumption),

--- a/arbeitszeit_web/www/presenters/show_a_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_a_account_details_presenter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import show_a_account_details
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -29,7 +29,7 @@ class ShowAAccountDetailsPresenter:
 
     translator: Translator
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(self, use_case_response: show_a_account_details.Response) -> ViewModel:
         transactions = [
@@ -63,7 +63,7 @@ class ShowAAccountDetailsPresenter:
         )
         return self.TransactionInfo(
             transaction_type,
-            self.datetime_service.format_datetime(
+            self.datetime_formatter.format_datetime(
                 date=transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
             str(round(transaction.transaction_volume, 2)),

--- a/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_p_account_details_presenter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases.show_p_account_details import ShowPAccountDetailsUseCase
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -29,7 +29,7 @@ class ShowPAccountDetailsPresenter:
 
     translator: Translator
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(
         self, use_case_response: ShowPAccountDetailsUseCase.Response
@@ -66,7 +66,7 @@ class ShowPAccountDetailsPresenter:
         )
         return self.TransactionInfo(
             transaction_type,
-            self.datetime_service.format_datetime(
+            self.datetime_formatter.format_datetime(
                 date=transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
             str(round(transaction.transaction_volume, 2)),

--- a/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_prd_account_details_presenter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import show_prd_account_details
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -32,7 +32,7 @@ class ShowPRDAccountDetailsPresenter:
 
     translator: Translator
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(
         self, use_case_response: show_prd_account_details.Response
@@ -78,7 +78,7 @@ class ShowPRDAccountDetailsPresenter:
         )
         return self.TransactionInfo(
             transaction_type=transaction_type,
-            date=self.datetime_service.format_datetime(
+            date=self.datetime_formatter.format_datetime(
                 date=transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
             transaction_volume=str(round(transaction.transaction_volume, 2)),

--- a/arbeitszeit_web/www/presenters/show_r_account_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_r_account_details_presenter.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.transactions import TransactionTypes
 from arbeitszeit.use_cases import show_r_account_details
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 from arbeitszeit_web.www.navbar import NavbarItem
@@ -29,7 +29,7 @@ class ShowRAccountDetailsPresenter:
 
     translator: Translator
     url_index: UrlIndex
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def present(self, use_case_response: show_r_account_details.Response) -> ViewModel:
         transactions = [
@@ -64,7 +64,7 @@ class ShowRAccountDetailsPresenter:
         )
         return self.TransactionInfo(
             transaction_type,
-            self.datetime_service.format_datetime(
+            self.datetime_formatter.format_datetime(
                 date=transaction.date, zone="Europe/Berlin", fmt="%d.%m.%Y %H:%M"
             ),
             str(round(transaction.transaction_volume, 2)),

--- a/arbeitszeit_web/www/presenters/start_page_presenter.py
+++ b/arbeitszeit_web/www/presenters/start_page_presenter.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import List
 
-from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.use_cases.start_page import StartPageUseCase
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 
 
 @dataclass
@@ -19,7 +19,7 @@ class StartPagePresenter:
         show_plans: bool
         plans: List[StartPagePresenter.Plan]
 
-    datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
 
     def show_start_page(self, response: StartPageUseCase.Response) -> ViewModel:
         if not response.latest_plans:
@@ -29,7 +29,7 @@ class StartPagePresenter:
             plans=[
                 self.Plan(
                     prd_name=plan.product_name,
-                    activation_date=self.datetime_service.format_datetime(
+                    activation_date=self.datetime_formatter.format_datetime(
                         plan.activation_date, zone="Europe/Berlin", fmt="%d.%m."
                     ),
                 )

--- a/tests/www/dependency_injection.py
+++ b/tests/www/dependency_injection.py
@@ -3,11 +3,13 @@ from arbeitszeit_web.email import EmailConfiguration, MailService
 from arbeitszeit_web.email.accountant_invitation_presenter import (
     AccountantInvitationEmailView,
 )
+from arbeitszeit_web.formatters.datetime_formatter import DatetimeFormatter
 from arbeitszeit_web.language_service import LanguageService
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.session import Session
 from arbeitszeit_web.url_index import UrlIndex
+from tests.datetime_service import FakeDatetimeService
 from tests.dependency_injection import TestingModule
 from tests.email import FakeEmailConfiguration, FakeEmailService
 from tests.email_presenters.accountant_invitation_email_view import (
@@ -35,6 +37,7 @@ class WwwTestsInjector(Module):
         binder[Request] = AliasProvider(FakeRequest)
         binder[LanguageService] = AliasProvider(FakeLanguageService)
         binder[MailService] = AliasProvider(FakeEmailService)
+        binder[DatetimeFormatter] = AliasProvider(FakeDatetimeService)
 
 
 def get_dependency_injector() -> Injector:


### PR DESCRIPTION
Before this change the DatetimeService interface was responsible for retrieving the current time and for formatting datetime values. Now we moved that responsibility out to another interface `arbeitszeit_web.formatters.datetime_formatter`. This should allow us to work on localization without disturbing the business logic code too much.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (2x)