### PR TITLE
Implement dedicated recording of hours worked

### DIFF
--- a/arbeitszeit/records.py
+++ b/arbeitszeit/records.py
@@ -347,3 +347,13 @@ class PasswordResetRequest:
     email_address: str
     reset_token: str
     created_at: datetime
+
+
+@dataclass
+class RegisteredHoursWorked:
+    id: UUID
+    company: UUID
+    member: UUID
+    amount: Decimal
+    transaction: UUID
+    registered_on: datetime

--- a/arbeitszeit/repositories.py
+++ b/arbeitszeit/repositories.py
@@ -489,6 +489,19 @@ class LanguageRepository(Protocol):
     def get_available_language_codes(self) -> Iterable[str]: ...
 
 
+class RegisteredHoursWorkedResult(QueryResult[records.RegisteredHoursWorked], Protocol):
+    def at_company(self, company: UUID) -> Self: ...
+
+    def ordered_by_registration_time(self, *, is_ascending: bool = ...) -> Self: ...
+
+    def joined_with_worker(self) -> QueryResult[
+        Tuple[
+            records.RegisteredHoursWorked,
+            records.Member,
+        ]
+    ]: ...
+
+
 class DatabaseGateway(Protocol):
     def create_private_consumption(
         self, transaction: UUID, amount: int, plan: UUID
@@ -627,3 +640,14 @@ class DatabaseGateway(Protocol):
     def create_password_reset_request(
         self, email_address: str, reset_token: str, created_at: datetime
     ) -> records.PasswordResetRequest: ...
+
+    def create_registered_hours_worked(
+        self,
+        company: UUID,
+        member: UUID,
+        amount: Decimal,
+        transaction: UUID,
+        registered_on: datetime,
+    ) -> records.RegisteredHoursWorked: ...
+
+    def get_registered_hours_worked(self) -> RegisteredHoursWorkedResult: ...

--- a/arbeitszeit/use_cases/list_registered_hours_worked.py
+++ b/arbeitszeit/use_cases/list_registered_hours_worked.py
@@ -37,18 +37,18 @@ class ListRegisteredHoursWorkedUseCase:
         work_account = company.get_account_by_type(AccountTypes.a)
         assert work_account
         records = (
-            self.database_gateway.get_transactions()
-            .where_account_is_sender(work_account)
-            .ordered_by_transaction_date(descending=True)
-            .joined_with_receiver()
+            self.database_gateway.get_registered_hours_worked()
+            .at_company(request.company_id)
+            .ordered_by_registration_time(is_ascending=False)
+            .joined_with_worker()
         )
         registered_hours_worked = [
             RegisteredHoursWorked(
-                hours=transaction.amount_sent,
-                worker_id=worker.id,
+                hours=registered_hours.amount,
+                worker_id=registered_hours.member,
                 worker_name=worker.get_name(),
-                registered_on=transaction.date,
+                registered_on=registered_hours.registered_on,
             )
-            for transaction, worker in records
+            for registered_hours, worker in records
         ]
         return Response(registered_hours_worked=registered_hours_worked)

--- a/arbeitszeit/use_cases/register_hours_worked.py
+++ b/arbeitszeit/use_cases/register_hours_worked.py
@@ -62,12 +62,20 @@ class RegisterHoursWorked:
                 rejection_reason=RegisterHoursWorkedResponse.RejectionReason.worker_not_at_company
             )
         fic = self.fic_service.get_current_payout_factor()
-        self.database_gateway.create_transaction(
-            date=self.datetime_service.now(),
+        now = self.datetime_service.now()
+        transaction = self.database_gateway.create_transaction(
+            date=now,
             sending_account=company.work_account,
             receiving_account=worker.account,
             amount_sent=use_case_request.hours_worked,
             amount_received=use_case_request.hours_worked * fic,
             purpose="Lohn",
+        )
+        self.database_gateway.create_registered_hours_worked(
+            company=company.id,
+            member=worker.id,
+            amount=use_case_request.hours_worked,
+            transaction=transaction.id,
+            registered_on=now,
         )
         return RegisterHoursWorkedResponse(rejection_reason=None)

--- a/arbeitszeit_flask/database/models.py
+++ b/arbeitszeit_flask/database/models.py
@@ -205,6 +205,15 @@ class ProductiveConsumption(db.Model):
     amount = db.Column(db.Integer, nullable=False)
 
 
+class RegisteredHoursWorked(db.Model):
+    id = db.Column(db.String, primary_key=True, default=generate_uuid)
+    company = db.Column(db.String, db.ForeignKey("company.id"), nullable=False)
+    worker = db.Column(db.String, db.ForeignKey("member.id"), nullable=False)
+    amount = db.Column(db.Numeric(), nullable=False)
+    transaction = db.Column(db.String, db.ForeignKey("transaction.id"), nullable=False)
+    registered_on = db.Column(db.DateTime, nullable=False)
+
+
 class CompanyWorkInvite(db.Model):
     id = db.Column(db.String, primary_key=True, default=generate_uuid)
     company = db.Column(db.String, db.ForeignKey("company.id"), nullable=False)

--- a/arbeitszeit_flask/migrations/versions/8245d6c57ca5_create_registered_hours_worked_table.py
+++ b/arbeitszeit_flask/migrations/versions/8245d6c57ca5_create_registered_hours_worked_table.py
@@ -1,0 +1,125 @@
+"""Create registered_hours_worked table
+
+Revision ID: 8245d6c57ca5
+Revises: 51b2f780aba4
+Create Date: 2024-06-03 18:17:20.397152
+
+"""
+
+from uuid import uuid4
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy import orm
+from sqlalchemy.ext.declarative import declarative_base
+
+revision = "8245d6c57ca5"
+down_revision = "51b2f780aba4"
+branch_labels = None
+depends_on = None
+
+
+def generate_uuid() -> str:
+    return str(uuid4())
+
+
+def upgrade():
+    op.create_table(
+        "registered_hours_worked",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("company", sa.String(), nullable=False),
+        sa.Column("worker", sa.String(), nullable=False),
+        sa.Column("transaction", sa.String(), nullable=False),
+        sa.Column("amount", sa.Numeric(), nullable=False),
+        sa.Column("registered_on", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["company"],
+            ["company.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["worker"],
+            ["member.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["transaction"],
+            ["transaction.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    Base = declarative_base()
+
+    class RegisteredHoursWorked(Base):
+        __tablename__ = "registered_hours_worked"
+        id = sa.Column(sa.String, primary_key=True, default=generate_uuid)
+        company = sa.Column(sa.String, sa.ForeignKey("company.id"), nullable=False)
+        worker = sa.Column(sa.String, sa.ForeignKey("member.id"), nullable=False)
+        amount = sa.Column(sa.Numeric(), nullable=False)
+        transaction = sa.Column(sa.String, sa.ForeignKey("transaction.id"), nullable=True)
+        registered_on = sa.Column(sa.DateTime, nullable=False)
+
+    class Company(Base):
+        __tablename__ = "company"
+        id = sa.Column(sa.String, primary_key=True, default=generate_uuid)
+        a_account = sa.Column(sa.ForeignKey("account.id"), nullable=False)
+
+    class Transaction(Base):
+        __tablename__ = "transaction"
+        id = sa.Column(sa.String, primary_key=True, default=generate_uuid)
+        sending_account = sa.Column(
+            sa.String, sa.ForeignKey("account.id"), nullable=False
+        )
+        receiving_account = sa.Column(
+            sa.String, sa.ForeignKey("account.id"), nullable=False
+        )
+        amount_sent = sa.Column(sa.Numeric(), nullable=False)
+        date = sa.Column(sa.DateTime, nullable=False)
+
+    class Account(Base):
+        __tablename__ = "account"
+        id = sa.Column(sa.String, primary_key=True, default=generate_uuid)
+
+    class Member(Base):
+        __tablename__ = "member"
+        id = sa.Column(sa.String, primary_key=True, default=generate_uuid)
+        account = sa.Column(sa.ForeignKey("account.id"), nullable=False)
+
+    bind = op.get_bind()
+    with orm.Session(bind=bind) as session:
+        sending_account = orm.aliased(Account)
+        receiving_account = orm.aliased(Account)
+        transactions = (
+            session.query(Transaction)
+            .join(
+                sending_account,
+                sending_account.id == Transaction.sending_account,
+            )
+            .join(
+                receiving_account,
+                receiving_account.id == Transaction.receiving_account,
+            )
+            .join(
+                Member,
+                Member.account == receiving_account.id,
+            )
+            .join(
+                Company,
+                Company.a_account == sending_account.id,
+            )
+            .with_entities(Transaction, Company, Member)
+        )
+        for transaction, company, member in transactions:
+            session.add(
+                RegisteredHoursWorked(
+                    company=company.id,
+                    worker=member.id,
+                    amount=transaction.amount_sent,
+                    transaction=transaction.id,
+                    registered_on=transaction.date,
+                )
+            )
+        session.flush()
+
+
+def downgrade():
+    op.drop_table("registered_hours_worked")

--- a/tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_registered_hours_worked_result.py
@@ -1,0 +1,197 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from arbeitszeit.use_cases import register_hours_worked
+from arbeitszeit_flask.database.repositories import DatabaseGatewayImpl
+from tests.data_generators import CompanyGenerator, MemberGenerator
+from tests.datetime_service import FakeDatetimeService
+
+from ..flask import FlaskTestCase
+
+
+class RegisteredHoursWorkedResultTests(FlaskTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.db_gateway = self.injector.get(DatabaseGatewayImpl)
+        self.company_generator = self.injector.get(CompanyGenerator)
+        self.member_generator = self.injector.get(MemberGenerator)
+        self.register_hours_worked_use_case = self.injector.get(
+            register_hours_worked.RegisterHoursWorked
+        )
+        self.datetime_service: FakeDatetimeService = self.injector.get(
+            FakeDatetimeService
+        )
+
+    def test_get_registered_hours_worked_yields_empty_result_before_any_records_were_created(
+        self,
+    ) -> None:
+        assert not self.db_gateway.get_registered_hours_worked()
+
+    def test_get_registered_hours_worked_yields_non_empty_result_after_creating_a_record(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert self.db_gateway.get_registered_hours_worked()
+
+    def test_that_record_has_correct_member_id(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (record := self.db_gateway.get_registered_hours_worked().first())
+        assert record.member == worker
+
+    def test_that_record_has_correct_company_id(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (record := self.db_gateway.get_registered_hours_worked().first())
+        assert record.company == company
+
+    def test_that_record_has_consistent_uuid(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker, hours=Decimal(5))
+        assert (first_result := self.db_gateway.get_registered_hours_worked().first())
+        assert (second_result := self.db_gateway.get_registered_hours_worked().first())
+        assert first_result.id == second_result.id
+
+    @parameterized.expand(
+        [
+            Decimal(1),
+            Decimal(99),
+        ]
+    )
+    def test_that_record_has_specified_amount(self, expected_hours: Decimal) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker, hours=expected_hours)
+        assert (record := self.db_gateway.get_registered_hours_worked().first())
+        assert record.amount == expected_hours
+
+    @parameterized.expand(
+        [
+            datetime(2000, 1, 1),
+            datetime(2000, 1, 2),
+            datetime(2012, 3, 21),
+        ]
+    )
+    def test_that_record_has_specified_registration_time(
+        self, expected_time: datetime
+    ) -> None:
+        self.datetime_service.freeze_time(expected_time)
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (record := self.db_gateway.get_registered_hours_worked().first())
+        assert record.registered_on == expected_time
+
+    def test_that_transaction_id_exists_in_db(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (record := self.db_gateway.get_registered_hours_worked().first())
+        assert record.transaction in (
+            record.id for record in self.db_gateway.get_transactions()
+        )
+
+    def test_that_we_find_a_record_if_we_filter_by_company_where_the_hours_were_worked(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert self.db_gateway.get_registered_hours_worked().at_company(company).first()
+
+    def test_that_we_dont_find_a_record_if_we_filter_by_company_that_does_not_exist(
+        self,
+    ) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (
+            not self.db_gateway.get_registered_hours_worked()
+            .at_company(uuid4())
+            .first()
+        )
+
+    def test_that_entries_are_ordered_descendingly_if_so_requested(self) -> None:
+        self.datetime_service.freeze_time()
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        self.datetime_service.advance_time()
+        self.register_hours_worked(company=company, worker=worker)
+        records = list(
+            self.db_gateway.get_registered_hours_worked().ordered_by_registration_time(
+                is_ascending=False
+            )
+        )
+        assert records[0].registered_on > records[1].registered_on
+
+    def test_that_entries_are_ordered_ascendingly_if_so_requested(self) -> None:
+        self.datetime_service.freeze_time()
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        self.datetime_service.advance_time()
+        self.register_hours_worked(company=company, worker=worker)
+        records = list(
+            self.db_gateway.get_registered_hours_worked().ordered_by_registration_time(
+                is_ascending=True
+            )
+        )
+        assert records[0].registered_on < records[1].registered_on
+
+    @parameterized.expand(
+        [
+            ("name1",),
+            ("other name",),
+        ]
+    )
+    def test_that_result_joined_with_worker_has_correct_worker_name(
+        self, expected_name: str
+    ) -> None:
+        worker = self.member_generator.create_member(name=expected_name)
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (
+            result := self.db_gateway.get_registered_hours_worked()
+            .joined_with_worker()
+            .first()
+        )
+        assert result[1].name == expected_name
+
+    def test_that_result_joined_with_worker_has_correct_worker_id(self) -> None:
+        worker = self.member_generator.create_member()
+        company = self.company_generator.create_company(workers=[worker])
+        self.register_hours_worked(company=company, worker=worker)
+        assert (
+            result := self.db_gateway.get_registered_hours_worked()
+            .joined_with_worker()
+            .first()
+        )
+        assert result[1].id == worker
+
+    def register_hours_worked(
+        self, company: UUID, worker: UUID, hours: Decimal = Decimal(1)
+    ) -> None:
+        request = register_hours_worked.RegisterHoursWorkedRequest(
+            company_id=company,
+            worker_id=worker,
+            hours_worked=hours,
+        )
+        response = self.register_hours_worked_use_case(use_case_request=request)
+        assert not response.is_rejected


### PR DESCRIPTION
This PR implements the dedicated recording of registered hours worked. Previously we only recorded hours worked via account transaction from the labour account of a company to the individual account of a worker.  This is in fact currently sufficient to reconstruct the hours worked of every single member in the system. This changed was made because it is necessary to move away from the notion that a single registration of hours worked would result in a single transaction in the public ledger but instead would need to split up into several transactions in the future. To elaborate one such transaction for every hour worked would be the portion of labour that is allocated for public plans. In the future we would most certainly want to create a separate transaction that would go into the public sector funds. Other future transactions are to be expected as well if we look towards introducing the notion of accumulation, where an additional portion of every registered work hour would go towards some accumulation funds instead of going into individual consumption.

This commit creates a new table in the DB to serve that end. The tests in the business logic side of things were not subject to change as the behavior of the application should not change in a way observable to the users.

_Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975_