### PR TITLE
Rename GetPrefilledDraftDataPresenter to GetDraftDetailsPresenter

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -89,12 +89,12 @@ from arbeitszeit_web.www.presenters.company_consumptions_presenter import (
 from arbeitszeit_web.www.presenters.create_draft_from_plan_presenter import (
     CreateDraftFromPlanPresenter,
 )
-from arbeitszeit_web.www.presenters.create_draft_presenter import (
-    GetPrefilledDraftDataPresenter,
-)
 from arbeitszeit_web.www.presenters.delete_draft_presenter import DeleteDraftPresenter
 from arbeitszeit_web.www.presenters.file_plan_with_accounting_presenter import (
     FilePlanWithAccountingPresenter,
+)
+from arbeitszeit_web.www.presenters.get_draft_details_presenter import (
+    GetDraftDetailsPresenter,
 )
 from arbeitszeit_web.www.presenters.get_plan_details_company_presenter import (
     GetPlanDetailsCompanyPresenter,
@@ -191,13 +191,13 @@ def file_plan(
 def get_draft_details(
     draft_id: str,
     use_case: GetDraftDetails,
-    presenter: GetPrefilledDraftDataPresenter,
+    presenter: GetDraftDetailsPresenter,
 ) -> Response:
     use_case_response = use_case(UUID(draft_id))
     if use_case_response is None:
         return http_404()
     form = CreateDraftForm()
-    view_model = presenter.show_prefilled_draft_data(use_case_response, form=form)
+    view_model = presenter.present_draft_details(use_case_response, form=form)
     return FlaskResponse(
         render_template(
             "company/draft_details.html",

--- a/arbeitszeit_web/www/presenters/create_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_presenter.py
@@ -1,61 +1,28 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional, Union
 
-from arbeitszeit.plan_details import PlanDetails
 from arbeitszeit.use_cases.create_plan_draft import Response
-from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess
-from arbeitszeit_web.forms import DraftForm
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 
 
 @dataclass
-class GetPrefilledDraftDataPresenter:
-    @dataclass
-    class ViewModel:
-        save_draft_url: str
-        cancel_url: str
-
-    url_index: UrlIndex
-
-    def show_prefilled_draft_data(
-        self, draft_data: Union[PlanDetails, DraftDetailsSuccess], form: DraftForm
-    ) -> ViewModel:
-        form.product_name_field().set_value(draft_data.product_name)
-        form.description_field().set_value(draft_data.description)
-        form.timeframe_field().set_value(draft_data.timeframe)
-        form.unit_of_distribution_field().set_value(draft_data.production_unit)
-        form.amount_field().set_value(draft_data.amount)
-        form.means_cost_field().set_value(draft_data.means_cost)
-        form.resource_cost_field().set_value(draft_data.resources_cost)
-        form.labour_cost_field().set_value(draft_data.labour_cost)
-        form.is_public_service_field().set_value(draft_data.is_public_service)
-        return self.ViewModel(
-            save_draft_url=self.url_index.get_create_draft_url(),
-            cancel_url=self.url_index.get_my_plans_url(),
-        )
-
-
-@dataclass
 class CreateDraftPresenter:
     @dataclass
     class ViewModel:
-        redirect_url: Optional[str]
+        redirect_url: str | None
 
     url_index: UrlIndex
     notifier: Notifier
     translator: Translator
 
     def present_plan_creation(self, response: Response) -> ViewModel:
-        redirect_url: Optional[str]
         if response.draft_id is None:
-            redirect_url = None
+            return self.ViewModel(redirect_url=None)
         else:
-            redirect_url = self.url_index.get_my_plan_drafts_url()
             self.notifier.display_info(
                 self.translator.gettext("Plan draft successfully created")
             )
-        return self.ViewModel(redirect_url=redirect_url)
+            return self.ViewModel(redirect_url=self.url_index.get_my_plan_drafts_url())

--- a/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from arbeitszeit.plan_details import PlanDetails
+from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess
+from arbeitszeit_web.forms import DraftForm
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class GetDraftDetailsPresenter:
+    @dataclass
+    class ViewModel:
+        save_draft_url: str
+        cancel_url: str
+
+    url_index: UrlIndex
+
+    def present_draft_details(
+        self, draft_data: PlanDetails | DraftDetailsSuccess, form: DraftForm
+    ) -> ViewModel:
+        form.product_name_field().set_value(draft_data.product_name)
+        form.description_field().set_value(draft_data.description)
+        form.timeframe_field().set_value(draft_data.timeframe)
+        form.unit_of_distribution_field().set_value(draft_data.production_unit)
+        form.amount_field().set_value(draft_data.amount)
+        form.means_cost_field().set_value(draft_data.means_cost)
+        form.resource_cost_field().set_value(draft_data.resources_cost)
+        form.labour_cost_field().set_value(draft_data.labour_cost)
+        form.is_public_service_field().set_value(draft_data.is_public_service)
+        return self.ViewModel(
+            save_draft_url=self.url_index.get_create_draft_url(),
+            cancel_url=self.url_index.get_my_plans_url(),
+        )

--- a/tests/www/presenters/test_get_draft_details_presenter.py
+++ b/tests/www/presenters/test_get_draft_details_presenter.py
@@ -3,8 +3,8 @@ from decimal import Decimal
 from uuid import uuid4
 
 from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess
-from arbeitszeit_web.www.presenters.create_draft_presenter import (
-    GetPrefilledDraftDataPresenter,
+from arbeitszeit_web.www.presenters.get_draft_details_presenter import (
+    GetDraftDetailsPresenter,
 )
 from tests.forms import DraftForm
 from tests.www.base_test_case import BaseTestCase
@@ -29,13 +29,13 @@ TEST_DRAFT_SUMMARY_SUCCESS = DraftDetailsSuccess(
 class PlanDetailsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.presenter = self.injector.get(GetPrefilledDraftDataPresenter)
+        self.presenter = self.injector.get(GetDraftDetailsPresenter)
         self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
         self.plan_details = self.plan_details_generator.create_plan_details()
 
     def test_correct_form_data_is_returned_for_plan_details(self) -> None:
         form = DraftForm()
-        self.presenter.show_prefilled_draft_data(self.plan_details, form=form)
+        self.presenter.present_draft_details(self.plan_details, form=form)
         assert form.product_name_field().get_value() == self.plan_details.product_name
         assert form.description_field().get_value() == self.plan_details.description
         assert form.timeframe_field().get_value() == self.plan_details.timeframe
@@ -56,9 +56,7 @@ class PlanDetailsPresenterTests(BaseTestCase):
 
     def test_correct_view_model_is_returned_for_plan_details(self) -> None:
         form = DraftForm()
-        view_model = self.presenter.show_prefilled_draft_data(
-            self.plan_details, form=form
-        )
+        view_model = self.presenter.present_draft_details(self.plan_details, form=form)
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
         self.assertEqual(
             view_model.save_draft_url, self.url_index.get_create_draft_url()
@@ -68,11 +66,11 @@ class PlanDetailsPresenterTests(BaseTestCase):
 class DraftDetailsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.presenter = self.injector.get(GetPrefilledDraftDataPresenter)
+        self.presenter = self.injector.get(GetDraftDetailsPresenter)
 
     def test_correct_form_data_is_returned_for_draft_details(self) -> None:
         form = DraftForm()
-        self.presenter.show_prefilled_draft_data(
+        self.presenter.present_draft_details(
             TEST_DRAFT_SUMMARY_SUCCESS,
             form=form,
         )
@@ -110,7 +108,7 @@ class DraftDetailsPresenterTests(BaseTestCase):
 
     def test_correct_view_model_is_returned_for_draft_details(self) -> None:
         form = DraftForm()
-        view_model = self.presenter.show_prefilled_draft_data(
+        view_model = self.presenter.present_draft_details(
             TEST_DRAFT_SUMMARY_SUCCESS, form=form
         )
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())


### PR DESCRIPTION
This GetPrefilledDraftDataPresenter was confusingly named as it was really the presenter responsible for rendering draft details.  This issue was addressed by renaming the presenter in question and the associated modules and tests.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76