### PR TITLE
Isolate web logic for DenyCooperation use case

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -11,11 +11,6 @@ from arbeitszeit.use_cases.cancel_cooperation_solicitation import (
 )
 from arbeitszeit.use_cases.create_draft_from_plan import CreateDraftFromPlanUseCase
 from arbeitszeit.use_cases.delete_draft import DeleteDraftUseCase
-from arbeitszeit.use_cases.deny_cooperation import (
-    DenyCooperation,
-    DenyCooperationRequest,
-    DenyCooperationResponse,
-)
 from arbeitszeit.use_cases.file_plan_with_accounting import FilePlanWithAccounting
 from arbeitszeit.use_cases.get_plan_details import GetPlanDetailsUseCase
 from arbeitszeit.use_cases.hide_plan import HidePlan
@@ -53,6 +48,7 @@ from arbeitszeit_flask.views.accept_cooperation_request_view import (
 from arbeitszeit_flask.views.company_dashboard_view import CompanyDashboardView
 from arbeitszeit_flask.views.create_cooperation_view import CreateCooperationView
 from arbeitszeit_flask.views.create_draft_view import CreateDraftView
+from arbeitszeit_flask.views.deny_cooperation_view import DenyCooperationView
 from arbeitszeit_flask.views.draft_details_view import DraftDetailsView
 from arbeitszeit_flask.views.http_error_view import http_404
 from arbeitszeit_flask.views.list_registered_hours_worked_view import (
@@ -280,23 +276,14 @@ class request_cooperation(RequestCooperationView): ...
 def my_cooperations(
     list_coordinations: ListCoordinationsOfCompany,
     list_inbound_coop_requests: ListInboundCoopRequests,
-    deny_cooperation: DenyCooperation,
     list_outbound_coop_requests: ListOutboundCoopRequests,
     list_my_cooperating_plans: ListMyCooperatingPlansUseCase,
     presenter: ShowMyCooperationsPresenter,
     cancel_cooperation_solicitation: CancelCooperationSolicitation,
 ):
-    deny_cooperation_response: Optional[DenyCooperationResponse] = None
     cancel_cooperation_solicitation_response: Optional[bool] = None
     if request.method == "POST":
-        if request.form.get("deny"):
-            coop_id, plan_id = [
-                UUID(id.strip()) for id in request.form["deny"].split(",")
-            ]
-            deny_cooperation_response = deny_cooperation(
-                DenyCooperationRequest(UUID(current_user.id), plan_id, coop_id)
-            )
-        elif request.form.get("cancel"):
+        if request.form.get("cancel"):
             plan_id = UUID(request.form["cancel"])
             requester_id = UUID(current_user.id)
             cancel_cooperation_solicitation_response = cancel_cooperation_solicitation(
@@ -321,7 +308,6 @@ def my_cooperations(
         list_inbound_coop_requests_response=list_inbound_coop_requests_response,
         list_outbound_coop_requests_response=list_outbound_coop_requests_response,
         list_my_cooperating_plans_response=list_my_coop_plans_response,
-        deny_cooperation_response=deny_cooperation_response,
         cancel_cooperation_solicitation_response=cancel_cooperation_solicitation_response,
     )
     return render_template("company/my_cooperations.html", **view_model.to_dict())
@@ -330,6 +316,11 @@ def my_cooperations(
 @CompanyRoute("/accept_cooperation_request", methods=["POST"])
 @as_flask_view()
 class accept_cooperation_request(AcceptCooperationRequestView): ...
+
+
+@CompanyRoute("/deny_cooperation_request", methods=["POST"])
+@as_flask_view()
+class deny_cooperation_request(DenyCooperationView): ...
 
 
 @CompanyRoute("/invite_worker_to_company", methods=["GET", "POST"])

--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -91,14 +91,15 @@
                         {{ "check"|icon }}
                 </button>
               </form>
-              <form action="" method="post">
+              <form action="/company/deny_cooperation_request" method="post">
                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                <div class="content pt-1">
-                    <button class="button large-button is-danger" name="deny" 
-                        value="{{ req.coop_id }},{{ req.plan_id }}" type="submit" title="{{ gettext('Decline') }}">
+                <input type="hidden" name="plan_id" value="{{ req.plan_id }}">
+                <input type="hidden" name="cooperation_id" value="{{ req.coop_id }}">
+                <button class="button large-button is-danger"
+                        type="submit"
+                        title="{{ gettext('Decline') }}">
                         {{ "times"|icon }}
-                    </button>
-                </div>
+                </button>
               </form>                
             </div>
         </article>  

--- a/arbeitszeit_flask/views/deny_cooperation_view.py
+++ b/arbeitszeit_flask/views/deny_cooperation_view.py
@@ -1,0 +1,36 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+import flask
+from flask_login import current_user
+
+from arbeitszeit.use_cases.deny_cooperation import (
+    DenyCooperation,
+    DenyCooperationRequest,
+)
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.types import Response
+from arbeitszeit_web.www.presenters.deny_cooperation_presenter import (
+    DenyCooperationPresenter,
+)
+
+
+@dataclass
+class DenyCooperationView:
+    deny_cooperation: DenyCooperation
+    presenter: DenyCooperationPresenter
+
+    @commit_changes
+    def POST(self) -> Response:
+        form = flask.request.form
+        cooperation_id = UUID(form["cooperation_id"].strip())
+        plan_id = UUID(form["plan_id"].strip())
+        deny_cooperation_response = self.deny_cooperation(
+            DenyCooperationRequest(
+                UUID(current_user.id),
+                plan_id,
+                cooperation_id,
+            )
+        )
+        view_model = self.presenter.render_response(deny_cooperation_response)
+        return flask.redirect(view_model.redirection_url)

--- a/arbeitszeit_web/www/presenters/deny_cooperation_presenter.py
+++ b/arbeitszeit_web/www/presenters/deny_cooperation_presenter.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+
+from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+
+
+@dataclass
+class ViewModel:
+    redirection_url: str
+
+
+@dataclass
+class DenyCooperationPresenter:
+    translator: Translator
+    notifier: Notifier
+
+    def render_response(
+        self, deny_cooperation_response: DenyCooperationResponse
+    ) -> ViewModel:
+        if not deny_cooperation_response.is_rejected:
+            self.notifier.display_info(
+                self.translator.gettext("Cooperation request has been denied.")
+            )
+        else:
+            if (
+                deny_cooperation_response
+                == DenyCooperationResponse.RejectionReason.plan_not_found
+                or DenyCooperationResponse.RejectionReason.cooperation_not_found
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("Plan or cooperation not found.")
+                )
+            elif (
+                deny_cooperation_response
+                == DenyCooperationResponse.RejectionReason.cooperation_was_not_requested
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext("This cooperation request does not exist.")
+                )
+            elif (
+                deny_cooperation_response
+                == DenyCooperationResponse.RejectionReason.requester_is_not_coordinator
+            ):
+                self.notifier.display_warning(
+                    self.translator.gettext(
+                        "You are not coordinator of this cooperation."
+                    )
+                )
+            else:
+                # catchall for rejected responses where rejection
+                # reason cannot be handled by presenter.
+                self.notifier.display_warning(
+                    self.translator.gettext("Could not deny cooperation")
+                )
+        return ViewModel(redirection_url="/company/my_cooperations")

--- a/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
@@ -1,7 +1,6 @@
 from dataclasses import asdict, dataclass
 from typing import Any, Dict, List, Optional
 
-from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
 from arbeitszeit.use_cases.list_coordinations_of_company import (
     CooperationInfo,
     ListCoordinationsOfCompanyResponse,
@@ -105,7 +104,6 @@ class ShowMyCooperationsPresenter:
         list_inbound_coop_requests_response: ListInboundCoopRequestsResponse,
         list_outbound_coop_requests_response: ListOutboundCoopRequestsResponse,
         list_my_cooperating_plans_response: ListMyCooperatingPlansUseCase.Response,
-        deny_cooperation_response: Optional[DenyCooperationResponse] = None,
         cancel_cooperation_solicitation_response: Optional[bool] = None,
     ) -> ShowMyCooperationsViewModel:
         list_of_coordinations = ListOfCoordinationsTable(
@@ -121,7 +119,6 @@ class ShowMyCooperationsPresenter:
             ]
         )
 
-        self._create_deny_message(deny_cooperation_response)
         self._create_cancel_message(cancel_cooperation_solicitation_response)
 
         list_of_outbound_coop_requests = ListOfOutboundCooperationRequestsTable(
@@ -197,47 +194,6 @@ class ShowMyCooperationsPresenter:
             coop_name=plan.coop_name,
             coop_url=self.url_index.get_coop_summary_url(coop_id=plan.coop_id),
         )
-
-    def _create_deny_message(
-        self, deny_cooperation_response: DenyCooperationResponse | None
-    ) -> None:
-        if not deny_cooperation_response:
-            return
-        if not deny_cooperation_response.is_rejected:
-            self.notifier.display_info(
-                self.translator.gettext("Cooperation request has been denied.")
-            )
-        else:
-            if (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.plan_not_found
-                or DenyCooperationResponse.RejectionReason.cooperation_not_found
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Plan or cooperation not found.")
-                )
-            elif (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.cooperation_was_not_requested
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("This cooperation request does not exist.")
-                )
-            elif (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.requester_is_not_coordinator
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext(
-                        "You are not coordinator of this cooperation."
-                    )
-                )
-            else:
-                # catchall for rejected responses where rejection
-                # reason cannot be handled by presenter.
-                self.notifier.display_warning(
-                    self.translator.gettext("Could not deny cooperation")
-                )
 
     def _create_cancel_message(self, cancel_coop_response: Optional[bool]) -> None:
         if cancel_coop_response is None:

--- a/tests/flask_integration/test_deny_cooperation_request_view.py
+++ b/tests/flask_integration/test_deny_cooperation_request_view.py
@@ -1,0 +1,21 @@
+from uuid import uuid4
+
+from tests.flask_integration.flask import ViewTestCase
+
+URL = "/company/deny_cooperation_request"
+
+
+class CompanyViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+
+    def test_that_posting_valid_form_data_yields_a_redirect(self) -> None:
+        response = self.client.post(
+            URL,
+            data={
+                "plan_id": str(uuid4()),
+                "cooperation_id": str(uuid4()),
+            },
+        )
+        self.assertEqual(response.status_code, 302)

--- a/tests/www/presenters/test_deny_cooperation_presenter.py
+++ b/tests/www/presenters/test_deny_cooperation_presenter.py
@@ -1,0 +1,31 @@
+from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
+from arbeitszeit_web.www.presenters.deny_cooperation_presenter import (
+    DenyCooperationPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class DenyCooperationPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(DenyCooperationPresenter)
+
+    def test_successfull_deny_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(DenyCooperationResponse(rejection_reason=None))
+        assert len(self.notifier.infos) == 1
+        assert not self.notifier.warnings
+        assert self.notifier.infos[0] == self.translator.gettext(
+            "Cooperation request has been denied."
+        )
+
+    def test_failed_deny_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(
+            deny_cooperation_response=DenyCooperationResponse(
+                rejection_reason=DenyCooperationResponse.RejectionReason.plan_not_found
+            )
+        )
+        assert len(self.notifier.warnings) == 1
+        assert not self.notifier.infos
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Plan or cooperation not found."
+        )

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
-from arbeitszeit.use_cases.deny_cooperation import DenyCooperationResponse
 from arbeitszeit.use_cases.list_coordinations_of_company import (
     CooperationInfo,
     ListCoordinationsOfCompanyResponse,
@@ -137,36 +136,6 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
         self.assertEqual(
             presentation.list_of_coordinations.rows[0].count_plans_in_coop,
             str(LIST_COORDINATIONS_RESPONSE_LEN_1.coordinations[0].count_plans_in_coop),
-        )
-
-    def test_successfull_deny_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            deny_cooperation_response=DenyCooperationResponse(rejection_reason=None),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-        )
-        assert len(self.notifier.infos) == 1
-        assert not self.notifier.warnings
-        assert self.notifier.infos[0] == self.translator.gettext(
-            "Cooperation request has been denied."
-        )
-
-    def test_failed_deny_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            deny_cooperation_response=DenyCooperationResponse(
-                rejection_reason=DenyCooperationResponse.RejectionReason.plan_not_found
-            ),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-        )
-        assert len(self.notifier.warnings) == 1
-        assert not self.notifier.infos
-        assert self.notifier.warnings[0] == self.translator.gettext(
-            "Plan or cooperation not found."
         )
 
     def test_successfull_cancel_request_response_is_presented_correctly(self) -> None:


### PR DESCRIPTION
Before this commit the web logic for the DenyCooperation was tied up with the `my_cooperations` route. This was undesirable and thusly the web logic was isolated into its own route, view and presenter. The HTML form on the `my_cooperations` route needed to be adjusted slightly. Also a new very basic test for the new route was implemented that checks that the web server at least does not crash when submitting a post request against it.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975  