### PR TITLE
Refine packaging instructions to include only essential arbeitszeitapp packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,12 @@ profiling = ["flask_profiler"]
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.packages]
-find = {}
+[tool.setuptools.packages.find]
+include = [
+    "arbeitszeit_flask",
+    "arbeitszeit",
+    "arbeitszeit_web",
+]
 
 [tool.black]
 target-version = ['py311']


### PR DESCRIPTION
Previously, our packaging instructions in pyproject.toml would indiscriminately bundle all Python source files. With this commit, we've refined our approach to selectively incorporate only pertinent packages. Specifically, we now include arbeitszeit_flask, arbeitszeit_web, and arbeitszeit, ensuring a more precise packaging process.