### PR TITLE
Implement proper draft editing

### DIFF
--- a/arbeitszeit/use_cases/edit_draft.py
+++ b/arbeitszeit/use_cases/edit_draft.py
@@ -7,24 +7,27 @@ from arbeitszeit.repositories import DatabaseGateway
 
 
 @dataclass
-class EditDraftUseCase:
-    @dataclass
-    class Request:
-        draft: UUID
-        editor: UUID
-        product_name: Optional[str]
-        amount: Optional[int]
-        description: Optional[str]
-        labour_cost: Optional[Decimal]
-        means_cost: Optional[Decimal]
-        resource_cost: Optional[Decimal]
-        is_public_service: Optional[bool]
-        timeframe: Optional[int]
-        unit_of_distribution: Optional[str]
+class Request:
+    draft: UUID
+    editor: UUID
+    product_name: Optional[str]
+    amount: Optional[int]
+    description: Optional[str]
+    labour_cost: Optional[Decimal]
+    means_cost: Optional[Decimal]
+    resource_cost: Optional[Decimal]
+    is_public_service: Optional[bool]
+    timeframe: Optional[int]
+    unit_of_distribution: Optional[str]
 
-    @dataclass
-    class Response:
-        is_success: bool
+
+@dataclass
+class Response:
+    is_success: bool
+
+
+@dataclass
+class EditDraftUseCase:
 
     database: DatabaseGateway
 
@@ -56,6 +59,6 @@ class EditDraftUseCase:
             is_success = True
         else:
             is_success = False
-        return self.Response(
+        return Response(
             is_success=is_success,
         )

--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -22,7 +22,6 @@ from arbeitszeit.use_cases.deny_cooperation import (
     DenyCooperationResponse,
 )
 from arbeitszeit.use_cases.file_plan_with_accounting import FilePlanWithAccounting
-from arbeitszeit.use_cases.get_draft_details import GetDraftDetails
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
 from arbeitszeit.use_cases.hide_plan import HidePlan
 from arbeitszeit.use_cases.list_coordinations_of_company import (
@@ -47,7 +46,6 @@ from arbeitszeit_flask.class_based_view import as_flask_view
 from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.flask_session import FlaskSession
-from arbeitszeit_flask.forms import CreateDraftForm
 from arbeitszeit_flask.types import Response
 from arbeitszeit_flask.views import (
     EndCooperationView,
@@ -57,6 +55,7 @@ from arbeitszeit_flask.views import (
 from arbeitszeit_flask.views.company_dashboard_view import CompanyDashboardView
 from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.create_draft_view import CreateDraftView
+from arbeitszeit_flask.views.draft_details_view import DraftDetailsView
 from arbeitszeit_flask.views.http_error_view import http_404
 from arbeitszeit_flask.views.register_hours_worked_view import RegisterHoursWorkedView
 from arbeitszeit_flask.views.register_productive_consumption import (
@@ -92,9 +91,6 @@ from arbeitszeit_web.www.presenters.create_draft_from_plan_presenter import (
 from arbeitszeit_web.www.presenters.delete_draft_presenter import DeleteDraftPresenter
 from arbeitszeit_web.www.presenters.file_plan_with_accounting_presenter import (
     FilePlanWithAccountingPresenter,
-)
-from arbeitszeit_web.www.presenters.get_draft_details_presenter import (
-    GetDraftDetailsPresenter,
 )
 from arbeitszeit_web.www.presenters.get_plan_details_company_presenter import (
     GetPlanDetailsCompanyPresenter,
@@ -187,24 +183,9 @@ def file_plan(
     return redirect(view_model.redirect_url)
 
 
-@CompanyRoute("/draft/<draft_id>", methods=["GET"])
-def get_draft_details(
-    draft_id: str,
-    use_case: GetDraftDetails,
-    presenter: GetDraftDetailsPresenter,
-) -> Response:
-    use_case_response = use_case(UUID(draft_id))
-    if use_case_response is None:
-        return http_404()
-    form = CreateDraftForm()
-    view_model = presenter.present_draft_details(use_case_response, form=form)
-    return FlaskResponse(
-        render_template(
-            "company/draft_details.html",
-            view_model=view_model,
-            form=form,
-        )
-    )
+@CompanyRoute("/draft/<uuid:draft_id>", methods=["GET", "POST"])
+@as_flask_view()
+class get_draft_details(DraftDetailsView): ...
 
 
 @CompanyRoute("/my_plans", methods=["GET"])

--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -284,7 +284,6 @@ class CreateDraftForm(Form):
     productive_or_public = BooleanField(
         trans.lazy_gettext("This plan is a public service")
     )
-    action = StringField()
 
     def product_name_field(self) -> WtFormField[str]:
         return WtFormField(form=self, field_name="prd_name")

--- a/arbeitszeit_flask/templates/company/draft_details.html
+++ b/arbeitszeit_flask/templates/company/draft_details.html
@@ -23,14 +23,14 @@
                     name="action"
                     value="save_draft"
                     type="submit"
-                    formaction="{{ view_model.save_draft_url }}">
+                    formaction="{{ save_draft_url }}">
               {{ gettext("Save draft")}}
             </button>
           </div>
           <div class="control">
             <div class="control">
               <a class="button is-light"
-                 href="{{ view_model.cancel_url }}">
+                 href="{{ cancel_url }}">
                 {{ gettext("Cancel")}}
               </a>
             </div>

--- a/arbeitszeit_flask/views/draft_details_view.py
+++ b/arbeitszeit_flask/views/draft_details_view.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from flask import Response as FlaskResponse
+from flask import redirect, render_template, request
+
+from arbeitszeit.use_cases.edit_draft import EditDraftUseCase
+from arbeitszeit.use_cases.get_draft_details import GetDraftDetails
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.forms import CreateDraftForm
+from arbeitszeit_flask.types import Response
+from arbeitszeit_flask.url_index import GeneralUrlIndex
+from arbeitszeit_flask.views.http_error_view import http_404
+from arbeitszeit_web.www.controllers.edit_draft_controller import EditDraftController
+from arbeitszeit_web.www.presenters.edit_draft_presenter import EditDraftPresenter
+from arbeitszeit_web.www.presenters.get_draft_details_presenter import (
+    GetDraftDetailsPresenter,
+)
+
+
+@dataclass
+class DraftDetailsView:
+    use_case: GetDraftDetails
+    presenter: GetDraftDetailsPresenter
+    edit_draft_use_case: EditDraftUseCase
+    edit_draft_controller: EditDraftController
+    edit_draft_presenter: EditDraftPresenter
+    url_index: GeneralUrlIndex
+
+    def GET(self, draft_id: UUID) -> Response:
+        use_case_response = self.use_case(draft_id)
+        if use_case_response is None:
+            return http_404()
+        form = CreateDraftForm()
+        view_model = self.presenter.present_draft_details(use_case_response, form=form)
+        return FlaskResponse(
+            render_template(
+                "company/draft_details.html",
+                cancel_url=view_model.cancel_url,
+                save_draft_url=view_model.save_draft_url,
+                form=form,
+            )
+        )
+
+    @commit_changes
+    def POST(self, draft_id: UUID) -> Response:
+        form = CreateDraftForm(request.form)
+        if not form.validate():
+            return self._handle_invalid_submission(form, status=400)
+        use_case_request = self.edit_draft_controller.process_form(
+            form=form,
+            draft_id=draft_id,
+        )
+        if use_case_request is None:
+            return self._handle_invalid_submission(form, status=400)
+        use_case_response = self.edit_draft_use_case.edit_draft(use_case_request)
+        view_model = self.edit_draft_presenter.render_response(use_case_response)
+        if view_model.redirect_url:
+            return redirect(view_model.redirect_url)
+        else:
+            return self._handle_invalid_submission(form, status=404)
+
+    def _handle_invalid_submission(
+        self, form: CreateDraftForm, status: int
+    ) -> Response:
+        return FlaskResponse(
+            render_template(
+                "company/draft_details.html",
+                save_draft_url="",
+                cancel_url=self.url_index.get_my_plans_url(),
+                form=form,
+            ),
+            status=status,
+        )

--- a/arbeitszeit_web/www/controllers/edit_draft_controller.py
+++ b/arbeitszeit_web/www/controllers/edit_draft_controller.py
@@ -1,0 +1,89 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from arbeitszeit.use_cases.edit_draft import Request
+from arbeitszeit_web.forms import DraftForm
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.session import Session
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class EditDraftController:
+    notifier: Notifier
+    translator: Translator
+    session: Session
+
+    def process_form(self, form: DraftForm, draft_id: UUID) -> Request | None:
+        product_name = form.product_name_field().get_value()
+        if not product_name:
+            form.product_name_field().attach_error(
+                self.translator.gettext("The product name field cannot be empty.")
+            )
+            return None
+        description = form.description_field().get_value()
+        if not description:
+            form.description_field().attach_error(
+                self.translator.gettext("The description field cannot be empty.")
+            )
+            return None
+        unit_of_distribution = form.unit_of_distribution_field().get_value()
+        if not unit_of_distribution:
+            form.unit_of_distribution_field().attach_error(
+                self.translator.gettext(
+                    "The smallest delivery unit field cannot be empty."
+                )
+            )
+            return None
+        labour_cost = form.labour_cost_field().get_value()
+        means_cost = form.means_cost_field().get_value()
+        resource_cost = form.resource_cost_field().get_value()
+        if not (labour_cost or means_cost or resource_cost):
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "At least one of the costs fields must be a positive number of hours."
+                )
+            )
+            return None
+        amount = form.amount_field().get_value()
+        if amount == 0:
+            form.amount_field().attach_error(
+                self.translator.gettext("The product amount planned cannot be 0.")
+            )
+            return None
+        elif amount < 0:
+            form.amount_field().attach_error(
+                self.translator.gettext(
+                    "The planned product amount cannot be negative."
+                )
+            )
+            return None
+        timeframe = form.timeframe_field().get_value()
+        if timeframe == 0:
+            form.timeframe_field().attach_error(
+                self.translator.gettext("The planning timeframe cannot be 0 days.")
+            )
+            return None
+        elif timeframe < 0:
+            form.timeframe_field().attach_error(
+                self.translator.gettext(
+                    "The planning timeframe cannot be a negative number of days."
+                )
+            )
+            return None
+        current_user = self.session.get_current_user()
+        if current_user is None:
+            return None
+        return Request(
+            draft=draft_id,
+            editor=current_user,
+            product_name=product_name,
+            amount=amount,
+            description=description,
+            labour_cost=labour_cost,
+            means_cost=means_cost,
+            resource_cost=resource_cost,
+            is_public_service=form.is_public_service_field().get_value(),
+            timeframe=timeframe,
+            unit_of_distribution=unit_of_distribution,
+        )

--- a/arbeitszeit_web/www/presenters/edit_draft_presenter.py
+++ b/arbeitszeit_web/www/presenters/edit_draft_presenter.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.edit_draft import Response
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirect_url: str | None
+
+
+@dataclass
+class EditDraftPresenter:
+    url_index: UrlIndex
+
+    def render_response(self, response: Response) -> ViewModel:
+        if response.is_success:
+            return ViewModel(redirect_url=self.url_index.get_my_plans_url())
+        else:
+            return ViewModel(redirect_url=None)

--- a/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_draft_details_presenter.py
@@ -20,6 +20,10 @@ class GetDraftDetailsPresenter:
     def present_draft_details(
         self, draft_data: PlanDetails | DraftDetailsSuccess, form: DraftForm
     ) -> ViewModel:
+        if isinstance(draft_data, PlanDetails):
+            draft_id = draft_data.plan_id
+        else:
+            draft_id = draft_data.draft_id
         form.product_name_field().set_value(draft_data.product_name)
         form.description_field().set_value(draft_data.description)
         form.timeframe_field().set_value(draft_data.timeframe)
@@ -30,6 +34,6 @@ class GetDraftDetailsPresenter:
         form.labour_cost_field().set_value(draft_data.labour_cost)
         form.is_public_service_field().set_value(draft_data.is_public_service)
         return self.ViewModel(
-            save_draft_url=self.url_index.get_create_draft_url(),
+            save_draft_url=self.url_index.get_draft_details_url(draft_id),
             cancel_url=self.url_index.get_my_plans_url(),
         )

--- a/tests/flask_integration/test_get_draft_details_view.py
+++ b/tests/flask_integration/test_get_draft_details_view.py
@@ -22,3 +22,29 @@ class ViewTests(ViewTestCase):
 
     def get_url(self, draft_id: UUID) -> str:
         return f"/company/draft/{draft_id}"
+
+    def test_post_404_with_random_uuid(self) -> None:
+        response = self.client.post(self.get_url(uuid4()), data=self._valid_form_data())
+        self.assertEqual(response.status_code, 404)
+
+    def test_posting_invalid_data_results_in_400_error(self) -> None:
+        response = self.client.post(self.get_url(uuid4()), data={})
+        self.assertEqual(response.status_code, 400)
+
+    def test_posting_valid_data_for_existing_plan_results_in_302(self) -> None:
+        draft = self.plan_generator.draft_plan(planner=self.company.id)
+        response = self.client.post(self.get_url(draft), data=self._valid_form_data())
+        self.assertEqual(response.status_code, 302)
+
+    def _valid_form_data(self) -> dict[str, str]:
+        return dict(
+            prd_name="test name",
+            description="test description",
+            timeframe="1",
+            prd_unit="test unit",
+            prd_amount="12",
+            costs_p="1",
+            costs_r="1",
+            costs_a="1",
+            productive_or_public="y",
+        )

--- a/tests/use_cases/test_edit_draft.py
+++ b/tests/use_cases/test_edit_draft.py
@@ -4,7 +4,7 @@ from unittest import TestCase
 from uuid import UUID, uuid4
 
 from arbeitszeit.records import ProductionCosts
-from arbeitszeit.use_cases.edit_draft import EditDraftUseCase
+from arbeitszeit.use_cases.edit_draft import EditDraftUseCase, Request
 from arbeitszeit.use_cases.get_draft_details import DraftDetailsSuccess, GetDraftDetails
 from tests.data_generators import CompanyGenerator, PlanGenerator
 
@@ -186,10 +186,10 @@ class UseCaseTests(TestCase):
         is_public_service: Optional[bool] = None,
         timeframe: Optional[int] = None,
         unit_of_distribution: Optional[str] = None,
-    ) -> EditDraftUseCase.Request:
+    ) -> Request:
         if editor is None:
             editor = uuid4()
-        return EditDraftUseCase.Request(
+        return Request(
             draft=draft,
             editor=editor,
             product_name=product_name,

--- a/tests/www/controllers/test_edit_draft_controller.py
+++ b/tests/www/controllers/test_edit_draft_controller.py
@@ -1,0 +1,318 @@
+from decimal import Decimal
+from uuid import uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit_web.www.controllers.edit_draft_controller import EditDraftController
+from tests.forms import DraftForm
+from tests.www.base_test_case import BaseTestCase
+
+
+class EditDraftControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(EditDraftController)
+        self.session.login_company(uuid4())
+
+    @parameterized.expand(
+        [
+            "test name",
+            "other test name",
+        ]
+    )
+    def test_that_product_name_from_form_field_is_used_in_request(
+        self, expected_name: str
+    ) -> None:
+        form = self.create_form(product_name=expected_name)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.product_name == expected_name
+
+    def test_that_empty_product_name_field_produces_error_message_on_form_field(
+        self,
+    ) -> None:
+        form = self.create_form(product_name="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert form.product_name_field().errors
+
+    def test_that_empty_product_name_field_produces_the_correct_error_message(
+        self,
+    ) -> None:
+        form = self.create_form(product_name="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert (
+            self.translator.gettext("The product name field cannot be empty.")
+            in form.product_name_field().errors
+        )
+
+    @parameterized.expand(
+        [
+            "test description",
+            "other test description",
+        ]
+    )
+    def test_that_description_from_field_is_used_in_request(
+        self, expected_description: str
+    ) -> None:
+        form = self.create_form(description=expected_description)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.description == expected_description
+
+    def test_that_empty_description_field_produces_an_error_message_on_the_description_field(
+        self,
+    ) -> None:
+        form = self.create_form(description="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert form.description_field().errors
+
+    def test_that_empty_description_field_attaches_correct_error_message_to_description_field(
+        self,
+    ) -> None:
+        form = self.create_form(description="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert (
+            self.translator.gettext("The description field cannot be empty.")
+            in form.description_field().errors
+        )
+
+    @parameterized.expand(
+        [
+            "test unit",
+            "other test unit",
+        ]
+    )
+    def test_that_delivery_unit_from_field_is_used_in_request(
+        self, expected_unit: str
+    ) -> None:
+        form = self.create_form(unit_of_distribution=expected_unit)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.unit_of_distribution == expected_unit
+
+    @parameterized.expand(
+        [
+            "product_name",
+            "description",
+            "unit_of_distribution",
+        ]
+    )
+    def test_that_empty_values_for_mandatory_string_fields_are_rejected(
+        self, field_name: str
+    ) -> None:
+        form = self.create_form(**{field_name: ""})  # type: ignore
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request is None
+
+    def test_that_empty_unit_of_distritution_field_produces_an_error_on_that_field(
+        self,
+    ) -> None:
+        form = self.create_form(unit_of_distribution="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert form.unit_of_distribution_field().errors
+
+    def test_that_empty_unit_of_distribution_field_attaches_correct_error_message_to_that_field(
+        self,
+    ) -> None:
+        form = self.create_form(unit_of_distribution="")
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert (
+            self.translator.gettext("The smallest delivery unit field cannot be empty.")
+            in form.unit_of_distribution_field().errors
+        )
+
+    def test_that_request_is_rejected_with_total_cost_zero(self) -> None:
+        form = self.create_form(
+            labour_cost=Decimal(0),
+            resource_cost=Decimal(0),
+            means_cost=Decimal(0),
+        )
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request is None
+
+    def test_that_correct_warning_is_displayed_when_all_costs_are_zero(self) -> None:
+        form = self.create_form(
+            labour_cost=Decimal(0),
+            resource_cost=Decimal(0),
+            means_cost=Decimal(0),
+        )
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert (
+            self.translator.gettext(
+                "At least one of the costs fields must be a positive number of hours."
+            )
+            in self.notifier.warnings
+        )
+
+    @parameterized.expand(
+        [
+            Decimal(1),
+            Decimal(3),
+            Decimal(123),
+            Decimal(0),
+        ]
+    )
+    def test_that_labour_cost_fields_from_form_are_used_in_request(
+        self, costs: Decimal
+    ) -> None:
+        form = self.create_form(labour_cost=costs)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.labour_cost == costs
+
+    @parameterized.expand(
+        [
+            Decimal(1),
+            Decimal(2),
+            Decimal(612),
+            Decimal(0),
+        ]
+    )
+    def test_that_means_cost_fields_from_form_are_used_in_request(
+        self, costs: Decimal
+    ) -> None:
+        form = self.create_form(means_cost=costs)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.means_cost == costs
+
+    @parameterized.expand(
+        [
+            Decimal(1),
+            Decimal(6),
+            Decimal(212),
+            Decimal(0),
+        ]
+    )
+    def test_that_resource_cost_fields_from_form_are_used_in_request(
+        self, costs: Decimal
+    ) -> None:
+        form = self.create_form(resource_cost=costs)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.resource_cost == costs
+
+    @parameterized.expand([0, -1])
+    def test_that_invalid_amount_values_are_rejected(self, amount: int) -> None:
+        form = self.create_form(amount=amount)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request is None
+
+    @parameterized.expand([1, 12, 75452])
+    def test_that_the_amount_field_is_used_in_the_request(self, amount: int) -> None:
+        form = self.create_form(amount=amount)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.amount == amount
+
+    @parameterized.expand(
+        [
+            (
+                0,
+                "The product amount planned cannot be 0.",
+            ),
+            (
+                -1,
+                "The planned product amount cannot be negative.",
+            ),
+        ]
+    )
+    def test_that_invalid_amount_values_produce_correct_error_message_on_that_field(
+        self, amount: int, expected_message: str
+    ) -> None:
+        form = self.create_form(amount=amount)
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert self.translator.gettext(expected_message) in form.amount_field().errors
+
+    @parameterized.expand([True, False])
+    def test_that_the_is_public_service_field_is_used_in_request(
+        self, expected_is_public_service: bool
+    ) -> None:
+        form = self.create_form(is_public_service=expected_is_public_service)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.is_public_service == expected_is_public_service
+
+    @parameterized.expand([0, -1])
+    def test_that_invalid_timeframe_values_are_rejected(self, timeframe: int) -> None:
+        form = self.create_form(timeframe=timeframe)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request is None
+
+    @parameterized.expand([1, 12, 75452])
+    def test_that_the_timeframe_field_is_used_in_the_request(
+        self, timeframe: int
+    ) -> None:
+        form = self.create_form(timeframe=timeframe)
+        request = self.controller.process_form(form=form, draft_id=uuid4())
+        assert request
+        assert request.timeframe == timeframe
+
+    @parameterized.expand(
+        [
+            (
+                0,
+                "The planning timeframe cannot be 0 days.",
+            ),
+            (
+                -1,
+                "The planning timeframe cannot be a negative number of days.",
+            ),
+        ]
+    )
+    def test_that_invalid_timeframe_values_produce_correct_error_message_on_that_field(
+        self, timeframe: int, expected_message: str
+    ) -> None:
+        form = self.create_form(timeframe=timeframe)
+        self.controller.process_form(form=form, draft_id=uuid4())
+        assert (
+            self.translator.gettext(expected_message) in form.timeframe_field().errors
+        )
+
+    def test_that_user_id_from_session_is_used_for_editor_field(self) -> None:
+        expected_id = uuid4()
+        self.session.login_company(expected_id)
+        request = self.controller.process_form(
+            form=self.create_form(), draft_id=uuid4()
+        )
+        assert request
+        assert request.editor == expected_id
+
+    def test_no_request_is_returned_if_user_is_not_authenticated(self) -> None:
+        self.session.logout()
+        request = self.controller.process_form(
+            form=self.create_form(), draft_id=uuid4()
+        )
+        assert request is None
+
+    def test_that_draft_id_from_arguments_is_used_in_request(self) -> None:
+        expected_draft_id = uuid4()
+        request = self.controller.process_form(
+            form=self.create_form(), draft_id=expected_draft_id
+        )
+        assert request
+        assert request.draft == expected_draft_id
+
+    def create_form(
+        self,
+        product_name: str = "test name",
+        description: str = "test description",
+        unit_of_distribution: str = "test unit",
+        labour_cost: Decimal = Decimal(1),
+        resource_cost: Decimal = Decimal(1),
+        means_cost: Decimal = Decimal(1),
+        amount: int = 1,
+        is_public_service: bool = True,
+        timeframe: int = 12,
+    ) -> DraftForm:
+        return DraftForm(
+            prd_name=product_name,
+            description=description,
+            prd_unit=unit_of_distribution,
+            costs_a=labour_cost,
+            costs_p=means_cost,
+            costs_r=resource_cost,
+            prd_amount=amount,
+            is_public_service=is_public_service,
+            timeframe=timeframe,
+        )

--- a/tests/www/presenters/test_edit_draft_presenter.py
+++ b/tests/www/presenters/test_edit_draft_presenter.py
@@ -1,0 +1,19 @@
+from arbeitszeit.use_cases.edit_draft import Response
+from arbeitszeit_web.www.presenters.edit_draft_presenter import EditDraftPresenter
+from tests.www.base_test_case import BaseTestCase
+
+
+class EditDraftPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(EditDraftPresenter)
+
+    def test_unsuccessful_response_leads_to_redirect_url_being_none(self) -> None:
+        view_model = self.presenter.render_response(response=Response(is_success=False))
+        assert view_model.redirect_url is None
+
+    def test_that_successful_response_leads_to_redirect_url_pointing_to_my_plans_view(
+        self,
+    ) -> None:
+        view_model = self.presenter.render_response(response=Response(is_success=True))
+        assert view_model.redirect_url == self.url_index.get_my_plans_url()

--- a/tests/www/presenters/test_get_draft_details_presenter.py
+++ b/tests/www/presenters/test_get_draft_details_presenter.py
@@ -59,7 +59,8 @@ class PlanDetailsPresenterTests(BaseTestCase):
         view_model = self.presenter.present_draft_details(self.plan_details, form=form)
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
         self.assertEqual(
-            view_model.save_draft_url, self.url_index.get_create_draft_url()
+            view_model.save_draft_url,
+            self.url_index.get_draft_details_url(self.plan_details.plan_id),
         )
 
 
@@ -113,5 +114,6 @@ class DraftDetailsPresenterTests(BaseTestCase):
         )
         self.assertEqual(view_model.cancel_url, self.url_index.get_my_plans_url())
         self.assertEqual(
-            view_model.save_draft_url, self.url_index.get_create_draft_url()
+            view_model.save_draft_url,
+            self.url_index.get_draft_details_url(TEST_DRAFT_SUMMARY_SUCCESS.draft_id),
         )


### PR DESCRIPTION
This commit implements proper draft editing for companies.  Before this commit companies would create a new draft everytime they tried to edit an existing draft. This was due to the EditDraft use case not being called. Instead we would call to the CreatePlanDraft use case every time.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76 (4x)