### PR TITLE
Create dedicated flask route for AcceptCooperationRequest use case

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -5,11 +5,6 @@ from flask import Response as FlaskResponse
 from flask import redirect, render_template, request, url_for
 from flask_login import current_user
 
-from arbeitszeit.use_cases.accept_cooperation import (
-    AcceptCooperation,
-    AcceptCooperationRequest,
-    AcceptCooperationResponse,
-)
 from arbeitszeit.use_cases.cancel_cooperation_solicitation import (
     CancelCooperationSolicitation,
     CancelCooperationSolicitationRequest,
@@ -51,6 +46,9 @@ from arbeitszeit_flask.views import (
     EndCooperationView,
     InviteWorkerToCompanyView,
     RequestCooperationView,
+)
+from arbeitszeit_flask.views.accept_cooperation_request_view import (
+    AcceptCooperationRequestView,
 )
 from arbeitszeit_flask.views.company_dashboard_view import CompanyDashboardView
 from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
@@ -279,25 +277,16 @@ class request_cooperation(RequestCooperationView): ...
 def my_cooperations(
     list_coordinations: ListCoordinationsOfCompany,
     list_inbound_coop_requests: ListInboundCoopRequests,
-    accept_cooperation: AcceptCooperation,
     deny_cooperation: DenyCooperation,
     list_outbound_coop_requests: ListOutboundCoopRequests,
     list_my_cooperating_plans: ListMyCooperatingPlansUseCase,
     presenter: ShowMyCooperationsPresenter,
     cancel_cooperation_solicitation: CancelCooperationSolicitation,
 ):
-    accept_cooperation_response: Optional[AcceptCooperationResponse] = None
     deny_cooperation_response: Optional[DenyCooperationResponse] = None
     cancel_cooperation_solicitation_response: Optional[bool] = None
     if request.method == "POST":
-        if request.form.get("accept"):
-            coop_id, plan_id = [
-                UUID(id.strip()) for id in request.form["accept"].split(",")
-            ]
-            accept_cooperation_response = accept_cooperation(
-                AcceptCooperationRequest(UUID(current_user.id), plan_id, coop_id)
-            )
-        elif request.form.get("deny"):
+        if request.form.get("deny"):
             coop_id, plan_id = [
                 UUID(id.strip()) for id in request.form["deny"].split(",")
             ]
@@ -329,11 +318,15 @@ def my_cooperations(
         list_inbound_coop_requests_response=list_inbound_coop_requests_response,
         list_outbound_coop_requests_response=list_outbound_coop_requests_response,
         list_my_cooperating_plans_response=list_my_coop_plans_response,
-        accept_cooperation_response=accept_cooperation_response,
         deny_cooperation_response=deny_cooperation_response,
         cancel_cooperation_solicitation_response=cancel_cooperation_solicitation_response,
     )
     return render_template("company/my_cooperations.html", **view_model.to_dict())
+
+
+@CompanyRoute("/accept_cooperation_request", methods=["POST"])
+@as_flask_view()
+class accept_cooperation_request(AcceptCooperationRequestView): ...
 
 
 @CompanyRoute("/invite_worker_to_company", methods=["GET", "POST"])

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -81,20 +81,25 @@
                 </div>
             </div>
             <div class="media-right">
-                <form action="" method="post">
+              <form action="/company/accept_cooperation_request" method="post">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="plan_id" value="{{ req.plan_id }}">
+                <input type="hidden" name="cooperation_id" value="{{ req.coop_id }}">
+                <button class="button large-button is-primary"
+                        type="submit"
+                        title="{{ gettext('Accept') }}">
+                  <i class="fas fa-check"></i>
+                </button>
+              </form>
+              <form action="" method="post">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <div class="content pt-1">
-                    <button class="button large-button is-primary" name="accept" 
-                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Accept') }}">
-                        <i class="fas fa-check"></i>
-                    </button>
-                    &nbsp;
-                    <button class="button large-button is-danger" name="deny" 
-                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Decline') }}">
-                        <i class="fas fa-times"></i>
-                    </button>
+                  <button class="button large-button is-danger" name="deny" 
+                          value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Decline') }}">
+                    <i class="fas fa-times"></i>
+                  </button>
                 </div>
-                </form>                
+              </form>                
             </div>
         </article>  
     

--- a/arbeitszeit_flask/views/accept_cooperation_request_view.py
+++ b/arbeitszeit_flask/views/accept_cooperation_request_view.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+import flask
+from flask_login import current_user
+
+from arbeitszeit.use_cases.accept_cooperation import (
+    AcceptCooperation,
+    AcceptCooperationRequest,
+)
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.types import Response
+from arbeitszeit_web.www.presenters.accept_cooperation_request_presenter import (
+    AcceptCooperationRequestPresenter,
+)
+
+
+@dataclass
+class AcceptCooperationRequestView:
+    use_case: AcceptCooperation
+    presenter: AcceptCooperationRequestPresenter
+
+    @commit_changes
+    def POST(self) -> Response:
+        form = flask.request.form
+        cooperation_id = UUID(form["cooperation_id"].strip())
+        plan_id = UUID(form["plan_id"].strip())
+        uc_request = AcceptCooperationRequest(
+            requester_id=UUID(current_user.id),
+            plan_id=plan_id,
+            cooperation_id=cooperation_id,
+        )
+        uc_response = self.use_case(uc_request)
+        view_model = self.presenter.render_response(uc_response)
+        return flask.redirect(view_model.redirection_url)

--- a/arbeitszeit_web/www/presenters/accept_cooperation_request_presenter.py
+++ b/arbeitszeit_web/www/presenters/accept_cooperation_request_presenter.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.accept_cooperation import AcceptCooperationResponse
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class ViewModel:
+    redirection_url: str
+
+
+@dataclass
+class AcceptCooperationRequestPresenter:
+    translator: Translator
+    notifier: Notifier
+
+    def render_response(self, response: AcceptCooperationResponse) -> ViewModel:
+        if not response.is_rejected:
+            self.notifier.display_info(
+                self.translator.gettext("Cooperation request has been accepted.")
+            )
+        else:
+            if (
+                response == AcceptCooperationResponse.RejectionReason.plan_not_found
+                or AcceptCooperationResponse.RejectionReason.cooperation_not_found
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Plan or cooperation not found.")
+                )
+            elif (
+                response == AcceptCooperationResponse.RejectionReason.plan_inactive
+                or AcceptCooperationResponse.RejectionReason.plan_has_cooperation
+                or AcceptCooperationResponse.RejectionReason.plan_is_public_service
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Something's wrong with that plan.")
+                )
+            elif (
+                response
+                == AcceptCooperationResponse.RejectionReason.cooperation_was_not_requested
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("This cooperation request does not exist.")
+                )
+            elif (
+                response
+                == AcceptCooperationResponse.RejectionReason.requester_is_not_coordinator
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext(
+                        "You are not coordinator of this cooperation."
+                    )
+                )
+        return ViewModel(redirection_url="/company/my_cooperations")

--- a/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
@@ -1,7 +1,6 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
-from arbeitszeit.use_cases.accept_cooperation import AcceptCooperationResponse
 from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
 from arbeitszeit.use_cases.list_coordinations_of_company import (
     CooperationInfo,
@@ -106,7 +105,6 @@ class ShowMyCooperationsPresenter:
         list_inbound_coop_requests_response: ListInboundCoopRequestsResponse,
         list_outbound_coop_requests_response: ListOutboundCoopRequestsResponse,
         list_my_cooperating_plans_response: ListMyCooperatingPlansUseCase.Response,
-        accept_cooperation_response: Optional[AcceptCooperationResponse] = None,
         deny_cooperation_response: Optional[DenyCooperationResponse] = None,
         cancel_cooperation_solicitation_response: Optional[bool] = None,
     ) -> ShowMyCooperationsViewModel:
@@ -123,7 +121,6 @@ class ShowMyCooperationsPresenter:
             ]
         )
 
-        self._create_accept_message(accept_cooperation_response)
         self._create_deny_message(deny_cooperation_response)
         self._create_cancel_message(cancel_cooperation_solicitation_response)
 
@@ -200,50 +197,6 @@ class ShowMyCooperationsPresenter:
             coop_name=plan.coop_name,
             coop_url=self.url_index.get_coop_summary_url(coop_id=plan.coop_id),
         )
-
-    def _create_accept_message(
-        self, accept_cooperation_response: AcceptCooperationResponse | None
-    ) -> None:
-        if not accept_cooperation_response:
-            return
-        if not accept_cooperation_response.is_rejected:
-            self.notifier.display_info(
-                self.translator.gettext("Cooperation request has been accepted.")
-            )
-        else:
-            if (
-                accept_cooperation_response
-                == AcceptCooperationResponse.RejectionReason.plan_not_found
-                or AcceptCooperationResponse.RejectionReason.cooperation_not_found
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Plan or cooperation not found.")
-                )
-            elif (
-                accept_cooperation_response
-                == AcceptCooperationResponse.RejectionReason.plan_inactive
-                or AcceptCooperationResponse.RejectionReason.plan_has_cooperation
-                or AcceptCooperationResponse.RejectionReason.plan_is_public_service
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Something's wrong with that plan.")
-                )
-            elif (
-                accept_cooperation_response
-                == AcceptCooperationResponse.RejectionReason.cooperation_was_not_requested
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("This cooperation request does not exist.")
-                )
-            elif (
-                accept_cooperation_response
-                == AcceptCooperationResponse.RejectionReason.requester_is_not_coordinator
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext(
-                        "You are not coordinator of this cooperation."
-                    )
-                )
 
     def _create_deny_message(
         self, deny_cooperation_response: DenyCooperationResponse | None

--- a/tests/flask_integration/test_accept_cooperation_request_view.py
+++ b/tests/flask_integration/test_accept_cooperation_request_view.py
@@ -1,0 +1,21 @@
+from uuid import uuid4
+
+from tests.flask_integration.flask import ViewTestCase
+
+URL = "/company/accept_cooperation_request"
+
+
+class CompanyViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+
+    def test_that_posting_valid_form_data_yields_a_redirect(self) -> None:
+        response = self.client.post(
+            URL,
+            data={
+                "plan_id": str(uuid4()),
+                "cooperation_id": str(uuid4()),
+            },
+        )
+        self.assertEqual(response.status_code, 302)

--- a/tests/www/presenters/test_accept_cooperation_request_presenter.py
+++ b/tests/www/presenters/test_accept_cooperation_request_presenter.py
@@ -1,0 +1,32 @@
+from arbeitszeit.use_cases.accept_cooperation import AcceptCooperationResponse
+from arbeitszeit_web.www.presenters.accept_cooperation_request_presenter import (
+    AcceptCooperationRequestPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class ShowMyCooperationsPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(AcceptCooperationRequestPresenter)
+
+    def test_successfull_accept_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(AcceptCooperationResponse(rejection_reason=None))
+        assert len(self.notifier.infos) == 1
+        assert not self.notifier.warnings
+        assert self.notifier.infos[0] == self.translator.gettext(
+            "Cooperation request has been accepted."
+        )
+        assert not self.notifier.warnings
+
+    def test_failed_accept_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(
+            AcceptCooperationResponse(
+                rejection_reason=AcceptCooperationResponse.RejectionReason.plan_not_found
+            )
+        )
+        assert len(self.notifier.warnings) == 1
+        assert not self.notifier.infos
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Plan or cooperation not found."
+        )

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
-from arbeitszeit.use_cases.accept_cooperation import AcceptCooperationResponse
 from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
 from arbeitszeit.use_cases.list_coordinations_of_company import (
     CooperationInfo,
@@ -140,23 +139,6 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
             str(LIST_COORDINATIONS_RESPONSE_LEN_1.coordinations[0].count_plans_in_coop),
         )
 
-    def test_successfull_accept_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-            accept_cooperation_response=AcceptCooperationResponse(
-                rejection_reason=None
-            ),
-        )
-        assert len(self.notifier.infos) == 1
-        assert not self.notifier.warnings
-        assert self.notifier.infos[0] == self.translator.gettext(
-            "Cooperation request has been accepted."
-        )
-        assert not self.notifier.warnings
-
     def test_successfull_deny_request_response_is_presented_correctly(self) -> None:
         self.presenter.present(
             list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
@@ -169,22 +151,6 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
         assert not self.notifier.warnings
         assert self.notifier.infos[0] == self.translator.gettext(
             "Cooperation request has been denied."
-        )
-
-    def test_failed_accept_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-            accept_cooperation_response=AcceptCooperationResponse(
-                rejection_reason=AcceptCooperationResponse.RejectionReason.plan_not_found
-            ),
-        )
-        assert len(self.notifier.warnings) == 1
-        assert not self.notifier.infos
-        assert self.notifier.warnings[0] == self.translator.gettext(
-            "Plan or cooperation not found."
         )
 
     def test_failed_deny_request_response_is_presented_correctly(self) -> None:
@@ -345,9 +311,6 @@ class CooperatingPlansTest(BaseTestCase):
         self.view_model = self.presenter.present(
             list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
             list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            accept_cooperation_response=AcceptCooperationResponse(
-                rejection_reason=None
-            ),
             list_outbound_coop_requests_response=get_outbound_response_length_1(),
             list_my_cooperating_plans_response=get_coop_plans_response_length_1(
                 plan_id=self.PLAN_ID, coop_id=self.COOP_ID


### PR DESCRIPTION
This PR separates the web logic for the AcceptCooperationRequest use case from the company.my_cooperations routes.  This separation removes the interdepence of the AcceptCooperationRequest web logic with that of the use cases ListCoordinationsOfCompany, DenyCooperation, ListMyCooperatingPlansUseCase and CancelCooperationSolicitation. All existing tests where moved to maintain the same level of test coverage. Also a redimentary test case for the flask routes was implemented.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975