### PR TITLE
Refactor test_list_outbound_coop_requests.py into class based suite

### DIFF
--- a/tests/use_cases/test_list_outbound_coop_requests.py
+++ b/tests/use_cases/test_list_outbound_coop_requests.py
@@ -6,10 +6,52 @@ from arbeitszeit.use_cases.list_outbound_coop_requests import (
     ListOutboundCoopRequestsRequest,
     ListOutboundCoopRequestsResponse,
 )
-from tests.data_generators import CompanyGenerator, CooperationGenerator, PlanGenerator
-from tests.datetime_service import FakeDatetimeService
+from tests.use_cases.base_test_case import BaseTestCase
 
-from .dependency_injection import injection_test
+
+class ListOutboundCoopRequestsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.list_requests = self.injector.get(ListOutboundCoopRequests)
+
+    def test_emtpy_list_is_returned_when_cooperation_is_not_found(self) -> None:
+        response = self.list_requests(ListOutboundCoopRequestsRequest(uuid4()))
+        self.assertEqual(len(response.cooperation_requests), 0)
+
+    def test_empty_list_is_returned_when_there_are_no_outbound_requests(self) -> None:
+        requester = self.company_generator.create_company()
+        coop = self.cooperation_generator.create_cooperation()
+        self.plan_generator.create_plan(requested_cooperation=coop)
+        response = self.list_requests(ListOutboundCoopRequestsRequest(requester))
+        self.assertEqual(len(response.cooperation_requests), 0)
+
+    def test_correct_plans_are_returned_when_there_are_outbound_requests(self) -> None:
+        requester = self.company_generator.create_company()
+        coop = self.cooperation_generator.create_cooperation()
+        requesting_plan1 = self.plan_generator.create_plan(
+            requested_cooperation=coop, planner=requester
+        )
+        requesting_plan2 = self.plan_generator.create_plan(
+            requested_cooperation=coop, planner=requester
+        )
+        response = self.list_requests(ListOutboundCoopRequestsRequest(requester))
+        self.assertEqual(len(response.cooperation_requests), 2)
+        self.assertTrue(plan_in_list(requesting_plan1, response))
+        self.assertTrue(plan_in_list(requesting_plan2, response))
+
+    def test_that_requests_for_expired_plans_are_not_shown(self) -> None:
+        self.datetime_service.freeze_time(datetime(2000, 1, 1))
+        requester = self.company_generator.create_company()
+        coop = self.cooperation_generator.create_cooperation()
+        self.plan_generator.create_plan(
+            requested_cooperation=coop, planner=requester, timeframe=1
+        )
+        self.plan_generator.create_plan(
+            requested_cooperation=coop, planner=requester, timeframe=5
+        )
+        self.datetime_service.advance_time(timedelta(days=2))
+        response = self.list_requests(ListOutboundCoopRequestsRequest(requester))
+        self.assertEqual(len(response.cooperation_requests), 1)
 
 
 def plan_in_list(plan: UUID, response: ListOutboundCoopRequestsResponse) -> bool:
@@ -17,68 +59,3 @@ def plan_in_list(plan: UUID, response: ListOutboundCoopRequestsResponse) -> bool
         if plan == listed_request.plan_id:
             return True
     return False
-
-
-@injection_test
-def test_emtpy_list_is_returned_when_cooperation_is_not_found(
-    list_requests: ListOutboundCoopRequests,
-):
-    response = list_requests(ListOutboundCoopRequestsRequest(uuid4()))
-    assert len(response.cooperation_requests) == 0
-
-
-@injection_test
-def test_empty_list_is_returned_when_there_are_no_outbound_requests(
-    list_requests: ListOutboundCoopRequests,
-    coop_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company()
-    coop = coop_generator.create_cooperation()
-    plan_generator.create_plan(requested_cooperation=coop)
-    response = list_requests(ListOutboundCoopRequestsRequest(requester))
-    assert len(response.cooperation_requests) == 0
-
-
-@injection_test
-def test_correct_plans_are_returned_when_there_are_outbound_requests(
-    list_requests: ListOutboundCoopRequests,
-    coop_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-):
-    requester = company_generator.create_company()
-    coop = coop_generator.create_cooperation()
-    requesting_plan1 = plan_generator.create_plan(
-        requested_cooperation=coop, planner=requester
-    )
-    requesting_plan2 = plan_generator.create_plan(
-        requested_cooperation=coop, planner=requester
-    )
-    response = list_requests(ListOutboundCoopRequestsRequest(requester))
-    assert len(response.cooperation_requests) == 2
-    assert plan_in_list(requesting_plan1, response)
-    assert plan_in_list(requesting_plan2, response)
-
-
-@injection_test
-def test_that_requests_for_expired_plans_are_not_shown(
-    list_requests: ListOutboundCoopRequests,
-    coop_generator: CooperationGenerator,
-    plan_generator: PlanGenerator,
-    company_generator: CompanyGenerator,
-    datetime_service: FakeDatetimeService,
-):
-    datetime_service.freeze_time(datetime(2000, 1, 1))
-    requester = company_generator.create_company()
-    coop = coop_generator.create_cooperation()
-    plan_generator.create_plan(
-        requested_cooperation=coop, planner=requester, timeframe=1
-    )
-    plan_generator.create_plan(
-        requested_cooperation=coop, planner=requester, timeframe=5
-    )
-    datetime_service.advance_time(timedelta(days=2))
-    response = list_requests(ListOutboundCoopRequestsRequest(requester))
-    assert len(response.cooperation_requests) == 1


### PR DESCRIPTION
Before this change the test suite in
tests/use_cases/test_list_outbound_coop_request.py was still using the pytest function style.  This commit refactors those tests to fit the usual class based style.

Plan-ID: d21d8863-1179-4b7c-9d17-1701a7f78e76