### PR TITLE
Don't include Flask-Login in contraints.txt

### DIFF
--- a/arbeitszeit_development/update_constraints.py
+++ b/arbeitszeit_development/update_constraints.py
@@ -123,16 +123,20 @@ class VersionStringCleaner:
 
 
 class PackageFilter:
-    # Since we use a custom flask-profiler package we need to exclude it from
-    # constraints.txt.  Unfortunately jsonschema packages with nixpkgs is not
-    # officially supported by flask-restx. That's why we exclude it
-    # here. docutils as distributed by nixpkgs is not officially supported by
-    # the current sphinx version.
     PACKAGE_BLACKLIST = {
-        "flask_profiler",
-        "jsonschema",
-        "docutils",
         "arbeitszeitapp",
+        # docutils as distributed by nixpkgs is not officially supported by the
+        # current sphinx version.
+        "docutils",
+        # Flask-Login in nixpkgs is a 0.7 prerelease which is not available on
+        # PyPI at the time of writing this comment.
+        "Flask-Login",
+        # Since we use a custom flask-profiler package we need to exclude it
+        # from constraints.txt.
+        "flask_profiler",
+        # Unfortunately jsonschema packages with nixpkgs is not officially
+        # supported by flask-restx.
+        "jsonschema",
     }
 
     def is_package_to_be_included_in_requirements(self, package_name: str) -> bool:

--- a/constraints.txt
+++ b/constraints.txt
@@ -21,7 +21,6 @@ flake8==7.0.0
 Flask==3.0.3
 flask-babel==4.0.0
 Flask-HTTPAuth==4.8.0
-Flask-Login==0.6.3
 Flask-Migrate==4.0.7
 flask-restx==1.3.0
 Flask-SQLAlchemy==3.1.1


### PR DESCRIPTION
Because we use an "unreleased" version of Flask-Login we need to exclude it from constraints.txt. Otherwise users of pip would ne be able to use constraints.txt due to Flask-Login==0.7 not being available on PyPI.