### PR TITLE
Remove "Load a draft" button from draft details view

### DIFF
--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -13,11 +13,6 @@
   </h1>
   <div class="columns is-centered">
     <div class="column is-three-fifths">
-      <p class="pb-5 has-text-right">
-        <a class="" href="{{ view_model.load_draft_url }}">
-          <span class="icon"><i class="fa-regular fa-floppy-disk"></i></span>
-          {{ gettext("Load a draft") }}</a>
-      </p>
       <form method="post">
         <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
         {{ draft_form(form) }}

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -50,7 +50,6 @@ class CreateDraftView:
                 "company/create_draft.html",
                 form=CreateDraftForm(),
                 view_model=dict(
-                    load_draft_url=GeneralUrlIndex().get_my_plan_drafts_url(),
                     save_draft_url="",
                     cancel_url="",
                 ),

--- a/arbeitszeit_web/www/presenters/create_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_presenter.py
@@ -16,7 +16,6 @@ from arbeitszeit_web.url_index import UrlIndex
 class GetPrefilledDraftDataPresenter:
     @dataclass
     class ViewModel:
-        load_draft_url: str
         save_draft_url: str
         cancel_url: str
 
@@ -35,7 +34,6 @@ class GetPrefilledDraftDataPresenter:
         form.labour_cost_field().set_value(draft_data.labour_cost)
         form.is_public_service_field().set_value(draft_data.is_public_service)
         return self.ViewModel(
-            load_draft_url=self.url_index.get_my_plan_drafts_url(),
             save_draft_url=self.url_index.get_create_draft_url(),
             cancel_url=self.url_index.get_create_draft_url(),
         )

--- a/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
@@ -63,9 +63,6 @@ class PlanDetailsPresenterTests(BaseTestCase):
         self.assertEqual(
             view_model.save_draft_url, self.url_index.get_create_draft_url()
         )
-        self.assertEqual(
-            view_model.load_draft_url, self.url_index.get_my_plan_drafts_url()
-        )
 
 
 class DraftDetailsPresenterTests(BaseTestCase):
@@ -119,7 +116,4 @@ class DraftDetailsPresenterTests(BaseTestCase):
         self.assertEqual(view_model.cancel_url, self.url_index.get_create_draft_url())
         self.assertEqual(
             view_model.save_draft_url, self.url_index.get_create_draft_url()
-        )
-        self.assertEqual(
-            view_model.load_draft_url, self.url_index.get_my_plan_drafts_url()
         )


### PR DESCRIPTION
The button "Load in draft" was removed with this commit because it did not serve a function anymore after the addition of the edit button in the drafts list in commit 72479a95b3b52849acecbe56d8644d5376659343.