### PR TITLE
Remove obsolete dependency from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Flask-Migrate
 flask-restx
 Flask-Talisman
 Flask-WTF
-injector
 is_safe_url
 matplotlib
 


### PR DESCRIPTION
The requirements.txt file declared a dependency on `injector`, which is not true, since we dropped the package from our dependency list way back. This commit removes this declaration.