### PR TITLE
Refactor CreatePlanDraft Handling

### DIFF
--- a/arbeitszeit/use_cases/create_plan_draft.py
+++ b/arbeitszeit/use_cases/create_plan_draft.py
@@ -40,7 +40,7 @@ class CreatePlanDraft:
     database: DatabaseGateway
     datetime_service: DatetimeService
 
-    def __call__(self, request: Request) -> Response:
+    def create_draft(self, request: Request) -> Response:
         if (
             request.costs.labour_cost < 0
             or request.costs.means_cost < 0

--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -20,15 +20,15 @@ from arbeitszeit_web.www.controllers.create_draft_controller import (
 class CreateDraftView:
     notifier: Notifier
     translator: Translator
-    prefilled_data_controller: CreateDraftController
-    create_draft: CreatePlanDraft
+    controller: CreateDraftController
+    use_case: CreatePlanDraft
     url_index: GeneralUrlIndex
 
     @commit_changes
     def POST(self) -> Response:
         form = CreateDraftForm(request.form)
-        use_case_request = self.prefilled_data_controller.import_form_data(form)
-        response = self.create_draft(use_case_request)
+        use_case_request = self.controller.import_form_data(form)
+        response = self.use_case.create_draft(use_case_request)
         if response.is_rejected:
             return http_403()
         self.notifier.display_info(self.translator.gettext("Draft successfully saved."))

--- a/tests/data_generators.py
+++ b/tests/data_generators.py
@@ -255,7 +255,7 @@ class PlanGenerator:
             planner = self.company_generator.create_company()
         if timeframe is None:
             timeframe = 14
-        response = self.create_plan_draft_use_case(
+        response = self.create_plan_draft_use_case.create_draft(
             request=Request(
                 costs=costs,
                 product_name=product_name,

--- a/tests/use_cases/test_create_plan_draft.py
+++ b/tests/use_cases/test_create_plan_draft.py
@@ -31,7 +31,7 @@ REQUEST = Request(
 class UseCaseTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.create_plan_draft = self.injector.get(CreatePlanDraft)
+        self.use_case = self.injector.get(CreatePlanDraft)
         self.get_draft_details = self.injector.get(get_draft_details.GetDraftDetails)
 
     def test_that_plan_plan_details_can_be_accessed_after_draft_is_created(
@@ -39,7 +39,7 @@ class UseCaseTests(BaseTestCase):
     ) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner)
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert not response.is_rejected
         assert response.draft_id
         assert self.get_draft_details(response.draft_id)
@@ -47,7 +47,7 @@ class UseCaseTests(BaseTestCase):
     def test_that_create_plan_returns_a_draft_id(self) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner)
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.draft_id
 
     def test_that_create_plan_gets_rejected_with_non_existing_planner(self) -> None:
@@ -55,7 +55,7 @@ class UseCaseTests(BaseTestCase):
             REQUEST,
             planner=uuid4(),
         )
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.is_rejected
         assert response.rejection_reason == RejectionReason.planner_does_not_exist
         assert not response.draft_id
@@ -69,7 +69,7 @@ class UseCaseTests(BaseTestCase):
             planner=planner,
             costs=ProductionCosts(Decimal(-1), Decimal(-1), Decimal(-1)),
         )
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.is_rejected
         assert response.rejection_reason == RejectionReason.negative_plan_input
         assert not response.draft_id
@@ -79,21 +79,21 @@ class UseCaseTests(BaseTestCase):
     ) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner, production_amount=-1)
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.is_rejected
         assert not response.draft_id
 
     def test_that_create_plan_gets_rejected_with_negative_timeframe(self) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner, timeframe_in_days=-1)
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.is_rejected
         assert not response.draft_id
 
     def test_that_drafted_plan_has_same_planner_as_specified_on_creation(self) -> None:
         planner = self.company_generator.create_company()
         request = replace(REQUEST, planner=planner)
-        response = self.create_plan_draft(request)
+        response = self.use_case.create_draft(request)
         assert response.draft_id
         details = self.get_draft_details(response.draft_id)
         assert details


### PR DESCRIPTION
This commit streamlines naming conventions and adjusts the CreatePlanDraft use case interface. Previously, we depended on the `__call__` method for handling use case requests. Now, we've replaced this with a more explicit `create_draft` method within the use case object.