### PR TITLE
Implement email service utilizing smtplib

### DIFF
--- a/arbeitszeit_flask/mail_service.py
+++ b/arbeitszeit_flask/mail_service.py
@@ -1,4 +1,9 @@
-from typing import List
+from contextlib import contextmanager
+from dataclasses import dataclass
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from smtplib import SMTP_SSL
+from typing import Generator, List
 
 from flask import current_app, render_template, url_for
 from flask_mail import Message
@@ -16,10 +21,13 @@ class FlaskEmailConfiguration:
 
 
 def get_mail_service() -> MailService:
-    if current_app.config.get("MAIL_BACKEND") == "flask_mail":
-        return FlaskMailService()
-    else:
-        return DebugMailService()
+    match current_app.config.get("MAIL_BACKEND"):
+        case "flask_mail":
+            return FlaskMailService()
+        case "smtplib_ssl":
+            return SmtpMailService()
+        case _:
+            return DebugMailService()
 
 
 class DebugMailService:
@@ -53,3 +61,35 @@ class FlaskMailService:
     ) -> None:
         msg = Message(subject=subject, recipients=recipients, html=html, sender=sender)
         mail.send(msg)
+
+
+@dataclass
+class SmtpMailService:
+    def send_message(
+        self,
+        subject: str,
+        recipients: List[str],
+        html: str,
+        sender: str,
+    ) -> None:
+        with self.create_smtp_connection() as smtp:
+            message = MIMEMultipart()
+            message["Subject"] = subject
+            message["From"] = sender
+            message.attach(MIMEText(html, "html"))
+            for recipient in recipients:
+                message["To"] = recipient
+                smtp.send_message(message)
+
+    @classmethod
+    @contextmanager
+    def create_smtp_connection(cls) -> Generator[SMTP_SSL, None, None]:
+        server = current_app.config.get("MAIL_SERVER", "localhost")
+        port = current_app.config.get("MAIL_PORT", "0")
+        smtp = SMTP_SSL(server, port=port)
+        smtp.ehlo()
+        username = current_app.config.get("MAIL_USERNAME", "")
+        password = current_app.config.get("MAIL_PASSWORD", "")
+        smtp.login(username, password)
+        yield smtp
+        smtp.quit()


### PR DESCRIPTION
This commit introduces a new `EmailService` implementation that utilizes Python's built-in `smtplib`. The objective is to eventually replace the existing flask_mail based implementation.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (2x)

Some context:

The [current email implementation](https://github.com/pallets-eco/flask-mail) seems to be no longer maintained as its github repo is read-only (Last commit 10 years ago).