### PR TITLE
Simplify html template for draft creation

### DIFF
--- a/arbeitszeit_flask/templates/company/create_draft.html
+++ b/arbeitszeit_flask/templates/company/create_draft.html
@@ -20,22 +20,15 @@
         <div class="field is-grouped is-grouped-centered">
           <div class="control">
             <button class="button is-primary is-light"
-                    name="action"
-                    value="save_draft"
-                    type="submit"
-                    formaction="{{ view_model.save_draft_url }}">
+                    type="submit">
               {{ gettext("Save as draft")}}
             </button>
           </div>
           <div class="control">
-            <button class="button is-light"
-                    name="action"
-                    value="cancel"
-                    type="submit"
-                    formaction="{{ view_model.cancel_url }}"
-                    formnovalidate>
+            <a class="button is-light"
+               href="{{ cancel_url }}">
               {{ gettext("Cancel")}}
-            </button>
+            </a>
           </div>
         </div>
       </form>

--- a/arbeitszeit_flask/templates/company/draft_details.html
+++ b/arbeitszeit_flask/templates/company/draft_details.html
@@ -28,14 +28,12 @@
             </button>
           </div>
           <div class="control">
-            <button class="button is-light"
-                    name="action"
-                    value="cancel"
-                    type="submit"
-                    formaction="{{ view_model.cancel_url }}"
-                    formnovalidate>
-              {{ gettext("Cancel")}}
-            </button>
+            <div class="control">
+              <a class="button is-light"
+                 href="{{ view_model.cancel_url }}">
+                {{ gettext("Cancel")}}
+              </a>
+            </div>
           </div>
         </div>
       </form>

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -1,6 +1,4 @@
 from dataclasses import dataclass
-from typing import Union
-from uuid import UUID
 
 from flask import Response as FlaskResponse
 from flask import redirect, render_template, request
@@ -10,9 +8,8 @@ from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.forms import CreateDraftForm
 from arbeitszeit_flask.types import Response
 from arbeitszeit_flask.url_index import GeneralUrlIndex
-from arbeitszeit_flask.views.http_error_view import http_404
+from arbeitszeit_flask.views.http_error_view import http_403
 from arbeitszeit_web.notification import Notifier
-from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.www.controllers.create_draft_controller import (
     CreateDraftController,
@@ -21,7 +18,6 @@ from arbeitszeit_web.www.controllers.create_draft_controller import (
 
 @dataclass
 class CreateDraftView:
-    request: Request
     notifier: Notifier
     translator: Translator
     prefilled_data_controller: CreateDraftController
@@ -31,35 +27,18 @@ class CreateDraftView:
     @commit_changes
     def POST(self) -> Response:
         form = CreateDraftForm(request.form)
-        user_action = self.request.get_form("action")
-        if user_action == "save_draft":
-            self._create_draft(form)
-            self.notifier.display_info(
-                self.translator.gettext("Draft successfully saved.")
-            )
-            return redirect(self.url_index.get_my_plan_drafts_url())
-        else:
-            self.notifier.display_info(
-                self.translator.gettext("Plan creation has been canceled.")
-            )
-            return redirect(self.url_index.get_my_plan_drafts_url())
+        use_case_request = self.prefilled_data_controller.import_form_data(form)
+        response = self.create_draft(use_case_request)
+        if response.is_rejected:
+            return http_403()
+        self.notifier.display_info(self.translator.gettext("Draft successfully saved."))
+        return redirect(self.url_index.get_my_plan_drafts_url())
 
     def GET(self) -> Response:
         return FlaskResponse(
             render_template(
                 "company/create_draft.html",
                 form=CreateDraftForm(),
-                view_model=dict(
-                    save_draft_url="",
-                    cancel_url="",
-                ),
+                cancel_url=self.url_index.get_my_plan_drafts_url(),
             )
         )
-
-    def _create_draft(self, form: CreateDraftForm) -> Union[Response, UUID]:
-        use_case_request = self.prefilled_data_controller.import_form_data(form)
-        response = self.create_draft(use_case_request)
-        if response.is_rejected:
-            return http_404()
-        assert response.draft_id
-        return response.draft_id

--- a/arbeitszeit_web/www/presenters/create_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_presenter.py
@@ -35,7 +35,7 @@ class GetPrefilledDraftDataPresenter:
         form.is_public_service_field().set_value(draft_data.is_public_service)
         return self.ViewModel(
             save_draft_url=self.url_index.get_create_draft_url(),
-            cancel_url=self.url_index.get_create_draft_url(),
+            cancel_url=self.url_index.get_my_plans_url(),
         )
 
 

--- a/tests/flask_integration/test_create_draft_view.py
+++ b/tests/flask_integration/test_create_draft_view.py
@@ -38,15 +38,9 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
         self.company = self.login_company()
         self.show_my_plans = self.injector.get(ShowMyPlansUseCase)
 
-    def test_post_user_canceling_leads_to_302_and_no_draft_gets_created(self) -> None:
-        test_data = self._create_form_data()
-        response = self.client.post("/company/create_draft", data=test_data)
-        self.assertEqual(response.status_code, 302)
-        self.assertFalse(self._count_drafts_of_company())
-
     def test_post_user_saving_draft_leads_to_302_and_draft_gets_created(self) -> None:
         self.assertFalse(self._count_drafts_of_company())
-        test_data = self._create_form_data(action="save_draft")
+        test_data = self._create_form_data()
         response = self.client.post("/company/create_draft", data=test_data)
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
@@ -54,7 +48,7 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
             1,
         )
 
-    def _create_form_data(self, action: str = "cancel") -> Dict:
+    def _create_form_data(self) -> Dict:
         return dict(
             prd_name="test name",
             description="test description",
@@ -65,7 +59,6 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
             costs_r=Decimal("15"),
             costs_a=Decimal("20"),
             productive_or_public=True,
-            action=action,
         )
 
     def _count_drafts_of_company(self) -> int:

--- a/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
+++ b/tests/www/presenters/test_get_prefilled_draft_data_presenter.py
@@ -59,7 +59,7 @@ class PlanDetailsPresenterTests(BaseTestCase):
         view_model = self.presenter.show_prefilled_draft_data(
             self.plan_details, form=form
         )
-        self.assertEqual(view_model.cancel_url, self.url_index.get_create_draft_url())
+        self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
         self.assertEqual(
             view_model.save_draft_url, self.url_index.get_create_draft_url()
         )
@@ -113,7 +113,7 @@ class DraftDetailsPresenterTests(BaseTestCase):
         view_model = self.presenter.show_prefilled_draft_data(
             TEST_DRAFT_SUMMARY_SUCCESS, form=form
         )
-        self.assertEqual(view_model.cancel_url, self.url_index.get_create_draft_url())
+        self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
         self.assertEqual(
             view_model.save_draft_url, self.url_index.get_create_draft_url()
         )


### PR DESCRIPTION
Before this commit the web logic around draft creation was slightly
complicated. The complication was that the "Cancel" action in the
creation form was handled as a POST request that would simply redirect
the user to another page. Now the same thing is achieved via a `<a>`
element. This allowed us to simplify the route/view.
