### PR TITLE
Introduce JsonList to possible json schema definition types

### DIFF
--- a/arbeitszeit_flask/api/schema_converter.py
+++ b/arbeitszeit_flask/api/schema_converter.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Union
+from typing import TypeAlias, Union
 
 from deepdiff import DeepDiff
 from flask_restx import Model, fields
@@ -8,11 +8,24 @@ from arbeitszeit_web.api.presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonInteger,
+    JsonList,
     JsonObject,
     JsonString,
     JsonValue,
     Namespace,
 )
+
+RestxField: TypeAlias = Union[
+    fields.List,
+    fields.Nested,
+    fields.String,
+    fields.Arbitrary,
+    fields.Boolean,
+    fields.DateTime,
+    fields.Integer,
+    fields.List,
+    dict[str, "RestxField"],
+]
 
 
 class DifferentModelWithSameNameExists(Exception):
@@ -22,9 +35,6 @@ class DifferentModelWithSameNameExists(Exception):
 class SchemaConverter:
     def __init__(self, namespace: Namespace) -> None:
         self.namespace = namespace
-
-    def _register_on_namespace(self, flaskx_model: Model) -> None:
-        self.namespace.model(name=flaskx_model.name, model=flaskx_model)
 
     def _prevent_overriding(self, model: Model) -> None:
         """
@@ -38,73 +48,40 @@ class SchemaConverter:
                     f"Different model with name {model.name} exists already."
                 )
 
-    def _dict_to_flaskx_model(
-        self, model_name: str, dict_model: Dict[str, Any]
-    ) -> Model:
-        flaskx_model = Model(name=model_name)
-        flaskx_model.update(dict_model)
-        return flaskx_model
-
-    def _unpack_member_in_list(
-        self, dict_model: Dict[str, Any], key: str, json_value: JsonValue
-    ) -> Dict[str, Any]:
-        if isinstance(json_value, JsonObject):
-            dict_model.update(
-                {
-                    key: fields.List(
-                        fields.Nested(
-                            self.json_schema_to_flaskx(schema=json_value),
-                            skip_none=True,
-                        ),
-                        required=True,
-                    )
-                }
-            )
-        else:
-            dict_model.update(
-                {
-                    key: fields.List(
-                        self.json_schema_to_flaskx(schema=json_value), required=True
-                    )
-                }
-            )
-        return dict_model
-
-    def _unpack_object_members_recursively(
-        self, json_object: JsonObject
-    ) -> Dict[str, Any]:
-        dict_model: Dict[str, Any] = {}
-        for key, json_value in json_object.members.items():
-            if json_value.as_list:
-                dict_model = self._unpack_member_in_list(dict_model, key, json_value)
-            else:
-                dict_model.update({key: self.json_schema_to_flaskx(schema=json_value)})
-        return dict_model
-
-    def json_schema_to_flaskx(self, schema: JsonValue) -> Union[
-        Model,
-        fields.String,
-        fields.Arbitrary,
-        fields.Boolean,
-        fields.DateTime,
-        fields.Integer,
-    ]:
+    def json_schema_to_flaskx(self, schema: JsonValue) -> Union[Model, RestxField]:
         if isinstance(schema, JsonObject):
-            dict_model = self._unpack_object_members_recursively(schema)
-            flaskx_model = self._dict_to_flaskx_model(
-                model_name=schema.name, dict_model=dict_model
-            )
-            self._prevent_overriding(flaskx_model)
-            self._register_on_namespace(flaskx_model)
-            return flaskx_model
-        elif isinstance(schema, JsonDecimal):
-            return fields.Arbitrary(required=schema.required)
-        elif isinstance(schema, JsonBoolean):
-            return fields.Boolean(required=schema.required)
-        elif isinstance(schema, JsonDatetime):
-            return fields.DateTime(required=schema.required)
-        elif isinstance(schema, JsonInteger):
-            return fields.Integer(required=schema.required)
+            model = Model(schema.name, self.field_from_schema(schema))
+            self._prevent_overriding(model)
+            self.namespace.model(name=model.name, model=model)
+            return model
         else:
-            assert isinstance(schema, JsonString)
-            return fields.String(required=schema.required)
+            return self.field_from_schema(schema)
+
+    def field_from_schema(self, schema: JsonValue) -> RestxField:
+        match schema:
+            case JsonObject(members=members):
+                return {
+                    key: self.field_from_schema(value) for key, value in members.items()
+                }
+            case JsonList(elements=JsonObject() as elements, required=required):
+                object_model = Model(
+                    elements.name,
+                    self.field_from_schema(elements),
+                )
+                self._prevent_overriding(object_model)
+                self.namespace.model(name=elements.name, model=object_model)
+                return fields.List(
+                    fields.Nested(object_model, skip_none=True), required=required
+                )
+            case JsonString(required=required):
+                return fields.String(required=required)
+            case JsonDecimal(required=required):
+                return fields.Arbitrary(required=required)
+            case JsonBoolean(required=required):
+                return fields.Boolean(required=required)
+            case JsonInteger(required=required):
+                return fields.Integer(required=required)
+            case JsonDatetime(required=required):
+                return fields.DateTime(required=required)
+            case other:
+                raise NotImplementedError(other)

--- a/arbeitszeit_web/api/presenters/interfaces.py
+++ b/arbeitszeit_web/api/presenters/interfaces.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Any, Dict, Protocol, Union
 
@@ -8,6 +10,7 @@ JsonValue = Union[
     "JsonBoolean",
     "JsonDatetime",
     "JsonInteger",
+    "JsonList",
 ]
 
 
@@ -15,14 +18,12 @@ JsonValue = Union[
 class JsonObject:
     members: Dict[str, JsonValue]
     name: str
-    as_list: bool = False
     required: bool = True
 
 
 @dataclass
 class JsonString:
     required: bool = True
-    as_list: bool = False
 
 
 @dataclass
@@ -30,25 +31,27 @@ class JsonDecimal:
     """A floating point number with an arbitrary precision."""
 
     required: bool = True
-    as_list: bool = False
 
 
 @dataclass
 class JsonBoolean:
     required: bool = True
-    as_list: bool = False
 
 
 @dataclass
 class JsonInteger:
     required: bool = True
-    as_list: bool = False
 
 
 @dataclass
 class JsonDatetime:
     required: bool = True
-    as_list: bool = False
+
+
+@dataclass
+class JsonList:
+    elements: JsonValue
+    required: bool = True
 
 
 class Namespace(Protocol):

--- a/arbeitszeit_web/api/presenters/query_companies_api_presenter.py
+++ b/arbeitszeit_web/api/presenters/query_companies_api_presenter.py
@@ -4,6 +4,7 @@ from typing import List, Optional
 from arbeitszeit.use_cases.query_companies import CompanyQueryResponse, QueriedCompany
 from arbeitszeit_web.api.presenters.interfaces import (
     JsonInteger,
+    JsonList,
     JsonObject,
     JsonString,
     JsonValue,
@@ -22,14 +23,15 @@ class QueryCompaniesApiPresenter:
     def get_schema(cls) -> JsonValue:
         return JsonObject(
             members=dict(
-                results=JsonObject(
-                    members=dict(
-                        company_id=JsonString(),
-                        company_email=JsonString(),
-                        company_name=JsonString(),
-                    ),
-                    name="Company",
-                    as_list=True,
+                results=JsonList(
+                    elements=JsonObject(
+                        members=dict(
+                            company_id=JsonString(),
+                            company_email=JsonString(),
+                            company_name=JsonString(),
+                        ),
+                        name="Company",
+                    )
                 ),
                 total_results=JsonInteger(),
                 offset=JsonInteger(),

--- a/arbeitszeit_web/api/presenters/query_plans_api_presenter.py
+++ b/arbeitszeit_web/api/presenters/query_plans_api_presenter.py
@@ -7,6 +7,7 @@ from arbeitszeit_web.api.presenters.interfaces import (
     JsonDatetime,
     JsonDecimal,
     JsonInteger,
+    JsonList,
     JsonObject,
     JsonString,
     JsonValue,
@@ -25,20 +26,21 @@ class QueryPlansApiPresenter:
     def get_schema(cls) -> JsonValue:
         return JsonObject(
             members=dict(
-                results=JsonObject(
-                    members=dict(
-                        plan_id=JsonString(),
-                        company_name=JsonString(),
-                        company_id=JsonString(),
-                        product_name=JsonString(),
-                        description=JsonString(),
-                        price_per_unit=JsonDecimal(),
-                        is_public_service=JsonBoolean(),
-                        is_cooperating=JsonBoolean(),
-                        activation_date=JsonDatetime(),
-                    ),
-                    name="Plan",
-                    as_list=True,
+                results=JsonList(
+                    elements=JsonObject(
+                        members=dict(
+                            plan_id=JsonString(),
+                            company_name=JsonString(),
+                            company_id=JsonString(),
+                            product_name=JsonString(),
+                            description=JsonString(),
+                            price_per_unit=JsonDecimal(),
+                            is_public_service=JsonBoolean(),
+                            is_cooperating=JsonBoolean(),
+                            activation_date=JsonDatetime(),
+                        ),
+                        name="Plan",
+                    )
                 ),
                 total_results=JsonInteger(),
                 offset=JsonInteger(),

--- a/tests/api/presenters/test_get_plan_presenter.py
+++ b/tests/api/presenters/test_get_plan_presenter.py
@@ -43,7 +43,6 @@ class TestSchema(BaseTestCase):
 
     def test_schema_top_level(self) -> None:
         assert isinstance(self.schema, JsonObject)
-        assert not self.schema.as_list
         assert self.schema.name == "PlanDetails"
 
     def test_schema_top_level_members_field_types_are_correct(self) -> None:

--- a/tests/api/presenters/test_liquid_means_consumption_presenter.py
+++ b/tests/api/presenters/test_liquid_means_consumption_presenter.py
@@ -99,9 +99,6 @@ class TestSchema(BaseTestCase):
     def test_schema_is_of_type_object(self) -> None:
         assert isinstance(self.schema, JsonObject)
 
-    def test_schema_is_not_shown_as_list(self) -> None:
-        assert not self.schema.as_list
-
     def test_schema_is_required(self) -> None:
         assert self.schema.required
 
@@ -124,7 +121,3 @@ class TestSchema(BaseTestCase):
     def test_member_success_is_required(self) -> None:
         assert isinstance(self.schema, JsonObject)
         assert self.schema.members["success"].required
-
-    def test_member_success_is_not_shown_as_list(self) -> None:
-        assert isinstance(self.schema, JsonObject)
-        assert not self.schema.members["success"].as_list

--- a/tests/api/presenters/test_list_active_plans_presenter.py
+++ b/tests/api/presenters/test_list_active_plans_presenter.py
@@ -1,11 +1,4 @@
-from arbeitszeit_web.api.presenters.interfaces import (
-    JsonBoolean,
-    JsonDatetime,
-    JsonDecimal,
-    JsonInteger,
-    JsonObject,
-    JsonString,
-)
+from arbeitszeit_web.api.presenters.interfaces import JsonList, JsonObject
 from arbeitszeit_web.api.presenters.query_plans_api_presenter import (
     QueryPlansApiPresenter,
 )
@@ -79,69 +72,10 @@ class TestSchema(BaseTestCase):
     def test_schema_top_level(self) -> None:
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonObject)
-        assert not schema.as_list
         assert schema.name == "PlanList"
 
-    def test_schema_top_level_members(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        assert isinstance(schema.members["results"], JsonObject)
-
-    def test_schema_top_level_members_field_types_are_correct(self) -> None:
-        top_level_schema = self.presenter.get_schema()
-        assert isinstance(top_level_schema, JsonObject)
-
-        field_expectations = [
-            ("results", JsonObject),
-            ("total_results", JsonInteger),
-            ("offset", JsonInteger),
-            ("limit", JsonInteger),
-        ]
-
-        assert len(top_level_schema.members) == len(field_expectations)
-
-        for field_name, expected_type in field_expectations:
-            assert isinstance(top_level_schema.members[field_name], expected_type)
-
-    def test_results_is_dictionary(self) -> None:
+    def test_results_is_list(self) -> None:
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonObject)
         results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-
-    def test_results_is_dictionary_as_list(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-        assert results_schema.as_list
-
-    def test_results_has_correct_schema_name(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-        assert results_schema.name == "Plan"
-
-    def test_results_members_field_types_are_correct(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-
-        field_expectations = [
-            ("plan_id", JsonString),
-            ("company_name", JsonString),
-            ("company_id", JsonString),
-            ("product_name", JsonString),
-            ("description", JsonString),
-            ("is_public_service", JsonBoolean),
-            ("is_cooperating", JsonBoolean),
-            ("price_per_unit", JsonDecimal),
-            ("activation_date", JsonDatetime),
-        ]
-
-        assert len(results_schema.members) == len(field_expectations)
-
-        for field_name, expected_type in field_expectations:
-            assert isinstance(results_schema.members[field_name], expected_type)
+        assert isinstance(results_schema, JsonList)

--- a/tests/api/presenters/test_login_company_presenter.py
+++ b/tests/api/presenters/test_login_company_presenter.py
@@ -113,7 +113,6 @@ class TestSchema(BaseTestCase):
     def test_schema_top_level(self) -> None:
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonObject)
-        assert not schema.as_list
         assert schema.name == "LoginCompanyResponse"
 
     def test_schema_top_level_members(self) -> None:

--- a/tests/api/presenters/test_login_member_presenter.py
+++ b/tests/api/presenters/test_login_member_presenter.py
@@ -113,7 +113,6 @@ class TestSchema(BaseTestCase):
     def test_schema_top_level(self) -> None:
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonObject)
-        assert not schema.as_list
         assert schema.name == "LoginMemberResponse"
 
     def test_schema_top_level_members(self) -> None:

--- a/tests/api/presenters/test_query_companies_presenter.py
+++ b/tests/api/presenters/test_query_companies_presenter.py
@@ -1,8 +1,4 @@
-from arbeitszeit_web.api.presenters.interfaces import (
-    JsonInteger,
-    JsonObject,
-    JsonString,
-)
+from arbeitszeit_web.api.presenters.interfaces import JsonObject
 from arbeitszeit_web.api.presenters.query_companies_api_presenter import (
     QueryCompaniesApiPresenter,
 )
@@ -80,63 +76,4 @@ class TestSchema(BaseTestCase):
     def test_schema_top_level(self) -> None:
         schema = self.presenter.get_schema()
         assert isinstance(schema, JsonObject)
-        assert not schema.as_list
         assert schema.name == "CompanyList"
-
-    def test_schema_top_level_members(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        assert isinstance(schema.members["results"], JsonObject)
-
-    def test_schema_top_level_members_field_types_are_correct(self) -> None:
-        top_level_schema = self.presenter.get_schema()
-        assert isinstance(top_level_schema, JsonObject)
-
-        field_expectations = [
-            ("results", JsonObject),
-            ("total_results", JsonInteger),
-            ("offset", JsonInteger),
-            ("limit", JsonInteger),
-        ]
-
-        assert len(top_level_schema.members) == len(field_expectations)
-
-        for field_name, expected_type in field_expectations:
-            assert isinstance(top_level_schema.members[field_name], expected_type)
-
-    def test_results_is_dictionary(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-
-    def test_results_is_dictionary_as_list(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-        assert results_schema.as_list
-
-    def test_results_has_correct_schema_name(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-        assert results_schema.name == "Company"
-
-    def test_results_members_field_types_are_correct(self) -> None:
-        schema = self.presenter.get_schema()
-        assert isinstance(schema, JsonObject)
-        results_schema = schema.members["results"]
-        assert isinstance(results_schema, JsonObject)
-
-        field_expectations = [
-            ("company_id", JsonString),
-            ("company_email", JsonString),
-            ("company_name", JsonString),
-        ]
-
-        assert len(results_schema.members) == len(field_expectations)
-
-        for field_name, expected_type in field_expectations:
-            assert isinstance(results_schema.members[field_name], expected_type)


### PR DESCRIPTION
Before this commit the schema definition for json endpoints had embedded the concept of a list in json into all the other schema types by having the attribute `as_list`. This attribute was completely removed. Instead we introduced a dedicated type `JsonList` that describes the fact that a certain value should be a list of values. Unfortunately this change broke all the schema tests in our API code that relied on the `as_list` feature. All schema tests that broke were removed without a replacement. We did not bother with a replacement because it is clear the API subsystem needs a complete re-design as it relies on deprecated libraries, an awkward interface an a schema definition system that is completely decoupled from the values that are actually produced by the API endpoints.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (3x)