### PR TITLE
Make company accounts info available to all authenticated users

### DIFF
--- a/arbeitszeit_flask/templates/macros/company_summary.html
+++ b/arbeitszeit_flask/templates/macros/company_summary.html
@@ -42,20 +42,47 @@
             <br>
             <div class="table-container">
                 <table class="table has-text-left mx-auto">
-                    <thead class="has-text-centered">
-                        <tr>
-                            <th></th>
-                            <th><span class="icon"><i class="fas fa-industry"></i></span><br>{{ gettext("Account p") }}
-                            </th>
-                            <th><span class="icon"><i class="fas fa-oil-can"></i></span><br>{{ gettext("Account r") }}
-                            </th>
-                            <th><span class="icon"><i class="fas fa-users"></i></span><br>{{ gettext("Account a") }}
-                            </th>
-                            <th><span class="icon"><i class="fas fa-exchange-alt"></i></span>
-                                <br>{{ gettext("Account prd") }}
-                            </th>
-                        </tr>
-                    </thead>
+                  <thead class="has-text-centered">
+                    <tr>
+                      <th></th>
+                      <th>
+                        <span class="icon">
+                          <i class="fas fa-industry"></i>
+                        </span>
+                        <br>
+                        <a href="{{ view_model.p_account_overview_url }}">
+                          {{ gettext("Account p") }}
+                        </a>
+                      </th>
+                      <th>
+                        <span class="icon">
+                          <i class="fas fa-oil-can"></i>
+                        </span>
+                        <br>
+                        <a href="{{ view_model.r_account_overview_url }}">
+                          {{ gettext("Account r") }}
+                        </a>
+                      </th>
+                      <th>
+                        <span class="icon">
+                          <i class="fas fa-users"></i>
+                        </span>
+                        <br>
+                        <a href="{{ view_model.a_account_overview_url }}">
+                          {{ gettext("Account a") }}
+                        </a>
+                      </th>
+                      <th>
+                        <span class="icon">
+                          <i class="fas fa-exchange-alt"></i>
+                        </span>
+                        <br>
+                        <a href="{{ view_model.prd_account_overview_url }}">
+                          {{ gettext("Account prd") }}
+                        </a>
+                      </th>
+                    </tr>
+                  </thead>
                     <tbody>
                         <tr>
                             <td>{{ gettext("Expectations") }}</td>

--- a/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_company_summary_presenter.py
@@ -48,6 +48,10 @@ class GetCompanySummaryViewModel:
     plan_details: List[PlanDetailsWeb]
     suppliers_ordered_by_volume: List[SuppliersWeb]
     show_suppliers: bool
+    p_account_overview_url: str
+    r_account_overview_url: str
+    a_account_overview_url: str
+    prd_account_overview_url: str
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -100,6 +104,18 @@ class GetCompanySummarySuccessPresenter:
             ],
             suppliers_ordered_by_volume=suppliers_ordered_by_volume,
             show_suppliers=bool(suppliers_ordered_by_volume),
+            p_account_overview_url=self.url_index.get_company_account_p_url(
+                company_id=use_case_response.id
+            ),
+            r_account_overview_url=self.url_index.get_company_account_r_url(
+                company_id=use_case_response.id
+            ),
+            a_account_overview_url=self.url_index.get_company_account_a_url(
+                company_id=use_case_response.id
+            ),
+            prd_account_overview_url=self.url_index.get_company_account_prd_url(
+                company_id=use_case_response.id
+            ),
         )
 
     def _get_plan_details(self, plan_details: PlanDetails) -> PlanDetailsWeb:

--- a/tests/www/presenters/test_get_company_summary_presenter.py
+++ b/tests/www/presenters/test_get_company_summary_presenter.py
@@ -104,6 +104,50 @@ class GetCompanySummaryPresenterTests(BaseTestCase):
             self.assertEqual(deviation.percentage, expected_percentages[count])
             self.assertEqual(deviation.is_critical, expected_is_critical[count])
 
+    def test_that_p_account_overview_url_points_to_url_returned_by_url_index(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
+        assert (
+            view_model.p_account_overview_url
+            == self.url_index.get_company_account_p_url(
+                company_id=RESPONSE_WITH_2_PLANS.id
+            )
+        )
+
+    def test_that_r_account_overview_url_points_to_url_returned_by_url_index(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
+        assert (
+            view_model.r_account_overview_url
+            == self.url_index.get_company_account_r_url(
+                company_id=RESPONSE_WITH_2_PLANS.id
+            )
+        )
+
+    def test_that_a_account_overview_url_points_to_url_returned_by_url_index(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
+        assert (
+            view_model.a_account_overview_url
+            == self.url_index.get_company_account_a_url(
+                company_id=RESPONSE_WITH_2_PLANS.id
+            )
+        )
+
+    def test_that_prd_account_overview_url_points_to_url_returned_by_url_index(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(RESPONSE_WITH_2_PLANS)
+        assert (
+            view_model.prd_account_overview_url
+            == self.url_index.get_company_account_prd_url(
+                company_id=RESPONSE_WITH_2_PLANS.id
+            )
+        )
+
 
 class PlansOfCompanyTests(BaseTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
This commit makes the account data for all companies available to all authenticated users. This was achieved by linking to the already implemented url routes in the company summary view.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76