### PR TITLE
Fix bug in setuptools package include directive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,12 @@ include-package-data = true
 
 [tool.setuptools.packages.find]
 include = [
-    "arbeitszeit_flask",
     "arbeitszeit",
+    "arbeitszeit.*",
+    "arbeitszeit_flask",
+    "arbeitszeit_flask.*",
     "arbeitszeit_web",
+    "arbeitszeit_web.*",
 ]
 
 [tool.black]


### PR DESCRIPTION
Before this change we would not include all subpackages of all packages in our packaging directives.