### PR TITLE
Introduce checks for NixOS 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,22 @@
         "type": "github"
       }
     },
+    "nixos-24-05": {
+      "locked": {
+        "lastModified": 1720954236,
+        "narHash": "sha256-1mEKHp4m9brvfQ0rjCca8P1WHpymK3TOr3v34ydv9bs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "53e81e790209e41f0c1efa9ff26ff2fd7ab35e27",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1706732774,
@@ -108,6 +124,7 @@
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
         "nixos-23-11": "nixos-23-11",
+        "nixos-24-05": "nixos-24-05",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nixos-23-11.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixos-24-05.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
@@ -14,6 +15,7 @@
       flake-utils,
       flask-profiler,
       nixos-23-11,
+      nixos-24-05,
     }:
     let
       supportedSystems = [
@@ -33,11 +35,16 @@
             inherit system;
             overlays = [ self.overlays.default ];
           };
+          pkgs-24-05 = import nixos-24-05 {
+            inherit system;
+            overlays = [ self.overlays.default ];
+          };
         in
         {
           devShells = rec {
             default = nixos-unstable;
             nixos-23-11 = pkgs-23-11.callPackage nix/devShell.nix { includeGlibcLocales = !isMacOs; };
+            nixos-24-05 = pkgs-24-05.callPackage nix/devShell.nix { includeGlibcLocales = !isMacOs; };
             nixos-unstable = pkgs.callPackage nix/devShell.nix {
               includeGlibcLocales = !isMacOs;
               nixfmt = pkgs.nixfmt-rfc-style;
@@ -59,8 +66,10 @@
             # versions we want to support.
             arbeitszeit-python3-nixpkgs-unstable = pkgs.python3.pkgs.arbeitszeitapp;
             arbeitszeit-python311-nixpkgs-unstable = pkgs.python311.pkgs.arbeitszeitapp;
-            arbeitszeit-python3-nixpkgs-stable = pkgs-23-11.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python311-nixpkgs-stable = pkgs-23-11.python311.pkgs.arbeitszeitapp;
+            arbeitszeit-python3-nixpkgs-stable = pkgs-24-05.python3.pkgs.arbeitszeitapp;
+            arbeitszeit-python311-nixpkgs-stable = pkgs-24-05.python311.pkgs.arbeitszeitapp;
+            arbeitszeit-python3-nixpkgs-old-stable = pkgs-23-11.python3.pkgs.arbeitszeitapp;
+            arbeitszeit-python311-nixpkgs-old-stable = pkgs-23-11.python311.pkgs.arbeitszeitapp;
           };
         }
       );


### PR DESCRIPTION
This commit extends the nix flake in such a way that the checks for unittest and package builds are now performed also for the NixOS 24.05 package set in addition to NixOS 23.11 and NixOS unstable.