### PR TITLE
Update development dependencies via update script

### DIFF
--- a/arbeitszeit_flask/static/bulma.css
+++ b/arbeitszeit_flask/static/bulma.css
@@ -1,5 +1,5 @@
 @charset "UTF-8";
-/*! bulma.io v1.0.1 | MIT License | github.com/jgthms/bulma */
+/*! bulma.io v1.0.2 | MIT License | github.com/jgthms/bulma */
 /* Bulma Utilities */
 :root {
   --bulma-control-radius: var(--bulma-radius);
@@ -144,7 +144,7 @@
   --bulma-text-85-l: 84%;
   --bulma-text-90-l: 89%;
   --bulma-text-95-l: 94%;
-  --bulma-text-100-l: 100%;
+  --bulma-text-100-l: 99%;
   --bulma-text-00: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-l), 1);
   --bulma-text-00-invert-l: var(--bulma-text-60-l);
   --bulma-text-00-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-invert-l), 1);
@@ -206,7 +206,7 @@
   --bulma-text-95-invert-l: var(--bulma-text-25-l);
   --bulma-text-95-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-invert-l), 1);
   --bulma-text-100: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-l), 1);
-  --bulma-text-100-invert-l: var(--bulma-text-30-l);
+  --bulma-text-100-invert-l: var(--bulma-text-25-l);
   --bulma-text-100-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-invert-l), 1);
   --bulma-text-invert-l: var(--bulma-text-100-l);
   --bulma-text-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-invert-l), 1);
@@ -356,7 +356,7 @@
   --bulma-link-85-l: 83%;
   --bulma-link-90-l: 88%;
   --bulma-link-95-l: 93%;
-  --bulma-link-100-l: 100%;
+  --bulma-link-100-l: 98%;
   --bulma-link-00: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-l), 1);
   --bulma-link-00-invert-l: var(--bulma-link-75-l);
   --bulma-link-00-invert: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-invert-l), 1);
@@ -568,7 +568,7 @@
   --bulma-success-85-l: 83%;
   --bulma-success-90-l: 88%;
   --bulma-success-95-l: 93%;
-  --bulma-success-100-l: 100%;
+  --bulma-success-100-l: 98%;
   --bulma-success-00: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-l), 1);
   --bulma-success-00-invert-l: var(--bulma-success-45-l);
   --bulma-success-00-invert: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-invert-l), 1);
@@ -674,7 +674,7 @@
   --bulma-warning-85-l: 83%;
   --bulma-warning-90-l: 88%;
   --bulma-warning-95-l: 93%;
-  --bulma-warning-100-l: 100%;
+  --bulma-warning-100-l: 98%;
   --bulma-warning-00: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-l), 1);
   --bulma-warning-00-invert-l: var(--bulma-warning-40-l);
   --bulma-warning-00-invert: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-invert-l), 1);
@@ -1045,7 +1045,7 @@
     --bulma-text-85-l: 84%;
     --bulma-text-90-l: 89%;
     --bulma-text-95-l: 94%;
-    --bulma-text-100-l: 100%;
+    --bulma-text-100-l: 99%;
     --bulma-text-00: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-l), 1);
     --bulma-text-00-invert-l: var(--bulma-text-60-l);
     --bulma-text-00-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-invert-l), 1);
@@ -1107,7 +1107,7 @@
     --bulma-text-95-invert-l: var(--bulma-text-25-l);
     --bulma-text-95-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-invert-l), 1);
     --bulma-text-100: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-l), 1);
-    --bulma-text-100-invert-l: var(--bulma-text-30-l);
+    --bulma-text-100-invert-l: var(--bulma-text-25-l);
     --bulma-text-100-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-invert-l), 1);
     --bulma-text-invert-l: var(--bulma-text-100-l);
     --bulma-text-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-invert-l), 1);
@@ -1257,7 +1257,7 @@
     --bulma-link-85-l: 83%;
     --bulma-link-90-l: 88%;
     --bulma-link-95-l: 93%;
-    --bulma-link-100-l: 100%;
+    --bulma-link-100-l: 98%;
     --bulma-link-00: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-l), 1);
     --bulma-link-00-invert-l: var(--bulma-link-75-l);
     --bulma-link-00-invert: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-invert-l), 1);
@@ -1469,7 +1469,7 @@
     --bulma-success-85-l: 83%;
     --bulma-success-90-l: 88%;
     --bulma-success-95-l: 93%;
-    --bulma-success-100-l: 100%;
+    --bulma-success-100-l: 98%;
     --bulma-success-00: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-l), 1);
     --bulma-success-00-invert-l: var(--bulma-success-45-l);
     --bulma-success-00-invert: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-invert-l), 1);
@@ -1575,7 +1575,7 @@
     --bulma-warning-85-l: 83%;
     --bulma-warning-90-l: 88%;
     --bulma-warning-95-l: 93%;
-    --bulma-warning-100-l: 100%;
+    --bulma-warning-100-l: 98%;
     --bulma-warning-00: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-l), 1);
     --bulma-warning-00-invert-l: var(--bulma-warning-40-l);
     --bulma-warning-00-invert: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-invert-l), 1);
@@ -1963,7 +1963,7 @@
   --bulma-text-85-l: 84%;
   --bulma-text-90-l: 89%;
   --bulma-text-95-l: 94%;
-  --bulma-text-100-l: 100%;
+  --bulma-text-100-l: 99%;
   --bulma-text-00: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-l), 1);
   --bulma-text-00-invert-l: var(--bulma-text-60-l);
   --bulma-text-00-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-invert-l), 1);
@@ -2025,7 +2025,7 @@
   --bulma-text-95-invert-l: var(--bulma-text-25-l);
   --bulma-text-95-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-invert-l), 1);
   --bulma-text-100: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-l), 1);
-  --bulma-text-100-invert-l: var(--bulma-text-30-l);
+  --bulma-text-100-invert-l: var(--bulma-text-25-l);
   --bulma-text-100-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-invert-l), 1);
   --bulma-text-invert-l: var(--bulma-text-100-l);
   --bulma-text-invert: hsla(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-invert-l), 1);
@@ -2175,7 +2175,7 @@
   --bulma-link-85-l: 83%;
   --bulma-link-90-l: 88%;
   --bulma-link-95-l: 93%;
-  --bulma-link-100-l: 100%;
+  --bulma-link-100-l: 98%;
   --bulma-link-00: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-l), 1);
   --bulma-link-00-invert-l: var(--bulma-link-75-l);
   --bulma-link-00-invert: hsla(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-invert-l), 1);
@@ -2387,7 +2387,7 @@
   --bulma-success-85-l: 83%;
   --bulma-success-90-l: 88%;
   --bulma-success-95-l: 93%;
-  --bulma-success-100-l: 100%;
+  --bulma-success-100-l: 98%;
   --bulma-success-00: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-l), 1);
   --bulma-success-00-invert-l: var(--bulma-success-45-l);
   --bulma-success-00-invert: hsla(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-invert-l), 1);
@@ -2493,7 +2493,7 @@
   --bulma-warning-85-l: 83%;
   --bulma-warning-90-l: 88%;
   --bulma-warning-95-l: 93%;
-  --bulma-warning-100-l: 100%;
+  --bulma-warning-100-l: 98%;
   --bulma-warning-00: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-l), 1);
   --bulma-warning-00-invert-l: var(--bulma-warning-40-l);
   --bulma-warning-00-invert: hsla(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-invert-l), 1);
@@ -4025,6 +4025,8 @@ a.box:active {
 .content ol {
   list-style-position: outside;
   margin-inline-start: 2em;
+}
+.content ol:not(:first-child) {
   margin-top: 1em;
 }
 .content ol:not([type]) {
@@ -4045,6 +4047,8 @@ a.box:active {
 .content ul {
   list-style: disc outside;
   margin-inline-start: 2em;
+}
+.content ul:not(:first-child) {
   margin-top: 1em;
 }
 .content ul ul {
@@ -5433,6 +5437,8 @@ button.tag:active,
   --bulma-input-h: var(--bulma-scheme-h);
   --bulma-input-s: var(--bulma-scheme-s);
   --bulma-input-l: var(--bulma-scheme-main-l);
+  --bulma-input-border-style: solid;
+  --bulma-input-border-width: var(--bulma-control-border-width);
   --bulma-input-border-l: var(--bulma-border-l);
   --bulma-input-border-l-delta: 0%;
   --bulma-input-hover-border-l-delta: var(--bulma-hover-border-l-delta);
@@ -5508,11 +5514,6 @@ button.tag:active,
 
 /* Bulma Form */
 .textarea, .input {
-  --bulma-input-h: var(--bulma-scheme-h);
-  --bulma-input-s: var(--bulma-scheme-s);
-  --bulma-input-border-style: solid;
-  --bulma-input-border-width: 1px;
-  --bulma-input-border-l: var(--bulma-border-l);
   box-shadow: inset 0 0.0625em 0.125em hsla(var(--bulma-scheme-h), var(--bulma-scheme-s), var(--bulma-scheme-invert-l), 0.05);
   max-width: 100%;
   width: 100%;
@@ -5689,8 +5690,12 @@ button.tag:active,
   cursor: not-allowed;
 }
 
-.radio + .radio {
-  margin-inline-start: 0.5em;
+.checkboxes,
+.radios {
+  display: flex;
+  flex-wrap: wrap;
+  column-gap: 1em;
+  row-gap: 0.5em;
 }
 
 /* Bulma Form */
@@ -6164,14 +6169,22 @@ button.tag:active,
 }
 
 /* Bulma Form */
+:root {
+  --bulma-label-color: var(--bulma-text-strong);
+  --bulma-label-spacing: 0.5em;
+  --bulma-label-weight: var(--bulma-weight-semibold);
+  --bulma-help-size: var(--bulma-size-small);
+  --bulma-field-block-spacing: 0.75rem;
+}
+
 .label {
-  color: var(--bulma-text-strong);
+  color: var(--bulma-label-color);
   display: block;
   font-size: var(--bulma-size-normal);
   font-weight: var(--bulma-weight-semibold);
 }
 .label:not(:last-child) {
-  margin-bottom: 0.5em;
+  margin-bottom: var(--bulma-label-spacing);
 }
 .label.is-small {
   font-size: var(--bulma-size-small);
@@ -6185,7 +6198,7 @@ button.tag:active,
 
 .help {
   display: block;
-  font-size: var(--bulma-size-small);
+  font-size: var(--bulma-help-size);
   margin-top: 0.25rem;
 }
 .help.is-white {
@@ -6223,7 +6236,7 @@ button.tag:active,
 }
 
 .field {
-  --bulma-block-spacing: 0.75rem;
+  --bulma-block-spacing: var(--bulma-field-block-spacing);
 }
 .field.has-addons {
   display: flex;
@@ -6240,14 +6253,14 @@ button.tag:active,
 .field.has-addons .control:first-child:not(:only-child) .button,
 .field.has-addons .control:first-child:not(:only-child) .input,
 .field.has-addons .control:first-child:not(:only-child) .select select {
-  border-bottom-right-radius: 0;
-  border-top-right-radius: 0;
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
 }
 .field.has-addons .control:last-child:not(:only-child) .button,
 .field.has-addons .control:last-child:not(:only-child) .input,
 .field.has-addons .control:last-child:not(:only-child) .select select {
-  border-bottom-left-radius: 0;
-  border-top-left-radius: 0;
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
 }
 .field.has-addons .control .button:not([disabled]):hover, .field.has-addons .control .button:not([disabled]).is-hovered,
 .field.has-addons .control .input:not([disabled]):hover,
@@ -7151,13 +7164,14 @@ button.dropdown-item.is-selected {
   --bulma-navbar-item-hover-background-l-delta: var(--bulma-hover-background-l-delta);
   --bulma-navbar-item-active-background-l-delta: var(--bulma-active-background-l-delta);
   --bulma-navbar-item-color-l: var(--bulma-text-l);
+  --bulma-navbar-item-color: hsl(var(--bulma-navbar-h), var(--bulma-navbar-s), var(--bulma-navbar-item-color-l));
   --bulma-navbar-item-selected-h: var(--bulma-link-h);
   --bulma-navbar-item-selected-s: var(--bulma-link-s);
   --bulma-navbar-item-selected-l: var(--bulma-link-l);
   --bulma-navbar-item-selected-background-l: var(--bulma-link-l);
   --bulma-navbar-item-selected-color-l: var(--bulma-link-invert-l);
   --bulma-navbar-item-img-max-height: 1.75rem;
-  --bulma-navbar-burger-color: var(--bulma-navbar-item-color);
+  --bulma-navbar-burger-color: var(--bulma-link);
   --bulma-navbar-tab-hover-background-color: transparent;
   --bulma-navbar-tab-hover-border-bottom-color: var(--bulma-link);
   --bulma-navbar-tab-active-color: var(--bulma-link);
@@ -7477,9 +7491,6 @@ body.has-navbar-fixed-bottom {
   position: relative;
   vertical-align: top;
   width: 2.5rem;
-  align-self: center;
-  margin-inline-start: auto;
-  margin-inline-end: 0.375rem;
 }
 .navbar-burger span {
   background-color: currentColor;
@@ -7517,6 +7528,12 @@ body.has-navbar-fixed-bottom {
 .navbar-burger.is-active span:nth-child(3), .navbar-burger.is-active span:nth-child(4) {
   opacity: 0;
 }
+.navbar-burger {
+  align-self: center;
+  color: var(--bulma-navbar-burger-color);
+  margin-inline-start: auto;
+  margin-inline-end: 0.375rem;
+}
 
 .navbar-menu {
   display: none;
@@ -7524,8 +7541,9 @@ body.has-navbar-fixed-bottom {
 
 .navbar-item,
 .navbar-link {
-  color: hsl(var(--bulma-navbar-h), var(--bulma-navbar-s), var(--bulma-navbar-item-color-l));
+  color: var(--bulma-navbar-item-color);
   display: block;
+  gap: 0.75rem;
   line-height: 1.5;
   padding: 0.5rem 0.75rem;
   position: relative;
@@ -7763,8 +7781,8 @@ a.navbar-item.is-active, a.navbar-item.is-selected,
   }
   .navbar-dropdown {
     background-color: var(--bulma-navbar-dropdown-background-color);
-    border-bottom-left-radius: var(--bulma-navbar-dropdown-radius);
-    border-bottom-right-radius: var(--bulma-navbar-dropdown-radius);
+    border-end-start-radius: var(--bulma-navbar-dropdown-radius);
+    border-end-end-radius: var(--bulma-navbar-dropdown-radius);
     border-top-color: var(--bulma-navbar-dropdown-border-color);
     border-top-style: var(--bulma-navbar-dropdown-border-style);
     border-top-width: var(--bulma-navbar-dropdown-border-width);
@@ -8250,8 +8268,8 @@ a.navbar-item.is-active, a.navbar-item.is-selected,
   color: hsl(var(--bulma-panel-h), var(--bulma-panel-s), var(--bulma-panel-color-l));
 }
 .panel-block:last-child {
-  border-bottom-left-radius: var(--bulma-panel-radius);
-  border-bottom-right-radius: var(--bulma-panel-radius);
+  border-end-start-radius: var(--bulma-panel-radius);
+  border-end-end-radius: var(--bulma-panel-radius);
 }
 
 a.panel-block,
@@ -8456,7 +8474,7 @@ label.panel-block:hover {
   flex-basis: 0;
   flex-grow: 1;
   flex-shrink: 1;
-  padding: 0.75rem;
+  padding: var(--bulma-column-gap);
 }
 .columns.is-mobile > .column.is-narrow {
   flex: none;
@@ -8531,91 +8549,91 @@ label.panel-block:hover {
 }
 .columns.is-mobile > .column.is-0 {
   flex: none;
-  width: calc(0% - var(--bulma-column-gap) / 2);
+  width: 0%;
 }
 .columns.is-mobile > .column.is-offset-0 {
   margin-inline-start: 0%;
 }
 .columns.is-mobile > .column.is-1 {
   flex: none;
-  width: calc(8.3333333333% - var(--bulma-column-gap) / 2);
+  width: 8.3333333333%;
 }
 .columns.is-mobile > .column.is-offset-1 {
   margin-inline-start: 8.3333333333%;
 }
 .columns.is-mobile > .column.is-2 {
   flex: none;
-  width: calc(16.6666666667% - var(--bulma-column-gap) / 2);
+  width: 16.6666666667%;
 }
 .columns.is-mobile > .column.is-offset-2 {
   margin-inline-start: 16.6666666667%;
 }
 .columns.is-mobile > .column.is-3 {
   flex: none;
-  width: calc(25% - var(--bulma-column-gap) / 2);
+  width: 25%;
 }
 .columns.is-mobile > .column.is-offset-3 {
   margin-inline-start: 25%;
 }
 .columns.is-mobile > .column.is-4 {
   flex: none;
-  width: calc(33.3333333333% - var(--bulma-column-gap) / 2);
+  width: 33.3333333333%;
 }
 .columns.is-mobile > .column.is-offset-4 {
   margin-inline-start: 33.3333333333%;
 }
 .columns.is-mobile > .column.is-5 {
   flex: none;
-  width: calc(41.6666666667% - var(--bulma-column-gap) / 2);
+  width: 41.6666666667%;
 }
 .columns.is-mobile > .column.is-offset-5 {
   margin-inline-start: 41.6666666667%;
 }
 .columns.is-mobile > .column.is-6 {
   flex: none;
-  width: calc(50% - var(--bulma-column-gap) / 2);
+  width: 50%;
 }
 .columns.is-mobile > .column.is-offset-6 {
   margin-inline-start: 50%;
 }
 .columns.is-mobile > .column.is-7 {
   flex: none;
-  width: calc(58.3333333333% - var(--bulma-column-gap) / 2);
+  width: 58.3333333333%;
 }
 .columns.is-mobile > .column.is-offset-7 {
   margin-inline-start: 58.3333333333%;
 }
 .columns.is-mobile > .column.is-8 {
   flex: none;
-  width: calc(66.6666666667% - var(--bulma-column-gap) / 2);
+  width: 66.6666666667%;
 }
 .columns.is-mobile > .column.is-offset-8 {
   margin-inline-start: 66.6666666667%;
 }
 .columns.is-mobile > .column.is-9 {
   flex: none;
-  width: calc(75% - var(--bulma-column-gap) / 2);
+  width: 75%;
 }
 .columns.is-mobile > .column.is-offset-9 {
   margin-inline-start: 75%;
 }
 .columns.is-mobile > .column.is-10 {
   flex: none;
-  width: calc(83.3333333333% - var(--bulma-column-gap) / 2);
+  width: 83.3333333333%;
 }
 .columns.is-mobile > .column.is-offset-10 {
   margin-inline-start: 83.3333333333%;
 }
 .columns.is-mobile > .column.is-11 {
   flex: none;
-  width: calc(91.6666666667% - var(--bulma-column-gap) / 2);
+  width: 91.6666666667%;
 }
 .columns.is-mobile > .column.is-offset-11 {
   margin-inline-start: 91.6666666667%;
 }
 .columns.is-mobile > .column.is-12 {
   flex: none;
-  width: calc(100% - var(--bulma-column-gap) / 2);
+  width: 100%;
 }
 .columns.is-mobile > .column.is-offset-12 {
   margin-inline-start: 100%;
@@ -8694,91 +8712,91 @@ label.panel-block:hover {
   }
   .column.is-0-mobile {
     flex: none;
-    width: calc(0% - var(--bulma-column-gap) / 2);
+    width: 0%;
   }
   .column.is-offset-0-mobile {
     margin-inline-start: 0%;
   }
   .column.is-1-mobile {
     flex: none;
-    width: calc(8.3333333333% - var(--bulma-column-gap) / 2);
+    width: 8.3333333333%;
   }
   .column.is-offset-1-mobile {
     margin-inline-start: 8.3333333333%;
   }
   .column.is-2-mobile {
     flex: none;
-    width: calc(16.6666666667% - var(--bulma-column-gap) / 2);
+    width: 16.6666666667%;
   }
   .column.is-offset-2-mobile {
     margin-inline-start: 16.6666666667%;
   }
   .column.is-3-mobile {
     flex: none;
-    width: calc(25% - var(--bulma-column-gap) / 2);
+    width: 25%;
   }
   .column.is-offset-3-mobile {
     margin-inline-start: 25%;
   }
   .column.is-4-mobile {
     flex: none;
-    width: calc(33.3333333333% - var(--bulma-column-gap) / 2);
+    width: 33.3333333333%;
   }
   .column.is-offset-4-mobile {
     margin-inline-start: 33.3333333333%;
   }
   .column.is-5-mobile {
     flex: none;
-    width: calc(41.6666666667% - var(--bulma-column-gap) / 2);
+    width: 41.6666666667%;
   }
   .column.is-offset-5-mobile {
     margin-inline-start: 41.6666666667%;
   }
   .column.is-6-mobile {
     flex: none;
-    width: calc(50% - var(--bulma-column-gap) / 2);
+    width: 50%;
   }
   .column.is-offset-6-mobile {
     margin-inline-start: 50%;
   }
   .column.is-7-mobile {
     flex: none;
-    width: calc(58.3333333333% - var(--bulma-column-gap) / 2);
+    width: 58.3333333333%;
   }
   .column.is-offset-7-mobile {
     margin-inline-start: 58.3333333333%;
   }
   .column.is-8-mobile {
     flex: none;
-    width: calc(66.6666666667% - var(--bulma-column-gap) / 2);
+    width: 66.6666666667%;
   }
   .column.is-offset-8-mobile {
     margin-inline-start: 66.6666666667%;
   }
   .column.is-9-mobile {
     flex: none;
-    width: calc(75% - var(--bulma-column-gap) / 2);
+    width: 75%;
   }
   .column.is-offset-9-mobile {
     margin-inline-start: 75%;
   }
   .column.is-10-mobile {
     flex: none;
-    width: calc(83.3333333333% - var(--bulma-column-gap) / 2);
+    width: 83.3333333333%;
   }
   .column.is-offset-10-mobile {
     margin-inline-start: 83.3333333333%;
   }
   .column.is-11-mobile {
     flex: none;
-    width: calc(91.6666666667% - var(--bulma-column-gap) / 2);
+    width: 91.6666666667%;
   }
   .column.is-offset-11-mobile {
     margin-inline-start: 91.6666666667%;
   }
   .column.is-12-mobile {
     flex: none;
-    width: calc(100% - var(--bulma-column-gap) / 2);
+    width: 100%;
   }
   .column.is-offset-12-mobile {
     margin-inline-start: 100%;
@@ -8858,91 +8876,91 @@ label.panel-block:hover {
   }
   .column.is-0, .column.is-0-tablet {
     flex: none;
-    width: calc(0% - var(--bulma-column-gap) / 2);
+    width: 0%;
   }
   .column.is-offset-0, .column.is-offset-0-tablet {
     margin-inline-start: 0%;
   }
   .column.is-1, .column.is-1-tablet {
     flex: none;
-    width: calc(8.3333333333% - var(--bulma-column-gap) / 2);
+    width: 8.3333333333%;
   }
   .column.is-offset-1, .column.is-offset-1-tablet {
     margin-inline-start: 8.3333333333%;
   }
   .column.is-2, .column.is-2-tablet {
     flex: none;
-    width: calc(16.6666666667% - var(--bulma-column-gap) / 2);
+    width: 16.6666666667%;
   }
   .column.is-offset-2, .column.is-offset-2-tablet {
     margin-inline-start: 16.6666666667%;
   }
   .column.is-3, .column.is-3-tablet {
     flex: none;
-    width: calc(25% - var(--bulma-column-gap) / 2);
+    width: 25%;
   }
   .column.is-offset-3, .column.is-offset-3-tablet {
     margin-inline-start: 25%;
   }
   .column.is-4, .column.is-4-tablet {
     flex: none;
-    width: calc(33.3333333333% - var(--bulma-column-gap) / 2);
+    width: 33.3333333333%;
   }
   .column.is-offset-4, .column.is-offset-4-tablet {
     margin-inline-start: 33.3333333333%;
   }
   .column.is-5, .column.is-5-tablet {
     flex: none;
-    width: calc(41.6666666667% - var(--bulma-column-gap) / 2);
+    width: 41.6666666667%;
   }
   .column.is-offset-5, .column.is-offset-5-tablet {
     margin-inline-start: 41.6666666667%;
   }
   .column.is-6, .column.is-6-tablet {
     flex: none;
-    width: calc(50% - var(--bulma-column-gap) / 2);
+    width: 50%;
   }
   .column.is-offset-6, .column.is-offset-6-tablet {
     margin-inline-start: 50%;
   }
   .column.is-7, .column.is-7-tablet {
     flex: none;
-    width: calc(58.3333333333% - var(--bulma-column-gap) / 2);
+    width: 58.3333333333%;
   }
   .column.is-offset-7, .column.is-offset-7-tablet {
     margin-inline-start: 58.3333333333%;
   }
   .column.is-8, .column.is-8-tablet {
     flex: none;
-    width: calc(66.6666666667% - var(--bulma-column-gap) / 2);
+    width: 66.6666666667%;
   }
   .column.is-offset-8, .column.is-offset-8-tablet {
     margin-inline-start: 66.6666666667%;
   }
   .column.is-9, .column.is-9-tablet {
     flex: none;
-    width: calc(75% - var(--bulma-column-gap) / 2);
+    width: 75%;
   }
   .column.is-offset-9, .column.is-offset-9-tablet {
     margin-inline-start: 75%;
   }
   .column.is-10, .column.is-10-tablet {
     flex: none;
-    width: calc(83.3333333333% - var(--bulma-column-gap) / 2);
+    width: 83.3333333333%;
   }
   .column.is-offset-10, .column.is-offset-10-tablet {
     margin-inline-start: 83.3333333333%;
   }
   .column.is-11, .column.is-11-tablet {
     flex: none;
-    width: calc(91.6666666667% - var(--bulma-column-gap) / 2);
+    width: 91.6666666667%;
   }
   .column.is-offset-11, .column.is-offset-11-tablet {
     margin-inline-start: 91.6666666667%;
   }
   .column.is-12, .column.is-12-tablet {
     flex: none;
-    width: calc(100% - var(--bulma-column-gap) / 2);
+    width: 100%;
   }
   .column.is-offset-12, .column.is-offset-12-tablet {
     margin-inline-start: 100%;
@@ -9186,91 +9204,91 @@ label.panel-block:hover {
   }
   .column.is-0-desktop {
     flex: none;
-    width: calc(0% - var(--bulma-column-gap) / 2);
+    width: 0%;
   }
   .column.is-offset-0-desktop {
     margin-inline-start: 0%;
   }
   .column.is-1-desktop {
     flex: none;
-    width: calc(8.3333333333% - var(--bulma-column-gap) / 2);
+    width: 8.3333333333%;
   }
   .column.is-offset-1-desktop {
     margin-inline-start: 8.3333333333%;
   }
   .column.is-2-desktop {
     flex: none;
-    width: calc(16.6666666667% - var(--bulma-column-gap) / 2);
+    width: 16.6666666667%;
   }
   .column.is-offset-2-desktop {
     margin-inline-start: 16.6666666667%;
   }
   .column.is-3-desktop {
     flex: none;
-    width: calc(25% - var(--bulma-column-gap) / 2);
+    width: 25%;
   }
   .column.is-offset-3-desktop {
     margin-inline-start: 25%;
   }
   .column.is-4-desktop {
     flex: none;
-    width: calc(33.3333333333% - var(--bulma-column-gap) / 2);
+    width: 33.3333333333%;
   }
   .column.is-offset-4-desktop {
     margin-inline-start: 33.3333333333%;
   }
   .column.is-5-desktop {
     flex: none;
-    width: calc(41.6666666667% - var(--bulma-column-gap) / 2);
+    width: 41.6666666667%;
   }
   .column.is-offset-5-desktop {
     margin-inline-start: 41.6666666667%;
   }
   .column.is-6-desktop {
     flex: none;
-    width: calc(50% - var(--bulma-column-gap) / 2);
+    width: 50%;
   }
   .column.is-offset-6-desktop {
     margin-inline-start: 50%;
   }
   .column.is-7-desktop {
     flex: none;
-    width: calc(58.3333333333% - var(--bulma-column-gap) / 2);
+    width: 58.3333333333%;
   }
   .column.is-offset-7-desktop {
     margin-inline-start: 58.3333333333%;
   }
   .column.is-8-desktop {
     flex: none;
-    width: calc(66.6666666667% - var(--bulma-column-gap) / 2);
+    width: 66.6666666667%;
   }
   .column.is-offset-8-desktop {
     margin-inline-start: 66.6666666667%;
   }
   .column.is-9-desktop {
     flex: none;
-    width: calc(75% - var(--bulma-column-gap) / 2);
+    width: 75%;
   }
   .column.is-offset-9-desktop {
     margin-inline-start: 75%;
   }
   .column.is-10-desktop {
     flex: none;
-    width: calc(83.3333333333% - var(--bulma-column-gap) / 2);
+    width: 83.3333333333%;
   }
   .column.is-offset-10-desktop {
     margin-inline-start: 83.3333333333%;
   }
   .column.is-11-desktop {
     flex: none;
-    width: calc(91.6666666667% - var(--bulma-column-gap) / 2);
+    width: 91.6666666667%;
   }
   .column.is-offset-11-desktop {
     margin-inline-start: 91.6666666667%;
   }
   .column.is-12-desktop {
     flex: none;
-    width: calc(100% - var(--bulma-column-gap) / 2);
+    width: 100%;
   }
   .column.is-offset-12-desktop {
     margin-inline-start: 100%;
@@ -9350,91 +9368,91 @@ label.panel-block:hover {
   }
   .column.is-0-widescreen {
     flex: none;
-    width: calc(0% - var(--bulma-column-gap) / 2);
+    width: 0%;
   }
   .column.is-offset-0-widescreen {
     margin-inline-start: 0%;
   }
   .column.is-1-widescreen {
     flex: none;
-    width: calc(8.3333333333% - var(--bulma-column-gap) / 2);
+    width: 8.3333333333%;
   }
   .column.is-offset-1-widescreen {
     margin-inline-start: 8.3333333333%;
   }
   .column.is-2-widescreen {
     flex: none;
-    width: calc(16.6666666667% - var(--bulma-column-gap) / 2);
+    width: 16.6666666667%;
   }
   .column.is-offset-2-widescreen {
     margin-inline-start: 16.6666666667%;
   }
   .column.is-3-widescreen {
     flex: none;
-    width: calc(25% - var(--bulma-column-gap) / 2);
+    width: 25%;
   }
   .column.is-offset-3-widescreen {
     margin-inline-start: 25%;
   }
   .column.is-4-widescreen {
     flex: none;
-    width: calc(33.3333333333% - var(--bulma-column-gap) / 2);
+    width: 33.3333333333%;
   }
   .column.is-offset-4-widescreen {
     margin-inline-start: 33.3333333333%;
   }
   .column.is-5-widescreen {
     flex: none;
-    width: calc(41.6666666667% - var(--bulma-column-gap) / 2);
+    width: 41.6666666667%;
   }
   .column.is-offset-5-widescreen {
     margin-inline-start: 41.6666666667%;
   }
   .column.is-6-widescreen {
     flex: none;
-    width: calc(50% - var(--bulma-column-gap) / 2);
+    width: 50%;
   }
   .column.is-offset-6-widescreen {
     margin-inline-start: 50%;
   }
   .column.is-7-widescreen {
     flex: none;
-    width: calc(58.3333333333% - var(--bulma-column-gap) / 2);
+    width: 58.3333333333%;
   }
   .column.is-offset-7-widescreen {
     margin-inline-start: 58.3333333333%;
   }
   .column.is-8-widescreen {
     flex: none;
-    width: calc(66.6666666667% - var(--bulma-column-gap) / 2);
+    width: 66.6666666667%;
   }
   .column.is-offset-8-widescreen {
     margin-inline-start: 66.6666666667%;
   }
   .column.is-9-widescreen {
     flex: none;
-    width: calc(75% - var(--bulma-column-gap) / 2);
+    width: 75%;
   }
   .column.is-offset-9-widescreen {
     margin-inline-start: 75%;
   }
   .column.is-10-widescreen {
     flex: none;
-    width: calc(83.3333333333% - var(--bulma-column-gap) / 2);
+    width: 83.3333333333%;
   }
   .column.is-offset-10-widescreen {
     margin-inline-start: 83.3333333333%;
   }
   .column.is-11-widescreen {
     flex: none;
-    width: calc(91.6666666667% - var(--bulma-column-gap) / 2);
+    width: 91.6666666667%;
   }
   .column.is-offset-11-widescreen {
     margin-inline-start: 91.6666666667%;
   }
   .column.is-12-widescreen {
     flex: none;
-    width: calc(100% - var(--bulma-column-gap) / 2);
+    width: 100%;
   }
   .column.is-offset-12-widescreen {
     margin-inline-start: 100%;
@@ -9614,7 +9632,7 @@ label.panel-block:hover {
   margin-bottom: calc(-1 * var(--bulma-column-gap));
 }
 .columns:not(:last-child) {
-  margin-bottom: calc(1.5rem - 0.75rem);
+  margin-bottom: calc(var(--bulma-block-spacing) - var(--bulma-column-gap));
 }
 .columns.is-centered {
   justify-content: center;
@@ -9651,6 +9669,438 @@ label.panel-block:hover {
 @media screen and (min-width: 1024px) {
   .columns.is-desktop {
     display: flex;
+  }
+}
+.columns.is-0 {
+  --bulma-column-gap: 0rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-0-mobile {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-0-tablet {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-0-tablet-only {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-0-touch {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-0-desktop {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-0-desktop-only {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-0-widescreen {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-0-widescreen-only {
+    --bulma-column-gap: 0rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-0-fullhd {
+    --bulma-column-gap: 0rem;
+  }
+}
+.columns.is-1 {
+  --bulma-column-gap: 0.25rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-1-mobile {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-1-tablet {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-1-tablet-only {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-1-touch {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-1-desktop {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-1-desktop-only {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-1-widescreen {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-1-widescreen-only {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-1-fullhd {
+    --bulma-column-gap: 0.25rem;
+  }
+}
+.columns.is-2 {
+  --bulma-column-gap: 0.5rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-2-mobile {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-2-tablet {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-2-tablet-only {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-2-touch {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-2-desktop {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-2-desktop-only {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-2-widescreen {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-2-widescreen-only {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-2-fullhd {
+    --bulma-column-gap: 0.5rem;
+  }
+}
+.columns.is-3 {
+  --bulma-column-gap: 0.75rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-3-mobile {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-3-tablet {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-3-tablet-only {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-3-touch {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-3-desktop {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-3-desktop-only {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-3-widescreen {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-3-widescreen-only {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-3-fullhd {
+    --bulma-column-gap: 0.75rem;
+  }
+}
+.columns.is-4 {
+  --bulma-column-gap: 1rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-4-mobile {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-4-tablet {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-4-tablet-only {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-4-touch {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-4-desktop {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-4-desktop-only {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-4-widescreen {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-4-widescreen-only {
+    --bulma-column-gap: 1rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-4-fullhd {
+    --bulma-column-gap: 1rem;
+  }
+}
+.columns.is-5 {
+  --bulma-column-gap: 1.25rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-5-mobile {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-5-tablet {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-5-tablet-only {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-5-touch {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-5-desktop {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-5-desktop-only {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-5-widescreen {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-5-widescreen-only {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-5-fullhd {
+    --bulma-column-gap: 1.25rem;
+  }
+}
+.columns.is-6 {
+  --bulma-column-gap: 1.5rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-6-mobile {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-6-tablet {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-6-tablet-only {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-6-touch {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-6-desktop {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-6-desktop-only {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-6-widescreen {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-6-widescreen-only {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-6-fullhd {
+    --bulma-column-gap: 1.5rem;
+  }
+}
+.columns.is-7 {
+  --bulma-column-gap: 1.75rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-7-mobile {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-7-tablet {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-7-tablet-only {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-7-touch {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-7-desktop {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-7-desktop-only {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-7-widescreen {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-7-widescreen-only {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-7-fullhd {
+    --bulma-column-gap: 1.75rem;
+  }
+}
+.columns.is-8 {
+  --bulma-column-gap: 2rem;
+}
+@media screen and (max-width: 768px) {
+  .columns.is-8-mobile {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 769px), print {
+  .columns.is-8-tablet {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 769px) and (max-width: 1023px) {
+  .columns.is-8-tablet-only {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (max-width: 1023px) {
+  .columns.is-8-touch {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 1024px) {
+  .columns.is-8-desktop {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 1024px) and (max-width: 1215px) {
+  .columns.is-8-desktop-only {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 1216px) {
+  .columns.is-8-widescreen {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 1216px) and (max-width: 1407px) {
+  .columns.is-8-widescreen-only {
+    --bulma-column-gap: 2rem;
+  }
+}
+@media screen and (min-width: 1408px) {
+  .columns.is-8-fullhd {
+    --bulma-column-gap: 2rem;
   }
 }
 
@@ -9965,6 +10415,66 @@ label.panel-block:hover {
 }
 .grid.is-col-min-12 {
   --bulma-grid-column-min: 18rem;
+}
+.grid.is-col-min-13 {
+  --bulma-grid-column-min: 19.5rem;
+}
+.grid.is-col-min-14 {
+  --bulma-grid-column-min: 21rem;
+}
+.grid.is-col-min-15 {
+  --bulma-grid-column-min: 22.5rem;
+}
+.grid.is-col-min-16 {
+  --bulma-grid-column-min: 24rem;
+}
+.grid.is-col-min-17 {
+  --bulma-grid-column-min: 25.5rem;
+}
+.grid.is-col-min-18 {
+  --bulma-grid-column-min: 27rem;
+}
+.grid.is-col-min-19 {
+  --bulma-grid-column-min: 28.5rem;
+}
+.grid.is-col-min-20 {
+  --bulma-grid-column-min: 30rem;
+}
+.grid.is-col-min-21 {
+  --bulma-grid-column-min: 31.5rem;
+}
+.grid.is-col-min-22 {
+  --bulma-grid-column-min: 33rem;
+}
+.grid.is-col-min-23 {
+  --bulma-grid-column-min: 34.5rem;
+}
+.grid.is-col-min-24 {
+  --bulma-grid-column-min: 36rem;
+}
+.grid.is-col-min-25 {
+  --bulma-grid-column-min: 37.5rem;
+}
+.grid.is-col-min-26 {
+  --bulma-grid-column-min: 39rem;
+}
+.grid.is-col-min-27 {
+  --bulma-grid-column-min: 40.5rem;
+}
+.grid.is-col-min-28 {
+  --bulma-grid-column-min: 42rem;
+}
+.grid.is-col-min-29 {
+  --bulma-grid-column-min: 43.5rem;
+}
+.grid.is-col-min-30 {
+  --bulma-grid-column-min: 45rem;
+}
+.grid.is-col-min-31 {
+  --bulma-grid-column-min: 46.5rem;
+}
+.grid.is-col-min-32 {
+  --bulma-grid-column-min: 48rem;
 }
 
 .cell {
@@ -12601,28 +13111,31 @@ label.panel-block:hover {
   padding-right: 32px;
   width: 100%;
 }
+.container.is-max-tablet {
+  max-width: 705px;
+}
 @media screen and (min-width: 1024px) {
   .container {
     max-width: 960px;
   }
 }
 @media screen and (max-width: 1215px) {
-  .container.is-widescreen:not(.is-max-desktop) {
+  .container.is-widescreen:not(.is-max-tablet):not(.is-max-desktop) {
     max-width: 1152px;
   }
 }
 @media screen and (max-width: 1407px) {
-  .container.is-fullhd:not(.is-max-desktop):not(.is-max-widescreen) {
+  .container.is-fullhd:not(.is-max-tablet):not(.is-max-desktop):not(.is-max-widescreen) {
     max-width: 1344px;
   }
 }
 @media screen and (min-width: 1216px) {
-  .container:not(.is-max-desktop) {
+  .container:not(.is-max-tablet):not(.is-max-desktop) {
     max-width: 1152px;
   }
 }
 @media screen and (min-width: 1408px) {
-  .container:not(.is-max-desktop):not(.is-max-widescreen) {
+  .container:not(.is-max-tablet):not(.is-max-desktop):not(.is-max-widescreen) {
     max-width: 1344px;
   }
 }
@@ -13323,6 +13836,9 @@ label.panel-block:hover {
     padding: var(--bulma-section-padding-large);
   }
 }
+.section.is-fullheight {
+  min-height: 100vh;
+}
 
 :root {
   --bulma-skeleton-background: var(--bulma-border);
@@ -13501,582 +14017,454 @@ textarea.is-skeleton:-ms-input-placeholder {
   background-color: var(--bulma-background);
 }
 
-[class*=is-color-white],
-[class*=has-text-white] {
-  --bulma-color-l: var(--bulma-white-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-white {
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-l)) !important;
 }
 
-[class*=is-background-white],
-[class*=has-background-white] {
-  --bulma-background-l: var(--bulma-white-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-white {
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-l)) !important;
 }
 
-.is-color-white-invert,
 .has-text-white-invert {
-  --bulma-color-l: var(--bulma-white-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-invert-l)) !important;
 }
 
-.is-background-white-invert,
 .has-background-white-invert {
-  --bulma-background-l: var(--bulma-white-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-invert-l)) !important;
 }
 
-.is-color-white-on-scheme,
 .has-text-white-on-scheme {
-  --bulma-color-l: var(--bulma-white-on-scheme-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-on-scheme-l)) !important;
 }
 
-.is-background-white-on-scheme,
 .has-background-white-on-scheme {
-  --bulma-background-l: var(--bulma-white-on-scheme-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-on-scheme-l)) !important;
 }
 
-.is-color-white-light,
 .has-text-white-light {
-  --bulma-color-l: var(--bulma-white-light-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-light-l)) !important;
 }
 
-.is-background-white-light,
 .has-background-white-light {
-  --bulma-background-l: var(--bulma-white-light-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-light-l)) !important;
 }
 
-.is-color-white-light-invert,
 .has-text-white-light-invert {
-  --bulma-color-l: var(--bulma-white-light-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-light-invert-l)) !important;
 }
 
-.is-background-white-light-invert,
 .has-background-white-light-invert {
-  --bulma-background-l: var(--bulma-white-light-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-light-invert-l)) !important;
 }
 
-.is-color-white-dark,
 .has-text-white-dark {
-  --bulma-color-l: var(--bulma-white-dark-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-dark-l)) !important;
 }
 
-.is-background-white-dark,
 .has-background-white-dark {
-  --bulma-background-l: var(--bulma-white-dark-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-dark-l)) !important;
 }
 
-.is-color-white-dark-invert,
 .has-text-white-dark-invert {
-  --bulma-color-l: var(--bulma-white-dark-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-dark-invert-l)) !important;
 }
 
-.is-background-white-dark-invert,
 .has-background-white-dark-invert {
-  --bulma-background-l: var(--bulma-white-dark-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-dark-invert-l)) !important;
 }
 
-.is-color-white-soft,
 .has-text-white-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-white-soft,
 .has-background-white-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-white-bold,
 .has-text-white-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-white-bold,
 .has-background-white-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-white-soft-invert,
 .has-text-white-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-white-soft-invert,
 .has-background-white-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-white-bold-invert,
 .has-text-white-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-white-bold-invert,
 .has-background-white-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-white-00,
 .has-text-white-00 {
-  --bulma-color-l: var(--bulma-white-00-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-00-l)) !important;
 }
 
-.is-background-white-00,
 .has-background-white-00 {
-  --bulma-background-l: var(--bulma-white-00-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-00-l)) !important;
 }
 
-.is-color-white-00-invert,
 .has-text-white-00-invert {
-  --bulma-color-l: var(--bulma-white-00-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-00-invert-l)) !important;
 }
 
-.is-background-white-00-invert,
 .has-background-white-00-invert {
-  --bulma-background-l: var(--bulma-white-00-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-00-invert-l)) !important;
 }
 
-.is-color-white-05,
 .has-text-white-05 {
-  --bulma-color-l: var(--bulma-white-05-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-05-l)) !important;
 }
 
-.is-background-white-05,
 .has-background-white-05 {
-  --bulma-background-l: var(--bulma-white-05-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-05-l)) !important;
 }
 
-.is-color-white-05-invert,
 .has-text-white-05-invert {
-  --bulma-color-l: var(--bulma-white-05-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-05-invert-l)) !important;
 }
 
-.is-background-white-05-invert,
 .has-background-white-05-invert {
-  --bulma-background-l: var(--bulma-white-05-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-05-invert-l)) !important;
 }
 
-.is-color-white-10,
 .has-text-white-10 {
-  --bulma-color-l: var(--bulma-white-10-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-10-l)) !important;
 }
 
-.is-background-white-10,
 .has-background-white-10 {
-  --bulma-background-l: var(--bulma-white-10-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-10-l)) !important;
 }
 
-.is-color-white-10-invert,
 .has-text-white-10-invert {
-  --bulma-color-l: var(--bulma-white-10-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-10-invert-l)) !important;
 }
 
-.is-background-white-10-invert,
 .has-background-white-10-invert {
-  --bulma-background-l: var(--bulma-white-10-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-10-invert-l)) !important;
 }
 
-.is-color-white-15,
 .has-text-white-15 {
-  --bulma-color-l: var(--bulma-white-15-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-15-l)) !important;
 }
 
-.is-background-white-15,
 .has-background-white-15 {
-  --bulma-background-l: var(--bulma-white-15-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-15-l)) !important;
 }
 
-.is-color-white-15-invert,
 .has-text-white-15-invert {
-  --bulma-color-l: var(--bulma-white-15-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-15-invert-l)) !important;
 }
 
-.is-background-white-15-invert,
 .has-background-white-15-invert {
-  --bulma-background-l: var(--bulma-white-15-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-15-invert-l)) !important;
 }
 
-.is-color-white-20,
 .has-text-white-20 {
-  --bulma-color-l: var(--bulma-white-20-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-20-l)) !important;
 }
 
-.is-background-white-20,
 .has-background-white-20 {
-  --bulma-background-l: var(--bulma-white-20-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-20-l)) !important;
 }
 
-.is-color-white-20-invert,
 .has-text-white-20-invert {
-  --bulma-color-l: var(--bulma-white-20-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-20-invert-l)) !important;
 }
 
-.is-background-white-20-invert,
 .has-background-white-20-invert {
-  --bulma-background-l: var(--bulma-white-20-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-20-invert-l)) !important;
 }
 
-.is-color-white-25,
 .has-text-white-25 {
-  --bulma-color-l: var(--bulma-white-25-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-25-l)) !important;
 }
 
-.is-background-white-25,
 .has-background-white-25 {
-  --bulma-background-l: var(--bulma-white-25-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-25-l)) !important;
 }
 
-.is-color-white-25-invert,
 .has-text-white-25-invert {
-  --bulma-color-l: var(--bulma-white-25-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-25-invert-l)) !important;
 }
 
-.is-background-white-25-invert,
 .has-background-white-25-invert {
-  --bulma-background-l: var(--bulma-white-25-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-25-invert-l)) !important;
 }
 
-.is-color-white-30,
 .has-text-white-30 {
-  --bulma-color-l: var(--bulma-white-30-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-30-l)) !important;
 }
 
-.is-background-white-30,
 .has-background-white-30 {
-  --bulma-background-l: var(--bulma-white-30-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-30-l)) !important;
 }
 
-.is-color-white-30-invert,
 .has-text-white-30-invert {
-  --bulma-color-l: var(--bulma-white-30-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-30-invert-l)) !important;
 }
 
-.is-background-white-30-invert,
 .has-background-white-30-invert {
-  --bulma-background-l: var(--bulma-white-30-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-30-invert-l)) !important;
 }
 
-.is-color-white-35,
 .has-text-white-35 {
-  --bulma-color-l: var(--bulma-white-35-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-35-l)) !important;
 }
 
-.is-background-white-35,
 .has-background-white-35 {
-  --bulma-background-l: var(--bulma-white-35-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-35-l)) !important;
 }
 
-.is-color-white-35-invert,
 .has-text-white-35-invert {
-  --bulma-color-l: var(--bulma-white-35-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-35-invert-l)) !important;
 }
 
-.is-background-white-35-invert,
 .has-background-white-35-invert {
-  --bulma-background-l: var(--bulma-white-35-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-35-invert-l)) !important;
 }
 
-.is-color-white-40,
 .has-text-white-40 {
-  --bulma-color-l: var(--bulma-white-40-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-40-l)) !important;
 }
 
-.is-background-white-40,
 .has-background-white-40 {
-  --bulma-background-l: var(--bulma-white-40-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-40-l)) !important;
 }
 
-.is-color-white-40-invert,
 .has-text-white-40-invert {
-  --bulma-color-l: var(--bulma-white-40-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-40-invert-l)) !important;
 }
 
-.is-background-white-40-invert,
 .has-background-white-40-invert {
-  --bulma-background-l: var(--bulma-white-40-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-40-invert-l)) !important;
 }
 
-.is-color-white-45,
 .has-text-white-45 {
-  --bulma-color-l: var(--bulma-white-45-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-45-l)) !important;
 }
 
-.is-background-white-45,
 .has-background-white-45 {
-  --bulma-background-l: var(--bulma-white-45-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-45-l)) !important;
 }
 
-.is-color-white-45-invert,
 .has-text-white-45-invert {
-  --bulma-color-l: var(--bulma-white-45-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-45-invert-l)) !important;
 }
 
-.is-background-white-45-invert,
 .has-background-white-45-invert {
-  --bulma-background-l: var(--bulma-white-45-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-45-invert-l)) !important;
 }
 
-.is-color-white-50,
 .has-text-white-50 {
-  --bulma-color-l: var(--bulma-white-50-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-50-l)) !important;
 }
 
-.is-background-white-50,
 .has-background-white-50 {
-  --bulma-background-l: var(--bulma-white-50-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-50-l)) !important;
 }
 
-.is-color-white-50-invert,
 .has-text-white-50-invert {
-  --bulma-color-l: var(--bulma-white-50-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-50-invert-l)) !important;
 }
 
-.is-background-white-50-invert,
 .has-background-white-50-invert {
-  --bulma-background-l: var(--bulma-white-50-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-50-invert-l)) !important;
 }
 
-.is-color-white-55,
 .has-text-white-55 {
-  --bulma-color-l: var(--bulma-white-55-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-55-l)) !important;
 }
 
-.is-background-white-55,
 .has-background-white-55 {
-  --bulma-background-l: var(--bulma-white-55-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-55-l)) !important;
 }
 
-.is-color-white-55-invert,
 .has-text-white-55-invert {
-  --bulma-color-l: var(--bulma-white-55-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-55-invert-l)) !important;
 }
 
-.is-background-white-55-invert,
 .has-background-white-55-invert {
-  --bulma-background-l: var(--bulma-white-55-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-55-invert-l)) !important;
 }
 
-.is-color-white-60,
 .has-text-white-60 {
-  --bulma-color-l: var(--bulma-white-60-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-60-l)) !important;
 }
 
-.is-background-white-60,
 .has-background-white-60 {
-  --bulma-background-l: var(--bulma-white-60-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-60-l)) !important;
 }
 
-.is-color-white-60-invert,
 .has-text-white-60-invert {
-  --bulma-color-l: var(--bulma-white-60-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-60-invert-l)) !important;
 }
 
-.is-background-white-60-invert,
 .has-background-white-60-invert {
-  --bulma-background-l: var(--bulma-white-60-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-60-invert-l)) !important;
 }
 
-.is-color-white-65,
 .has-text-white-65 {
-  --bulma-color-l: var(--bulma-white-65-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-65-l)) !important;
 }
 
-.is-background-white-65,
 .has-background-white-65 {
-  --bulma-background-l: var(--bulma-white-65-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-65-l)) !important;
 }
 
-.is-color-white-65-invert,
 .has-text-white-65-invert {
-  --bulma-color-l: var(--bulma-white-65-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-65-invert-l)) !important;
 }
 
-.is-background-white-65-invert,
 .has-background-white-65-invert {
-  --bulma-background-l: var(--bulma-white-65-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-65-invert-l)) !important;
 }
 
-.is-color-white-70,
 .has-text-white-70 {
-  --bulma-color-l: var(--bulma-white-70-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-70-l)) !important;
 }
 
-.is-background-white-70,
 .has-background-white-70 {
-  --bulma-background-l: var(--bulma-white-70-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-70-l)) !important;
 }
 
-.is-color-white-70-invert,
 .has-text-white-70-invert {
-  --bulma-color-l: var(--bulma-white-70-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-70-invert-l)) !important;
 }
 
-.is-background-white-70-invert,
 .has-background-white-70-invert {
-  --bulma-background-l: var(--bulma-white-70-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-70-invert-l)) !important;
 }
 
-.is-color-white-75,
 .has-text-white-75 {
-  --bulma-color-l: var(--bulma-white-75-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-75-l)) !important;
 }
 
-.is-background-white-75,
 .has-background-white-75 {
-  --bulma-background-l: var(--bulma-white-75-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-75-l)) !important;
 }
 
-.is-color-white-75-invert,
 .has-text-white-75-invert {
-  --bulma-color-l: var(--bulma-white-75-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-75-invert-l)) !important;
 }
 
-.is-background-white-75-invert,
 .has-background-white-75-invert {
-  --bulma-background-l: var(--bulma-white-75-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-75-invert-l)) !important;
 }
 
-.is-color-white-80,
 .has-text-white-80 {
-  --bulma-color-l: var(--bulma-white-80-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-80-l)) !important;
 }
 
-.is-background-white-80,
 .has-background-white-80 {
-  --bulma-background-l: var(--bulma-white-80-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-80-l)) !important;
 }
 
-.is-color-white-80-invert,
 .has-text-white-80-invert {
-  --bulma-color-l: var(--bulma-white-80-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-80-invert-l)) !important;
 }
 
-.is-background-white-80-invert,
 .has-background-white-80-invert {
-  --bulma-background-l: var(--bulma-white-80-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-80-invert-l)) !important;
 }
 
-.is-color-white-85,
 .has-text-white-85 {
-  --bulma-color-l: var(--bulma-white-85-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-85-l)) !important;
 }
 
-.is-background-white-85,
 .has-background-white-85 {
-  --bulma-background-l: var(--bulma-white-85-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-85-l)) !important;
 }
 
-.is-color-white-85-invert,
 .has-text-white-85-invert {
-  --bulma-color-l: var(--bulma-white-85-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-85-invert-l)) !important;
 }
 
-.is-background-white-85-invert,
 .has-background-white-85-invert {
-  --bulma-background-l: var(--bulma-white-85-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-85-invert-l)) !important;
 }
 
-.is-color-white-90,
 .has-text-white-90 {
-  --bulma-color-l: var(--bulma-white-90-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-90-l)) !important;
 }
 
-.is-background-white-90,
 .has-background-white-90 {
-  --bulma-background-l: var(--bulma-white-90-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-90-l)) !important;
 }
 
-.is-color-white-90-invert,
 .has-text-white-90-invert {
-  --bulma-color-l: var(--bulma-white-90-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-90-invert-l)) !important;
 }
 
-.is-background-white-90-invert,
 .has-background-white-90-invert {
-  --bulma-background-l: var(--bulma-white-90-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-90-invert-l)) !important;
 }
 
-.is-color-white-95,
 .has-text-white-95 {
-  --bulma-color-l: var(--bulma-white-95-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-95-l)) !important;
 }
 
-.is-background-white-95,
 .has-background-white-95 {
-  --bulma-background-l: var(--bulma-white-95-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-95-l)) !important;
 }
 
-.is-color-white-95-invert,
 .has-text-white-95-invert {
-  --bulma-color-l: var(--bulma-white-95-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-95-invert-l)) !important;
 }
 
-.is-background-white-95-invert,
 .has-background-white-95-invert {
-  --bulma-background-l: var(--bulma-white-95-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-95-invert-l)) !important;
 }
 
-.is-color-white-100,
 .has-text-white-100 {
-  --bulma-color-l: var(--bulma-white-100-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-100-l)) !important;
 }
 
-.is-background-white-100,
 .has-background-white-100 {
-  --bulma-background-l: var(--bulma-white-100-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-100-l)) !important;
 }
 
-.is-color-white-100-invert,
 .has-text-white-100-invert {
-  --bulma-color-l: var(--bulma-white-100-invert-l);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-100-invert-l)) !important;
 }
 
-.is-background-white-100-invert,
 .has-background-white-100-invert {
-  --bulma-background-l: var(--bulma-white-100-invert-l);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), var(--bulma-white-100-invert-l)) !important;
 }
 
-a.is-color-white:hover, a.is-color-white:focus-visible,
-button.is-color-white:hover,
-button.is-color-white:focus-visible,
-is-color-white.is-hoverable:hover,
-is-color-white.is-hoverable:focus-visible,
-a.has-text-white:hover,
-a.has-text-white:focus-visible,
+a.has-text-white:hover, a.has-text-white:focus-visible,
 button.has-text-white:hover,
 button.has-text-white:focus-visible,
 has-text-white.is-hoverable:hover,
 has-text-white.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-white-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-white:active,
-button.is-color-white:active,
-is-color-white.is-hoverable:active,
 a.has-text-white:active,
 button.has-text-white:active,
 has-text-white.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-white-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-white:hover, a.is-background-white:focus-visible,
-button.is-background-white:hover,
-button.is-background-white:focus-visible,
-is-background-white.is-hoverable:hover,
-is-background-white.is-hoverable:focus-visible,
-a.has-background-white:hover,
-a.has-background-white:focus-visible,
+a.has-background-white:hover, a.has-background-white:focus-visible,
 button.has-background-white:hover,
 button.has-background-white:focus-visible,
 has-background-white.is-hoverable:hover,
 has-background-white.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-white-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-white:active,
-button.is-background-white:active,
-is-background-white.is-hoverable:active,
 a.has-background-white:active,
 button.has-background-white:active,
 has-background-white.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-white-h), var(--bulma-white-s), calc(var(--bulma-white-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-white {
@@ -14128,582 +14516,454 @@ has-background-white.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-black],
-[class*=has-text-black] {
-  --bulma-color-l: var(--bulma-black-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-black {
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-l)) !important;
 }
 
-[class*=is-background-black],
-[class*=has-background-black] {
-  --bulma-background-l: var(--bulma-black-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-black {
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-l)) !important;
 }
 
-.is-color-black-invert,
 .has-text-black-invert {
-  --bulma-color-l: var(--bulma-black-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-invert-l)) !important;
 }
 
-.is-background-black-invert,
 .has-background-black-invert {
-  --bulma-background-l: var(--bulma-black-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-invert-l)) !important;
 }
 
-.is-color-black-on-scheme,
 .has-text-black-on-scheme {
-  --bulma-color-l: var(--bulma-black-on-scheme-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-on-scheme-l)) !important;
 }
 
-.is-background-black-on-scheme,
 .has-background-black-on-scheme {
-  --bulma-background-l: var(--bulma-black-on-scheme-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-on-scheme-l)) !important;
 }
 
-.is-color-black-light,
 .has-text-black-light {
-  --bulma-color-l: var(--bulma-black-light-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-light-l)) !important;
 }
 
-.is-background-black-light,
 .has-background-black-light {
-  --bulma-background-l: var(--bulma-black-light-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-light-l)) !important;
 }
 
-.is-color-black-light-invert,
 .has-text-black-light-invert {
-  --bulma-color-l: var(--bulma-black-light-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-light-invert-l)) !important;
 }
 
-.is-background-black-light-invert,
 .has-background-black-light-invert {
-  --bulma-background-l: var(--bulma-black-light-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-light-invert-l)) !important;
 }
 
-.is-color-black-dark,
 .has-text-black-dark {
-  --bulma-color-l: var(--bulma-black-dark-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-dark-l)) !important;
 }
 
-.is-background-black-dark,
 .has-background-black-dark {
-  --bulma-background-l: var(--bulma-black-dark-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-dark-l)) !important;
 }
 
-.is-color-black-dark-invert,
 .has-text-black-dark-invert {
-  --bulma-color-l: var(--bulma-black-dark-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-dark-invert-l)) !important;
 }
 
-.is-background-black-dark-invert,
 .has-background-black-dark-invert {
-  --bulma-background-l: var(--bulma-black-dark-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-dark-invert-l)) !important;
 }
 
-.is-color-black-soft,
 .has-text-black-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-black-soft,
 .has-background-black-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-black-bold,
 .has-text-black-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-black-bold,
 .has-background-black-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-black-soft-invert,
 .has-text-black-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-black-soft-invert,
 .has-background-black-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-black-bold-invert,
 .has-text-black-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-black-bold-invert,
 .has-background-black-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-black-00,
 .has-text-black-00 {
-  --bulma-color-l: var(--bulma-black-00-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-00-l)) !important;
 }
 
-.is-background-black-00,
 .has-background-black-00 {
-  --bulma-background-l: var(--bulma-black-00-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-00-l)) !important;
 }
 
-.is-color-black-00-invert,
 .has-text-black-00-invert {
-  --bulma-color-l: var(--bulma-black-00-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-00-invert-l)) !important;
 }
 
-.is-background-black-00-invert,
 .has-background-black-00-invert {
-  --bulma-background-l: var(--bulma-black-00-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-00-invert-l)) !important;
 }
 
-.is-color-black-05,
 .has-text-black-05 {
-  --bulma-color-l: var(--bulma-black-05-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-05-l)) !important;
 }
 
-.is-background-black-05,
 .has-background-black-05 {
-  --bulma-background-l: var(--bulma-black-05-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-05-l)) !important;
 }
 
-.is-color-black-05-invert,
 .has-text-black-05-invert {
-  --bulma-color-l: var(--bulma-black-05-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-05-invert-l)) !important;
 }
 
-.is-background-black-05-invert,
 .has-background-black-05-invert {
-  --bulma-background-l: var(--bulma-black-05-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-05-invert-l)) !important;
 }
 
-.is-color-black-10,
 .has-text-black-10 {
-  --bulma-color-l: var(--bulma-black-10-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-10-l)) !important;
 }
 
-.is-background-black-10,
 .has-background-black-10 {
-  --bulma-background-l: var(--bulma-black-10-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-10-l)) !important;
 }
 
-.is-color-black-10-invert,
 .has-text-black-10-invert {
-  --bulma-color-l: var(--bulma-black-10-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-10-invert-l)) !important;
 }
 
-.is-background-black-10-invert,
 .has-background-black-10-invert {
-  --bulma-background-l: var(--bulma-black-10-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-10-invert-l)) !important;
 }
 
-.is-color-black-15,
 .has-text-black-15 {
-  --bulma-color-l: var(--bulma-black-15-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-15-l)) !important;
 }
 
-.is-background-black-15,
 .has-background-black-15 {
-  --bulma-background-l: var(--bulma-black-15-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-15-l)) !important;
 }
 
-.is-color-black-15-invert,
 .has-text-black-15-invert {
-  --bulma-color-l: var(--bulma-black-15-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-15-invert-l)) !important;
 }
 
-.is-background-black-15-invert,
 .has-background-black-15-invert {
-  --bulma-background-l: var(--bulma-black-15-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-15-invert-l)) !important;
 }
 
-.is-color-black-20,
 .has-text-black-20 {
-  --bulma-color-l: var(--bulma-black-20-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-20-l)) !important;
 }
 
-.is-background-black-20,
 .has-background-black-20 {
-  --bulma-background-l: var(--bulma-black-20-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-20-l)) !important;
 }
 
-.is-color-black-20-invert,
 .has-text-black-20-invert {
-  --bulma-color-l: var(--bulma-black-20-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-20-invert-l)) !important;
 }
 
-.is-background-black-20-invert,
 .has-background-black-20-invert {
-  --bulma-background-l: var(--bulma-black-20-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-20-invert-l)) !important;
 }
 
-.is-color-black-25,
 .has-text-black-25 {
-  --bulma-color-l: var(--bulma-black-25-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-25-l)) !important;
 }
 
-.is-background-black-25,
 .has-background-black-25 {
-  --bulma-background-l: var(--bulma-black-25-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-25-l)) !important;
 }
 
-.is-color-black-25-invert,
 .has-text-black-25-invert {
-  --bulma-color-l: var(--bulma-black-25-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-25-invert-l)) !important;
 }
 
-.is-background-black-25-invert,
 .has-background-black-25-invert {
-  --bulma-background-l: var(--bulma-black-25-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-25-invert-l)) !important;
 }
 
-.is-color-black-30,
 .has-text-black-30 {
-  --bulma-color-l: var(--bulma-black-30-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-30-l)) !important;
 }
 
-.is-background-black-30,
 .has-background-black-30 {
-  --bulma-background-l: var(--bulma-black-30-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-30-l)) !important;
 }
 
-.is-color-black-30-invert,
 .has-text-black-30-invert {
-  --bulma-color-l: var(--bulma-black-30-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-30-invert-l)) !important;
 }
 
-.is-background-black-30-invert,
 .has-background-black-30-invert {
-  --bulma-background-l: var(--bulma-black-30-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-30-invert-l)) !important;
 }
 
-.is-color-black-35,
 .has-text-black-35 {
-  --bulma-color-l: var(--bulma-black-35-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-35-l)) !important;
 }
 
-.is-background-black-35,
 .has-background-black-35 {
-  --bulma-background-l: var(--bulma-black-35-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-35-l)) !important;
 }
 
-.is-color-black-35-invert,
 .has-text-black-35-invert {
-  --bulma-color-l: var(--bulma-black-35-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-35-invert-l)) !important;
 }
 
-.is-background-black-35-invert,
 .has-background-black-35-invert {
-  --bulma-background-l: var(--bulma-black-35-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-35-invert-l)) !important;
 }
 
-.is-color-black-40,
 .has-text-black-40 {
-  --bulma-color-l: var(--bulma-black-40-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-40-l)) !important;
 }
 
-.is-background-black-40,
 .has-background-black-40 {
-  --bulma-background-l: var(--bulma-black-40-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-40-l)) !important;
 }
 
-.is-color-black-40-invert,
 .has-text-black-40-invert {
-  --bulma-color-l: var(--bulma-black-40-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-40-invert-l)) !important;
 }
 
-.is-background-black-40-invert,
 .has-background-black-40-invert {
-  --bulma-background-l: var(--bulma-black-40-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-40-invert-l)) !important;
 }
 
-.is-color-black-45,
 .has-text-black-45 {
-  --bulma-color-l: var(--bulma-black-45-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-45-l)) !important;
 }
 
-.is-background-black-45,
 .has-background-black-45 {
-  --bulma-background-l: var(--bulma-black-45-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-45-l)) !important;
 }
 
-.is-color-black-45-invert,
 .has-text-black-45-invert {
-  --bulma-color-l: var(--bulma-black-45-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-45-invert-l)) !important;
 }
 
-.is-background-black-45-invert,
 .has-background-black-45-invert {
-  --bulma-background-l: var(--bulma-black-45-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-45-invert-l)) !important;
 }
 
-.is-color-black-50,
 .has-text-black-50 {
-  --bulma-color-l: var(--bulma-black-50-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-50-l)) !important;
 }
 
-.is-background-black-50,
 .has-background-black-50 {
-  --bulma-background-l: var(--bulma-black-50-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-50-l)) !important;
 }
 
-.is-color-black-50-invert,
 .has-text-black-50-invert {
-  --bulma-color-l: var(--bulma-black-50-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-50-invert-l)) !important;
 }
 
-.is-background-black-50-invert,
 .has-background-black-50-invert {
-  --bulma-background-l: var(--bulma-black-50-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-50-invert-l)) !important;
 }
 
-.is-color-black-55,
 .has-text-black-55 {
-  --bulma-color-l: var(--bulma-black-55-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-55-l)) !important;
 }
 
-.is-background-black-55,
 .has-background-black-55 {
-  --bulma-background-l: var(--bulma-black-55-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-55-l)) !important;
 }
 
-.is-color-black-55-invert,
 .has-text-black-55-invert {
-  --bulma-color-l: var(--bulma-black-55-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-55-invert-l)) !important;
 }
 
-.is-background-black-55-invert,
 .has-background-black-55-invert {
-  --bulma-background-l: var(--bulma-black-55-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-55-invert-l)) !important;
 }
 
-.is-color-black-60,
 .has-text-black-60 {
-  --bulma-color-l: var(--bulma-black-60-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-60-l)) !important;
 }
 
-.is-background-black-60,
 .has-background-black-60 {
-  --bulma-background-l: var(--bulma-black-60-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-60-l)) !important;
 }
 
-.is-color-black-60-invert,
 .has-text-black-60-invert {
-  --bulma-color-l: var(--bulma-black-60-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-60-invert-l)) !important;
 }
 
-.is-background-black-60-invert,
 .has-background-black-60-invert {
-  --bulma-background-l: var(--bulma-black-60-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-60-invert-l)) !important;
 }
 
-.is-color-black-65,
 .has-text-black-65 {
-  --bulma-color-l: var(--bulma-black-65-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-65-l)) !important;
 }
 
-.is-background-black-65,
 .has-background-black-65 {
-  --bulma-background-l: var(--bulma-black-65-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-65-l)) !important;
 }
 
-.is-color-black-65-invert,
 .has-text-black-65-invert {
-  --bulma-color-l: var(--bulma-black-65-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-65-invert-l)) !important;
 }
 
-.is-background-black-65-invert,
 .has-background-black-65-invert {
-  --bulma-background-l: var(--bulma-black-65-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-65-invert-l)) !important;
 }
 
-.is-color-black-70,
 .has-text-black-70 {
-  --bulma-color-l: var(--bulma-black-70-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-70-l)) !important;
 }
 
-.is-background-black-70,
 .has-background-black-70 {
-  --bulma-background-l: var(--bulma-black-70-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-70-l)) !important;
 }
 
-.is-color-black-70-invert,
 .has-text-black-70-invert {
-  --bulma-color-l: var(--bulma-black-70-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-70-invert-l)) !important;
 }
 
-.is-background-black-70-invert,
 .has-background-black-70-invert {
-  --bulma-background-l: var(--bulma-black-70-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-70-invert-l)) !important;
 }
 
-.is-color-black-75,
 .has-text-black-75 {
-  --bulma-color-l: var(--bulma-black-75-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-75-l)) !important;
 }
 
-.is-background-black-75,
 .has-background-black-75 {
-  --bulma-background-l: var(--bulma-black-75-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-75-l)) !important;
 }
 
-.is-color-black-75-invert,
 .has-text-black-75-invert {
-  --bulma-color-l: var(--bulma-black-75-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-75-invert-l)) !important;
 }
 
-.is-background-black-75-invert,
 .has-background-black-75-invert {
-  --bulma-background-l: var(--bulma-black-75-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-75-invert-l)) !important;
 }
 
-.is-color-black-80,
 .has-text-black-80 {
-  --bulma-color-l: var(--bulma-black-80-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-80-l)) !important;
 }
 
-.is-background-black-80,
 .has-background-black-80 {
-  --bulma-background-l: var(--bulma-black-80-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-80-l)) !important;
 }
 
-.is-color-black-80-invert,
 .has-text-black-80-invert {
-  --bulma-color-l: var(--bulma-black-80-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-80-invert-l)) !important;
 }
 
-.is-background-black-80-invert,
 .has-background-black-80-invert {
-  --bulma-background-l: var(--bulma-black-80-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-80-invert-l)) !important;
 }
 
-.is-color-black-85,
 .has-text-black-85 {
-  --bulma-color-l: var(--bulma-black-85-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-85-l)) !important;
 }
 
-.is-background-black-85,
 .has-background-black-85 {
-  --bulma-background-l: var(--bulma-black-85-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-85-l)) !important;
 }
 
-.is-color-black-85-invert,
 .has-text-black-85-invert {
-  --bulma-color-l: var(--bulma-black-85-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-85-invert-l)) !important;
 }
 
-.is-background-black-85-invert,
 .has-background-black-85-invert {
-  --bulma-background-l: var(--bulma-black-85-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-85-invert-l)) !important;
 }
 
-.is-color-black-90,
 .has-text-black-90 {
-  --bulma-color-l: var(--bulma-black-90-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-90-l)) !important;
 }
 
-.is-background-black-90,
 .has-background-black-90 {
-  --bulma-background-l: var(--bulma-black-90-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-90-l)) !important;
 }
 
-.is-color-black-90-invert,
 .has-text-black-90-invert {
-  --bulma-color-l: var(--bulma-black-90-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-90-invert-l)) !important;
 }
 
-.is-background-black-90-invert,
 .has-background-black-90-invert {
-  --bulma-background-l: var(--bulma-black-90-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-90-invert-l)) !important;
 }
 
-.is-color-black-95,
 .has-text-black-95 {
-  --bulma-color-l: var(--bulma-black-95-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-95-l)) !important;
 }
 
-.is-background-black-95,
 .has-background-black-95 {
-  --bulma-background-l: var(--bulma-black-95-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-95-l)) !important;
 }
 
-.is-color-black-95-invert,
 .has-text-black-95-invert {
-  --bulma-color-l: var(--bulma-black-95-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-95-invert-l)) !important;
 }
 
-.is-background-black-95-invert,
 .has-background-black-95-invert {
-  --bulma-background-l: var(--bulma-black-95-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-95-invert-l)) !important;
 }
 
-.is-color-black-100,
 .has-text-black-100 {
-  --bulma-color-l: var(--bulma-black-100-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-100-l)) !important;
 }
 
-.is-background-black-100,
 .has-background-black-100 {
-  --bulma-background-l: var(--bulma-black-100-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-100-l)) !important;
 }
 
-.is-color-black-100-invert,
 .has-text-black-100-invert {
-  --bulma-color-l: var(--bulma-black-100-invert-l);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-100-invert-l)) !important;
 }
 
-.is-background-black-100-invert,
 .has-background-black-100-invert {
-  --bulma-background-l: var(--bulma-black-100-invert-l);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), var(--bulma-black-100-invert-l)) !important;
 }
 
-a.is-color-black:hover, a.is-color-black:focus-visible,
-button.is-color-black:hover,
-button.is-color-black:focus-visible,
-is-color-black.is-hoverable:hover,
-is-color-black.is-hoverable:focus-visible,
-a.has-text-black:hover,
-a.has-text-black:focus-visible,
+a.has-text-black:hover, a.has-text-black:focus-visible,
 button.has-text-black:hover,
 button.has-text-black:focus-visible,
 has-text-black.is-hoverable:hover,
 has-text-black.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-black-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-black:active,
-button.is-color-black:active,
-is-color-black.is-hoverable:active,
 a.has-text-black:active,
 button.has-text-black:active,
 has-text-black.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-black-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-black:hover, a.is-background-black:focus-visible,
-button.is-background-black:hover,
-button.is-background-black:focus-visible,
-is-background-black.is-hoverable:hover,
-is-background-black.is-hoverable:focus-visible,
-a.has-background-black:hover,
-a.has-background-black:focus-visible,
+a.has-background-black:hover, a.has-background-black:focus-visible,
 button.has-background-black:hover,
 button.has-background-black:focus-visible,
 has-background-black.is-hoverable:hover,
 has-background-black.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-black-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-black:active,
-button.is-background-black:active,
-is-background-black.is-hoverable:active,
 a.has-background-black:active,
 button.has-background-black:active,
 has-background-black.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-black-h), var(--bulma-black-s), calc(var(--bulma-black-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-black {
@@ -14755,582 +15015,454 @@ has-background-black.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-light],
-[class*=has-text-light] {
-  --bulma-color-l: var(--bulma-light-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-light {
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-l)) !important;
 }
 
-[class*=is-background-light],
-[class*=has-background-light] {
-  --bulma-background-l: var(--bulma-light-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-light {
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-l)) !important;
 }
 
-.is-color-light-invert,
 .has-text-light-invert {
-  --bulma-color-l: var(--bulma-light-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-invert-l)) !important;
 }
 
-.is-background-light-invert,
 .has-background-light-invert {
-  --bulma-background-l: var(--bulma-light-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-invert-l)) !important;
 }
 
-.is-color-light-on-scheme,
 .has-text-light-on-scheme {
-  --bulma-color-l: var(--bulma-light-on-scheme-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-on-scheme-l)) !important;
 }
 
-.is-background-light-on-scheme,
 .has-background-light-on-scheme {
-  --bulma-background-l: var(--bulma-light-on-scheme-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-on-scheme-l)) !important;
 }
 
-.is-color-light-light,
 .has-text-light-light {
-  --bulma-color-l: var(--bulma-light-light-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-light-l)) !important;
 }
 
-.is-background-light-light,
 .has-background-light-light {
-  --bulma-background-l: var(--bulma-light-light-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-light-l)) !important;
 }
 
-.is-color-light-light-invert,
 .has-text-light-light-invert {
-  --bulma-color-l: var(--bulma-light-light-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-light-invert-l)) !important;
 }
 
-.is-background-light-light-invert,
 .has-background-light-light-invert {
-  --bulma-background-l: var(--bulma-light-light-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-light-invert-l)) !important;
 }
 
-.is-color-light-dark,
 .has-text-light-dark {
-  --bulma-color-l: var(--bulma-light-dark-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-dark-l)) !important;
 }
 
-.is-background-light-dark,
 .has-background-light-dark {
-  --bulma-background-l: var(--bulma-light-dark-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-dark-l)) !important;
 }
 
-.is-color-light-dark-invert,
 .has-text-light-dark-invert {
-  --bulma-color-l: var(--bulma-light-dark-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-dark-invert-l)) !important;
 }
 
-.is-background-light-dark-invert,
 .has-background-light-dark-invert {
-  --bulma-background-l: var(--bulma-light-dark-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-dark-invert-l)) !important;
 }
 
-.is-color-light-soft,
 .has-text-light-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-light-soft,
 .has-background-light-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-light-bold,
 .has-text-light-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-light-bold,
 .has-background-light-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-light-soft-invert,
 .has-text-light-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-light-soft-invert,
 .has-background-light-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-light-bold-invert,
 .has-text-light-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-light-bold-invert,
 .has-background-light-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-light-00,
 .has-text-light-00 {
-  --bulma-color-l: var(--bulma-light-00-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-00-l)) !important;
 }
 
-.is-background-light-00,
 .has-background-light-00 {
-  --bulma-background-l: var(--bulma-light-00-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-00-l)) !important;
 }
 
-.is-color-light-00-invert,
 .has-text-light-00-invert {
-  --bulma-color-l: var(--bulma-light-00-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-00-invert-l)) !important;
 }
 
-.is-background-light-00-invert,
 .has-background-light-00-invert {
-  --bulma-background-l: var(--bulma-light-00-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-00-invert-l)) !important;
 }
 
-.is-color-light-05,
 .has-text-light-05 {
-  --bulma-color-l: var(--bulma-light-05-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-05-l)) !important;
 }
 
-.is-background-light-05,
 .has-background-light-05 {
-  --bulma-background-l: var(--bulma-light-05-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-05-l)) !important;
 }
 
-.is-color-light-05-invert,
 .has-text-light-05-invert {
-  --bulma-color-l: var(--bulma-light-05-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-05-invert-l)) !important;
 }
 
-.is-background-light-05-invert,
 .has-background-light-05-invert {
-  --bulma-background-l: var(--bulma-light-05-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-05-invert-l)) !important;
 }
 
-.is-color-light-10,
 .has-text-light-10 {
-  --bulma-color-l: var(--bulma-light-10-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-10-l)) !important;
 }
 
-.is-background-light-10,
 .has-background-light-10 {
-  --bulma-background-l: var(--bulma-light-10-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-10-l)) !important;
 }
 
-.is-color-light-10-invert,
 .has-text-light-10-invert {
-  --bulma-color-l: var(--bulma-light-10-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-10-invert-l)) !important;
 }
 
-.is-background-light-10-invert,
 .has-background-light-10-invert {
-  --bulma-background-l: var(--bulma-light-10-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-10-invert-l)) !important;
 }
 
-.is-color-light-15,
 .has-text-light-15 {
-  --bulma-color-l: var(--bulma-light-15-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-15-l)) !important;
 }
 
-.is-background-light-15,
 .has-background-light-15 {
-  --bulma-background-l: var(--bulma-light-15-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-15-l)) !important;
 }
 
-.is-color-light-15-invert,
 .has-text-light-15-invert {
-  --bulma-color-l: var(--bulma-light-15-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-15-invert-l)) !important;
 }
 
-.is-background-light-15-invert,
 .has-background-light-15-invert {
-  --bulma-background-l: var(--bulma-light-15-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-15-invert-l)) !important;
 }
 
-.is-color-light-20,
 .has-text-light-20 {
-  --bulma-color-l: var(--bulma-light-20-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-20-l)) !important;
 }
 
-.is-background-light-20,
 .has-background-light-20 {
-  --bulma-background-l: var(--bulma-light-20-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-20-l)) !important;
 }
 
-.is-color-light-20-invert,
 .has-text-light-20-invert {
-  --bulma-color-l: var(--bulma-light-20-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-20-invert-l)) !important;
 }
 
-.is-background-light-20-invert,
 .has-background-light-20-invert {
-  --bulma-background-l: var(--bulma-light-20-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-20-invert-l)) !important;
 }
 
-.is-color-light-25,
 .has-text-light-25 {
-  --bulma-color-l: var(--bulma-light-25-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-25-l)) !important;
 }
 
-.is-background-light-25,
 .has-background-light-25 {
-  --bulma-background-l: var(--bulma-light-25-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-25-l)) !important;
 }
 
-.is-color-light-25-invert,
 .has-text-light-25-invert {
-  --bulma-color-l: var(--bulma-light-25-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-25-invert-l)) !important;
 }
 
-.is-background-light-25-invert,
 .has-background-light-25-invert {
-  --bulma-background-l: var(--bulma-light-25-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-25-invert-l)) !important;
 }
 
-.is-color-light-30,
 .has-text-light-30 {
-  --bulma-color-l: var(--bulma-light-30-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-30-l)) !important;
 }
 
-.is-background-light-30,
 .has-background-light-30 {
-  --bulma-background-l: var(--bulma-light-30-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-30-l)) !important;
 }
 
-.is-color-light-30-invert,
 .has-text-light-30-invert {
-  --bulma-color-l: var(--bulma-light-30-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-30-invert-l)) !important;
 }
 
-.is-background-light-30-invert,
 .has-background-light-30-invert {
-  --bulma-background-l: var(--bulma-light-30-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-30-invert-l)) !important;
 }
 
-.is-color-light-35,
 .has-text-light-35 {
-  --bulma-color-l: var(--bulma-light-35-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-35-l)) !important;
 }
 
-.is-background-light-35,
 .has-background-light-35 {
-  --bulma-background-l: var(--bulma-light-35-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-35-l)) !important;
 }
 
-.is-color-light-35-invert,
 .has-text-light-35-invert {
-  --bulma-color-l: var(--bulma-light-35-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-35-invert-l)) !important;
 }
 
-.is-background-light-35-invert,
 .has-background-light-35-invert {
-  --bulma-background-l: var(--bulma-light-35-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-35-invert-l)) !important;
 }
 
-.is-color-light-40,
 .has-text-light-40 {
-  --bulma-color-l: var(--bulma-light-40-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-40-l)) !important;
 }
 
-.is-background-light-40,
 .has-background-light-40 {
-  --bulma-background-l: var(--bulma-light-40-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-40-l)) !important;
 }
 
-.is-color-light-40-invert,
 .has-text-light-40-invert {
-  --bulma-color-l: var(--bulma-light-40-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-40-invert-l)) !important;
 }
 
-.is-background-light-40-invert,
 .has-background-light-40-invert {
-  --bulma-background-l: var(--bulma-light-40-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-40-invert-l)) !important;
 }
 
-.is-color-light-45,
 .has-text-light-45 {
-  --bulma-color-l: var(--bulma-light-45-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-45-l)) !important;
 }
 
-.is-background-light-45,
 .has-background-light-45 {
-  --bulma-background-l: var(--bulma-light-45-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-45-l)) !important;
 }
 
-.is-color-light-45-invert,
 .has-text-light-45-invert {
-  --bulma-color-l: var(--bulma-light-45-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-45-invert-l)) !important;
 }
 
-.is-background-light-45-invert,
 .has-background-light-45-invert {
-  --bulma-background-l: var(--bulma-light-45-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-45-invert-l)) !important;
 }
 
-.is-color-light-50,
 .has-text-light-50 {
-  --bulma-color-l: var(--bulma-light-50-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-50-l)) !important;
 }
 
-.is-background-light-50,
 .has-background-light-50 {
-  --bulma-background-l: var(--bulma-light-50-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-50-l)) !important;
 }
 
-.is-color-light-50-invert,
 .has-text-light-50-invert {
-  --bulma-color-l: var(--bulma-light-50-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-50-invert-l)) !important;
 }
 
-.is-background-light-50-invert,
 .has-background-light-50-invert {
-  --bulma-background-l: var(--bulma-light-50-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-50-invert-l)) !important;
 }
 
-.is-color-light-55,
 .has-text-light-55 {
-  --bulma-color-l: var(--bulma-light-55-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-55-l)) !important;
 }
 
-.is-background-light-55,
 .has-background-light-55 {
-  --bulma-background-l: var(--bulma-light-55-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-55-l)) !important;
 }
 
-.is-color-light-55-invert,
 .has-text-light-55-invert {
-  --bulma-color-l: var(--bulma-light-55-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-55-invert-l)) !important;
 }
 
-.is-background-light-55-invert,
 .has-background-light-55-invert {
-  --bulma-background-l: var(--bulma-light-55-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-55-invert-l)) !important;
 }
 
-.is-color-light-60,
 .has-text-light-60 {
-  --bulma-color-l: var(--bulma-light-60-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-60-l)) !important;
 }
 
-.is-background-light-60,
 .has-background-light-60 {
-  --bulma-background-l: var(--bulma-light-60-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-60-l)) !important;
 }
 
-.is-color-light-60-invert,
 .has-text-light-60-invert {
-  --bulma-color-l: var(--bulma-light-60-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-60-invert-l)) !important;
 }
 
-.is-background-light-60-invert,
 .has-background-light-60-invert {
-  --bulma-background-l: var(--bulma-light-60-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-60-invert-l)) !important;
 }
 
-.is-color-light-65,
 .has-text-light-65 {
-  --bulma-color-l: var(--bulma-light-65-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-65-l)) !important;
 }
 
-.is-background-light-65,
 .has-background-light-65 {
-  --bulma-background-l: var(--bulma-light-65-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-65-l)) !important;
 }
 
-.is-color-light-65-invert,
 .has-text-light-65-invert {
-  --bulma-color-l: var(--bulma-light-65-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-65-invert-l)) !important;
 }
 
-.is-background-light-65-invert,
 .has-background-light-65-invert {
-  --bulma-background-l: var(--bulma-light-65-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-65-invert-l)) !important;
 }
 
-.is-color-light-70,
 .has-text-light-70 {
-  --bulma-color-l: var(--bulma-light-70-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-70-l)) !important;
 }
 
-.is-background-light-70,
 .has-background-light-70 {
-  --bulma-background-l: var(--bulma-light-70-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-70-l)) !important;
 }
 
-.is-color-light-70-invert,
 .has-text-light-70-invert {
-  --bulma-color-l: var(--bulma-light-70-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-70-invert-l)) !important;
 }
 
-.is-background-light-70-invert,
 .has-background-light-70-invert {
-  --bulma-background-l: var(--bulma-light-70-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-70-invert-l)) !important;
 }
 
-.is-color-light-75,
 .has-text-light-75 {
-  --bulma-color-l: var(--bulma-light-75-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-75-l)) !important;
 }
 
-.is-background-light-75,
 .has-background-light-75 {
-  --bulma-background-l: var(--bulma-light-75-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-75-l)) !important;
 }
 
-.is-color-light-75-invert,
 .has-text-light-75-invert {
-  --bulma-color-l: var(--bulma-light-75-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-75-invert-l)) !important;
 }
 
-.is-background-light-75-invert,
 .has-background-light-75-invert {
-  --bulma-background-l: var(--bulma-light-75-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-75-invert-l)) !important;
 }
 
-.is-color-light-80,
 .has-text-light-80 {
-  --bulma-color-l: var(--bulma-light-80-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-80-l)) !important;
 }
 
-.is-background-light-80,
 .has-background-light-80 {
-  --bulma-background-l: var(--bulma-light-80-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-80-l)) !important;
 }
 
-.is-color-light-80-invert,
 .has-text-light-80-invert {
-  --bulma-color-l: var(--bulma-light-80-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-80-invert-l)) !important;
 }
 
-.is-background-light-80-invert,
 .has-background-light-80-invert {
-  --bulma-background-l: var(--bulma-light-80-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-80-invert-l)) !important;
 }
 
-.is-color-light-85,
 .has-text-light-85 {
-  --bulma-color-l: var(--bulma-light-85-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-85-l)) !important;
 }
 
-.is-background-light-85,
 .has-background-light-85 {
-  --bulma-background-l: var(--bulma-light-85-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-85-l)) !important;
 }
 
-.is-color-light-85-invert,
 .has-text-light-85-invert {
-  --bulma-color-l: var(--bulma-light-85-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-85-invert-l)) !important;
 }
 
-.is-background-light-85-invert,
 .has-background-light-85-invert {
-  --bulma-background-l: var(--bulma-light-85-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-85-invert-l)) !important;
 }
 
-.is-color-light-90,
 .has-text-light-90 {
-  --bulma-color-l: var(--bulma-light-90-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-90-l)) !important;
 }
 
-.is-background-light-90,
 .has-background-light-90 {
-  --bulma-background-l: var(--bulma-light-90-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-90-l)) !important;
 }
 
-.is-color-light-90-invert,
 .has-text-light-90-invert {
-  --bulma-color-l: var(--bulma-light-90-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-90-invert-l)) !important;
 }
 
-.is-background-light-90-invert,
 .has-background-light-90-invert {
-  --bulma-background-l: var(--bulma-light-90-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-90-invert-l)) !important;
 }
 
-.is-color-light-95,
 .has-text-light-95 {
-  --bulma-color-l: var(--bulma-light-95-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-95-l)) !important;
 }
 
-.is-background-light-95,
 .has-background-light-95 {
-  --bulma-background-l: var(--bulma-light-95-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-95-l)) !important;
 }
 
-.is-color-light-95-invert,
 .has-text-light-95-invert {
-  --bulma-color-l: var(--bulma-light-95-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-95-invert-l)) !important;
 }
 
-.is-background-light-95-invert,
 .has-background-light-95-invert {
-  --bulma-background-l: var(--bulma-light-95-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-95-invert-l)) !important;
 }
 
-.is-color-light-100,
 .has-text-light-100 {
-  --bulma-color-l: var(--bulma-light-100-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-100-l)) !important;
 }
 
-.is-background-light-100,
 .has-background-light-100 {
-  --bulma-background-l: var(--bulma-light-100-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-100-l)) !important;
 }
 
-.is-color-light-100-invert,
 .has-text-light-100-invert {
-  --bulma-color-l: var(--bulma-light-100-invert-l);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-100-invert-l)) !important;
 }
 
-.is-background-light-100-invert,
 .has-background-light-100-invert {
-  --bulma-background-l: var(--bulma-light-100-invert-l);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), var(--bulma-light-100-invert-l)) !important;
 }
 
-a.is-color-light:hover, a.is-color-light:focus-visible,
-button.is-color-light:hover,
-button.is-color-light:focus-visible,
-is-color-light.is-hoverable:hover,
-is-color-light.is-hoverable:focus-visible,
-a.has-text-light:hover,
-a.has-text-light:focus-visible,
+a.has-text-light:hover, a.has-text-light:focus-visible,
 button.has-text-light:hover,
 button.has-text-light:focus-visible,
 has-text-light.is-hoverable:hover,
 has-text-light.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-light-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-light:active,
-button.is-color-light:active,
-is-color-light.is-hoverable:active,
 a.has-text-light:active,
 button.has-text-light:active,
 has-text-light.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-light-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-light:hover, a.is-background-light:focus-visible,
-button.is-background-light:hover,
-button.is-background-light:focus-visible,
-is-background-light.is-hoverable:hover,
-is-background-light.is-hoverable:focus-visible,
-a.has-background-light:hover,
-a.has-background-light:focus-visible,
+a.has-background-light:hover, a.has-background-light:focus-visible,
 button.has-background-light:hover,
 button.has-background-light:focus-visible,
 has-background-light.is-hoverable:hover,
 has-background-light.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-light-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-light:active,
-button.is-background-light:active,
-is-background-light.is-hoverable:active,
 a.has-background-light:active,
 button.has-background-light:active,
 has-background-light.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-light-h), var(--bulma-light-s), calc(var(--bulma-light-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-light {
@@ -15382,582 +15514,454 @@ has-background-light.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-dark],
-[class*=has-text-dark] {
-  --bulma-color-l: var(--bulma-dark-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-dark {
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-l)) !important;
 }
 
-[class*=is-background-dark],
-[class*=has-background-dark] {
-  --bulma-background-l: var(--bulma-dark-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-dark {
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-l)) !important;
 }
 
-.is-color-dark-invert,
 .has-text-dark-invert {
-  --bulma-color-l: var(--bulma-dark-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-invert-l)) !important;
 }
 
-.is-background-dark-invert,
 .has-background-dark-invert {
-  --bulma-background-l: var(--bulma-dark-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-invert-l)) !important;
 }
 
-.is-color-dark-on-scheme,
 .has-text-dark-on-scheme {
-  --bulma-color-l: var(--bulma-dark-on-scheme-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-on-scheme-l)) !important;
 }
 
-.is-background-dark-on-scheme,
 .has-background-dark-on-scheme {
-  --bulma-background-l: var(--bulma-dark-on-scheme-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-on-scheme-l)) !important;
 }
 
-.is-color-dark-light,
 .has-text-dark-light {
-  --bulma-color-l: var(--bulma-dark-light-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-light-l)) !important;
 }
 
-.is-background-dark-light,
 .has-background-dark-light {
-  --bulma-background-l: var(--bulma-dark-light-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-light-l)) !important;
 }
 
-.is-color-dark-light-invert,
 .has-text-dark-light-invert {
-  --bulma-color-l: var(--bulma-dark-light-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-light-invert-l)) !important;
 }
 
-.is-background-dark-light-invert,
 .has-background-dark-light-invert {
-  --bulma-background-l: var(--bulma-dark-light-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-light-invert-l)) !important;
 }
 
-.is-color-dark-dark,
 .has-text-dark-dark {
-  --bulma-color-l: var(--bulma-dark-dark-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-dark-l)) !important;
 }
 
-.is-background-dark-dark,
 .has-background-dark-dark {
-  --bulma-background-l: var(--bulma-dark-dark-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-dark-l)) !important;
 }
 
-.is-color-dark-dark-invert,
 .has-text-dark-dark-invert {
-  --bulma-color-l: var(--bulma-dark-dark-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-dark-invert-l)) !important;
 }
 
-.is-background-dark-dark-invert,
 .has-background-dark-dark-invert {
-  --bulma-background-l: var(--bulma-dark-dark-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-dark-invert-l)) !important;
 }
 
-.is-color-dark-soft,
 .has-text-dark-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-dark-soft,
 .has-background-dark-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-dark-bold,
 .has-text-dark-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-dark-bold,
 .has-background-dark-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-dark-soft-invert,
 .has-text-dark-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-dark-soft-invert,
 .has-background-dark-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-dark-bold-invert,
 .has-text-dark-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-dark-bold-invert,
 .has-background-dark-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-dark-00,
 .has-text-dark-00 {
-  --bulma-color-l: var(--bulma-dark-00-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-00-l)) !important;
 }
 
-.is-background-dark-00,
 .has-background-dark-00 {
-  --bulma-background-l: var(--bulma-dark-00-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-00-l)) !important;
 }
 
-.is-color-dark-00-invert,
 .has-text-dark-00-invert {
-  --bulma-color-l: var(--bulma-dark-00-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-00-invert-l)) !important;
 }
 
-.is-background-dark-00-invert,
 .has-background-dark-00-invert {
-  --bulma-background-l: var(--bulma-dark-00-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-00-invert-l)) !important;
 }
 
-.is-color-dark-05,
 .has-text-dark-05 {
-  --bulma-color-l: var(--bulma-dark-05-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-05-l)) !important;
 }
 
-.is-background-dark-05,
 .has-background-dark-05 {
-  --bulma-background-l: var(--bulma-dark-05-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-05-l)) !important;
 }
 
-.is-color-dark-05-invert,
 .has-text-dark-05-invert {
-  --bulma-color-l: var(--bulma-dark-05-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-05-invert-l)) !important;
 }
 
-.is-background-dark-05-invert,
 .has-background-dark-05-invert {
-  --bulma-background-l: var(--bulma-dark-05-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-05-invert-l)) !important;
 }
 
-.is-color-dark-10,
 .has-text-dark-10 {
-  --bulma-color-l: var(--bulma-dark-10-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-10-l)) !important;
 }
 
-.is-background-dark-10,
 .has-background-dark-10 {
-  --bulma-background-l: var(--bulma-dark-10-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-10-l)) !important;
 }
 
-.is-color-dark-10-invert,
 .has-text-dark-10-invert {
-  --bulma-color-l: var(--bulma-dark-10-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-10-invert-l)) !important;
 }
 
-.is-background-dark-10-invert,
 .has-background-dark-10-invert {
-  --bulma-background-l: var(--bulma-dark-10-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-10-invert-l)) !important;
 }
 
-.is-color-dark-15,
 .has-text-dark-15 {
-  --bulma-color-l: var(--bulma-dark-15-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-15-l)) !important;
 }
 
-.is-background-dark-15,
 .has-background-dark-15 {
-  --bulma-background-l: var(--bulma-dark-15-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-15-l)) !important;
 }
 
-.is-color-dark-15-invert,
 .has-text-dark-15-invert {
-  --bulma-color-l: var(--bulma-dark-15-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-15-invert-l)) !important;
 }
 
-.is-background-dark-15-invert,
 .has-background-dark-15-invert {
-  --bulma-background-l: var(--bulma-dark-15-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-15-invert-l)) !important;
 }
 
-.is-color-dark-20,
 .has-text-dark-20 {
-  --bulma-color-l: var(--bulma-dark-20-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-20-l)) !important;
 }
 
-.is-background-dark-20,
 .has-background-dark-20 {
-  --bulma-background-l: var(--bulma-dark-20-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-20-l)) !important;
 }
 
-.is-color-dark-20-invert,
 .has-text-dark-20-invert {
-  --bulma-color-l: var(--bulma-dark-20-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-20-invert-l)) !important;
 }
 
-.is-background-dark-20-invert,
 .has-background-dark-20-invert {
-  --bulma-background-l: var(--bulma-dark-20-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-20-invert-l)) !important;
 }
 
-.is-color-dark-25,
 .has-text-dark-25 {
-  --bulma-color-l: var(--bulma-dark-25-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-25-l)) !important;
 }
 
-.is-background-dark-25,
 .has-background-dark-25 {
-  --bulma-background-l: var(--bulma-dark-25-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-25-l)) !important;
 }
 
-.is-color-dark-25-invert,
 .has-text-dark-25-invert {
-  --bulma-color-l: var(--bulma-dark-25-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-25-invert-l)) !important;
 }
 
-.is-background-dark-25-invert,
 .has-background-dark-25-invert {
-  --bulma-background-l: var(--bulma-dark-25-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-25-invert-l)) !important;
 }
 
-.is-color-dark-30,
 .has-text-dark-30 {
-  --bulma-color-l: var(--bulma-dark-30-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-30-l)) !important;
 }
 
-.is-background-dark-30,
 .has-background-dark-30 {
-  --bulma-background-l: var(--bulma-dark-30-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-30-l)) !important;
 }
 
-.is-color-dark-30-invert,
 .has-text-dark-30-invert {
-  --bulma-color-l: var(--bulma-dark-30-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-30-invert-l)) !important;
 }
 
-.is-background-dark-30-invert,
 .has-background-dark-30-invert {
-  --bulma-background-l: var(--bulma-dark-30-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-30-invert-l)) !important;
 }
 
-.is-color-dark-35,
 .has-text-dark-35 {
-  --bulma-color-l: var(--bulma-dark-35-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-35-l)) !important;
 }
 
-.is-background-dark-35,
 .has-background-dark-35 {
-  --bulma-background-l: var(--bulma-dark-35-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-35-l)) !important;
 }
 
-.is-color-dark-35-invert,
 .has-text-dark-35-invert {
-  --bulma-color-l: var(--bulma-dark-35-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-35-invert-l)) !important;
 }
 
-.is-background-dark-35-invert,
 .has-background-dark-35-invert {
-  --bulma-background-l: var(--bulma-dark-35-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-35-invert-l)) !important;
 }
 
-.is-color-dark-40,
 .has-text-dark-40 {
-  --bulma-color-l: var(--bulma-dark-40-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-40-l)) !important;
 }
 
-.is-background-dark-40,
 .has-background-dark-40 {
-  --bulma-background-l: var(--bulma-dark-40-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-40-l)) !important;
 }
 
-.is-color-dark-40-invert,
 .has-text-dark-40-invert {
-  --bulma-color-l: var(--bulma-dark-40-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-40-invert-l)) !important;
 }
 
-.is-background-dark-40-invert,
 .has-background-dark-40-invert {
-  --bulma-background-l: var(--bulma-dark-40-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-40-invert-l)) !important;
 }
 
-.is-color-dark-45,
 .has-text-dark-45 {
-  --bulma-color-l: var(--bulma-dark-45-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-45-l)) !important;
 }
 
-.is-background-dark-45,
 .has-background-dark-45 {
-  --bulma-background-l: var(--bulma-dark-45-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-45-l)) !important;
 }
 
-.is-color-dark-45-invert,
 .has-text-dark-45-invert {
-  --bulma-color-l: var(--bulma-dark-45-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-45-invert-l)) !important;
 }
 
-.is-background-dark-45-invert,
 .has-background-dark-45-invert {
-  --bulma-background-l: var(--bulma-dark-45-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-45-invert-l)) !important;
 }
 
-.is-color-dark-50,
 .has-text-dark-50 {
-  --bulma-color-l: var(--bulma-dark-50-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-50-l)) !important;
 }
 
-.is-background-dark-50,
 .has-background-dark-50 {
-  --bulma-background-l: var(--bulma-dark-50-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-50-l)) !important;
 }
 
-.is-color-dark-50-invert,
 .has-text-dark-50-invert {
-  --bulma-color-l: var(--bulma-dark-50-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-50-invert-l)) !important;
 }
 
-.is-background-dark-50-invert,
 .has-background-dark-50-invert {
-  --bulma-background-l: var(--bulma-dark-50-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-50-invert-l)) !important;
 }
 
-.is-color-dark-55,
 .has-text-dark-55 {
-  --bulma-color-l: var(--bulma-dark-55-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-55-l)) !important;
 }
 
-.is-background-dark-55,
 .has-background-dark-55 {
-  --bulma-background-l: var(--bulma-dark-55-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-55-l)) !important;
 }
 
-.is-color-dark-55-invert,
 .has-text-dark-55-invert {
-  --bulma-color-l: var(--bulma-dark-55-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-55-invert-l)) !important;
 }
 
-.is-background-dark-55-invert,
 .has-background-dark-55-invert {
-  --bulma-background-l: var(--bulma-dark-55-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-55-invert-l)) !important;
 }
 
-.is-color-dark-60,
 .has-text-dark-60 {
-  --bulma-color-l: var(--bulma-dark-60-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-60-l)) !important;
 }
 
-.is-background-dark-60,
 .has-background-dark-60 {
-  --bulma-background-l: var(--bulma-dark-60-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-60-l)) !important;
 }
 
-.is-color-dark-60-invert,
 .has-text-dark-60-invert {
-  --bulma-color-l: var(--bulma-dark-60-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-60-invert-l)) !important;
 }
 
-.is-background-dark-60-invert,
 .has-background-dark-60-invert {
-  --bulma-background-l: var(--bulma-dark-60-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-60-invert-l)) !important;
 }
 
-.is-color-dark-65,
 .has-text-dark-65 {
-  --bulma-color-l: var(--bulma-dark-65-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-65-l)) !important;
 }
 
-.is-background-dark-65,
 .has-background-dark-65 {
-  --bulma-background-l: var(--bulma-dark-65-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-65-l)) !important;
 }
 
-.is-color-dark-65-invert,
 .has-text-dark-65-invert {
-  --bulma-color-l: var(--bulma-dark-65-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-65-invert-l)) !important;
 }
 
-.is-background-dark-65-invert,
 .has-background-dark-65-invert {
-  --bulma-background-l: var(--bulma-dark-65-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-65-invert-l)) !important;
 }
 
-.is-color-dark-70,
 .has-text-dark-70 {
-  --bulma-color-l: var(--bulma-dark-70-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-70-l)) !important;
 }
 
-.is-background-dark-70,
 .has-background-dark-70 {
-  --bulma-background-l: var(--bulma-dark-70-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-70-l)) !important;
 }
 
-.is-color-dark-70-invert,
 .has-text-dark-70-invert {
-  --bulma-color-l: var(--bulma-dark-70-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-70-invert-l)) !important;
 }
 
-.is-background-dark-70-invert,
 .has-background-dark-70-invert {
-  --bulma-background-l: var(--bulma-dark-70-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-70-invert-l)) !important;
 }
 
-.is-color-dark-75,
 .has-text-dark-75 {
-  --bulma-color-l: var(--bulma-dark-75-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-75-l)) !important;
 }
 
-.is-background-dark-75,
 .has-background-dark-75 {
-  --bulma-background-l: var(--bulma-dark-75-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-75-l)) !important;
 }
 
-.is-color-dark-75-invert,
 .has-text-dark-75-invert {
-  --bulma-color-l: var(--bulma-dark-75-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-75-invert-l)) !important;
 }
 
-.is-background-dark-75-invert,
 .has-background-dark-75-invert {
-  --bulma-background-l: var(--bulma-dark-75-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-75-invert-l)) !important;
 }
 
-.is-color-dark-80,
 .has-text-dark-80 {
-  --bulma-color-l: var(--bulma-dark-80-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-80-l)) !important;
 }
 
-.is-background-dark-80,
 .has-background-dark-80 {
-  --bulma-background-l: var(--bulma-dark-80-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-80-l)) !important;
 }
 
-.is-color-dark-80-invert,
 .has-text-dark-80-invert {
-  --bulma-color-l: var(--bulma-dark-80-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-80-invert-l)) !important;
 }
 
-.is-background-dark-80-invert,
 .has-background-dark-80-invert {
-  --bulma-background-l: var(--bulma-dark-80-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-80-invert-l)) !important;
 }
 
-.is-color-dark-85,
 .has-text-dark-85 {
-  --bulma-color-l: var(--bulma-dark-85-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-85-l)) !important;
 }
 
-.is-background-dark-85,
 .has-background-dark-85 {
-  --bulma-background-l: var(--bulma-dark-85-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-85-l)) !important;
 }
 
-.is-color-dark-85-invert,
 .has-text-dark-85-invert {
-  --bulma-color-l: var(--bulma-dark-85-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-85-invert-l)) !important;
 }
 
-.is-background-dark-85-invert,
 .has-background-dark-85-invert {
-  --bulma-background-l: var(--bulma-dark-85-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-85-invert-l)) !important;
 }
 
-.is-color-dark-90,
 .has-text-dark-90 {
-  --bulma-color-l: var(--bulma-dark-90-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-90-l)) !important;
 }
 
-.is-background-dark-90,
 .has-background-dark-90 {
-  --bulma-background-l: var(--bulma-dark-90-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-90-l)) !important;
 }
 
-.is-color-dark-90-invert,
 .has-text-dark-90-invert {
-  --bulma-color-l: var(--bulma-dark-90-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-90-invert-l)) !important;
 }
 
-.is-background-dark-90-invert,
 .has-background-dark-90-invert {
-  --bulma-background-l: var(--bulma-dark-90-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-90-invert-l)) !important;
 }
 
-.is-color-dark-95,
 .has-text-dark-95 {
-  --bulma-color-l: var(--bulma-dark-95-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-95-l)) !important;
 }
 
-.is-background-dark-95,
 .has-background-dark-95 {
-  --bulma-background-l: var(--bulma-dark-95-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-95-l)) !important;
 }
 
-.is-color-dark-95-invert,
 .has-text-dark-95-invert {
-  --bulma-color-l: var(--bulma-dark-95-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-95-invert-l)) !important;
 }
 
-.is-background-dark-95-invert,
 .has-background-dark-95-invert {
-  --bulma-background-l: var(--bulma-dark-95-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-95-invert-l)) !important;
 }
 
-.is-color-dark-100,
 .has-text-dark-100 {
-  --bulma-color-l: var(--bulma-dark-100-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-100-l)) !important;
 }
 
-.is-background-dark-100,
 .has-background-dark-100 {
-  --bulma-background-l: var(--bulma-dark-100-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-100-l)) !important;
 }
 
-.is-color-dark-100-invert,
 .has-text-dark-100-invert {
-  --bulma-color-l: var(--bulma-dark-100-invert-l);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-100-invert-l)) !important;
 }
 
-.is-background-dark-100-invert,
 .has-background-dark-100-invert {
-  --bulma-background-l: var(--bulma-dark-100-invert-l);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), var(--bulma-dark-100-invert-l)) !important;
 }
 
-a.is-color-dark:hover, a.is-color-dark:focus-visible,
-button.is-color-dark:hover,
-button.is-color-dark:focus-visible,
-is-color-dark.is-hoverable:hover,
-is-color-dark.is-hoverable:focus-visible,
-a.has-text-dark:hover,
-a.has-text-dark:focus-visible,
+a.has-text-dark:hover, a.has-text-dark:focus-visible,
 button.has-text-dark:hover,
 button.has-text-dark:focus-visible,
 has-text-dark.is-hoverable:hover,
 has-text-dark.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-dark-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-dark:active,
-button.is-color-dark:active,
-is-color-dark.is-hoverable:active,
 a.has-text-dark:active,
 button.has-text-dark:active,
 has-text-dark.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-dark-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-dark:hover, a.is-background-dark:focus-visible,
-button.is-background-dark:hover,
-button.is-background-dark:focus-visible,
-is-background-dark.is-hoverable:hover,
-is-background-dark.is-hoverable:focus-visible,
-a.has-background-dark:hover,
-a.has-background-dark:focus-visible,
+a.has-background-dark:hover, a.has-background-dark:focus-visible,
 button.has-background-dark:hover,
 button.has-background-dark:focus-visible,
 has-background-dark.is-hoverable:hover,
 has-background-dark.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-dark-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-dark:active,
-button.is-background-dark:active,
-is-background-dark.is-hoverable:active,
 a.has-background-dark:active,
 button.has-background-dark:active,
 has-background-dark.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-dark-h), var(--bulma-dark-s), calc(var(--bulma-dark-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-dark {
@@ -16009,582 +16013,454 @@ has-background-dark.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-text],
-[class*=has-text-text] {
-  --bulma-color-l: var(--bulma-text-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-text {
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-l)) !important;
 }
 
-[class*=is-background-text],
-[class*=has-background-text] {
-  --bulma-background-l: var(--bulma-text-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-text {
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-l)) !important;
 }
 
-.is-color-text-invert,
 .has-text-text-invert {
-  --bulma-color-l: var(--bulma-text-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-invert-l)) !important;
 }
 
-.is-background-text-invert,
 .has-background-text-invert {
-  --bulma-background-l: var(--bulma-text-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-invert-l)) !important;
 }
 
-.is-color-text-on-scheme,
 .has-text-text-on-scheme {
-  --bulma-color-l: var(--bulma-text-on-scheme-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-on-scheme-l)) !important;
 }
 
-.is-background-text-on-scheme,
 .has-background-text-on-scheme {
-  --bulma-background-l: var(--bulma-text-on-scheme-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-on-scheme-l)) !important;
 }
 
-.is-color-text-light,
 .has-text-text-light {
-  --bulma-color-l: var(--bulma-text-light-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-light-l)) !important;
 }
 
-.is-background-text-light,
 .has-background-text-light {
-  --bulma-background-l: var(--bulma-text-light-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-light-l)) !important;
 }
 
-.is-color-text-light-invert,
 .has-text-text-light-invert {
-  --bulma-color-l: var(--bulma-text-light-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-light-invert-l)) !important;
 }
 
-.is-background-text-light-invert,
 .has-background-text-light-invert {
-  --bulma-background-l: var(--bulma-text-light-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-light-invert-l)) !important;
 }
 
-.is-color-text-dark,
 .has-text-text-dark {
-  --bulma-color-l: var(--bulma-text-dark-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-dark-l)) !important;
 }
 
-.is-background-text-dark,
 .has-background-text-dark {
-  --bulma-background-l: var(--bulma-text-dark-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-dark-l)) !important;
 }
 
-.is-color-text-dark-invert,
 .has-text-text-dark-invert {
-  --bulma-color-l: var(--bulma-text-dark-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-dark-invert-l)) !important;
 }
 
-.is-background-text-dark-invert,
 .has-background-text-dark-invert {
-  --bulma-background-l: var(--bulma-text-dark-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-dark-invert-l)) !important;
 }
 
-.is-color-text-soft,
 .has-text-text-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-text-soft,
 .has-background-text-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-text-bold,
 .has-text-text-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-text-bold,
 .has-background-text-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-text-soft-invert,
 .has-text-text-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-text-soft-invert,
 .has-background-text-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-text-bold-invert,
 .has-text-text-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-text-bold-invert,
 .has-background-text-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-text-00,
 .has-text-text-00 {
-  --bulma-color-l: var(--bulma-text-00-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-l)) !important;
 }
 
-.is-background-text-00,
 .has-background-text-00 {
-  --bulma-background-l: var(--bulma-text-00-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-l)) !important;
 }
 
-.is-color-text-00-invert,
 .has-text-text-00-invert {
-  --bulma-color-l: var(--bulma-text-00-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-invert-l)) !important;
 }
 
-.is-background-text-00-invert,
 .has-background-text-00-invert {
-  --bulma-background-l: var(--bulma-text-00-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-00-invert-l)) !important;
 }
 
-.is-color-text-05,
 .has-text-text-05 {
-  --bulma-color-l: var(--bulma-text-05-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-05-l)) !important;
 }
 
-.is-background-text-05,
 .has-background-text-05 {
-  --bulma-background-l: var(--bulma-text-05-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-05-l)) !important;
 }
 
-.is-color-text-05-invert,
 .has-text-text-05-invert {
-  --bulma-color-l: var(--bulma-text-05-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-05-invert-l)) !important;
 }
 
-.is-background-text-05-invert,
 .has-background-text-05-invert {
-  --bulma-background-l: var(--bulma-text-05-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-05-invert-l)) !important;
 }
 
-.is-color-text-10,
 .has-text-text-10 {
-  --bulma-color-l: var(--bulma-text-10-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-10-l)) !important;
 }
 
-.is-background-text-10,
 .has-background-text-10 {
-  --bulma-background-l: var(--bulma-text-10-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-10-l)) !important;
 }
 
-.is-color-text-10-invert,
 .has-text-text-10-invert {
-  --bulma-color-l: var(--bulma-text-10-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-10-invert-l)) !important;
 }
 
-.is-background-text-10-invert,
 .has-background-text-10-invert {
-  --bulma-background-l: var(--bulma-text-10-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-10-invert-l)) !important;
 }
 
-.is-color-text-15,
 .has-text-text-15 {
-  --bulma-color-l: var(--bulma-text-15-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-15-l)) !important;
 }
 
-.is-background-text-15,
 .has-background-text-15 {
-  --bulma-background-l: var(--bulma-text-15-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-15-l)) !important;
 }
 
-.is-color-text-15-invert,
 .has-text-text-15-invert {
-  --bulma-color-l: var(--bulma-text-15-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-15-invert-l)) !important;
 }
 
-.is-background-text-15-invert,
 .has-background-text-15-invert {
-  --bulma-background-l: var(--bulma-text-15-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-15-invert-l)) !important;
 }
 
-.is-color-text-20,
 .has-text-text-20 {
-  --bulma-color-l: var(--bulma-text-20-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-20-l)) !important;
 }
 
-.is-background-text-20,
 .has-background-text-20 {
-  --bulma-background-l: var(--bulma-text-20-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-20-l)) !important;
 }
 
-.is-color-text-20-invert,
 .has-text-text-20-invert {
-  --bulma-color-l: var(--bulma-text-20-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-20-invert-l)) !important;
 }
 
-.is-background-text-20-invert,
 .has-background-text-20-invert {
-  --bulma-background-l: var(--bulma-text-20-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-20-invert-l)) !important;
 }
 
-.is-color-text-25,
 .has-text-text-25 {
-  --bulma-color-l: var(--bulma-text-25-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-25-l)) !important;
 }
 
-.is-background-text-25,
 .has-background-text-25 {
-  --bulma-background-l: var(--bulma-text-25-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-25-l)) !important;
 }
 
-.is-color-text-25-invert,
 .has-text-text-25-invert {
-  --bulma-color-l: var(--bulma-text-25-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-25-invert-l)) !important;
 }
 
-.is-background-text-25-invert,
 .has-background-text-25-invert {
-  --bulma-background-l: var(--bulma-text-25-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-25-invert-l)) !important;
 }
 
-.is-color-text-30,
 .has-text-text-30 {
-  --bulma-color-l: var(--bulma-text-30-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-30-l)) !important;
 }
 
-.is-background-text-30,
 .has-background-text-30 {
-  --bulma-background-l: var(--bulma-text-30-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-30-l)) !important;
 }
 
-.is-color-text-30-invert,
 .has-text-text-30-invert {
-  --bulma-color-l: var(--bulma-text-30-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-30-invert-l)) !important;
 }
 
-.is-background-text-30-invert,
 .has-background-text-30-invert {
-  --bulma-background-l: var(--bulma-text-30-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-30-invert-l)) !important;
 }
 
-.is-color-text-35,
 .has-text-text-35 {
-  --bulma-color-l: var(--bulma-text-35-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-35-l)) !important;
 }
 
-.is-background-text-35,
 .has-background-text-35 {
-  --bulma-background-l: var(--bulma-text-35-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-35-l)) !important;
 }
 
-.is-color-text-35-invert,
 .has-text-text-35-invert {
-  --bulma-color-l: var(--bulma-text-35-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-35-invert-l)) !important;
 }
 
-.is-background-text-35-invert,
 .has-background-text-35-invert {
-  --bulma-background-l: var(--bulma-text-35-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-35-invert-l)) !important;
 }
 
-.is-color-text-40,
 .has-text-text-40 {
-  --bulma-color-l: var(--bulma-text-40-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-40-l)) !important;
 }
 
-.is-background-text-40,
 .has-background-text-40 {
-  --bulma-background-l: var(--bulma-text-40-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-40-l)) !important;
 }
 
-.is-color-text-40-invert,
 .has-text-text-40-invert {
-  --bulma-color-l: var(--bulma-text-40-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-40-invert-l)) !important;
 }
 
-.is-background-text-40-invert,
 .has-background-text-40-invert {
-  --bulma-background-l: var(--bulma-text-40-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-40-invert-l)) !important;
 }
 
-.is-color-text-45,
 .has-text-text-45 {
-  --bulma-color-l: var(--bulma-text-45-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-45-l)) !important;
 }
 
-.is-background-text-45,
 .has-background-text-45 {
-  --bulma-background-l: var(--bulma-text-45-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-45-l)) !important;
 }
 
-.is-color-text-45-invert,
 .has-text-text-45-invert {
-  --bulma-color-l: var(--bulma-text-45-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-45-invert-l)) !important;
 }
 
-.is-background-text-45-invert,
 .has-background-text-45-invert {
-  --bulma-background-l: var(--bulma-text-45-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-45-invert-l)) !important;
 }
 
-.is-color-text-50,
 .has-text-text-50 {
-  --bulma-color-l: var(--bulma-text-50-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-50-l)) !important;
 }
 
-.is-background-text-50,
 .has-background-text-50 {
-  --bulma-background-l: var(--bulma-text-50-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-50-l)) !important;
 }
 
-.is-color-text-50-invert,
 .has-text-text-50-invert {
-  --bulma-color-l: var(--bulma-text-50-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-50-invert-l)) !important;
 }
 
-.is-background-text-50-invert,
 .has-background-text-50-invert {
-  --bulma-background-l: var(--bulma-text-50-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-50-invert-l)) !important;
 }
 
-.is-color-text-55,
 .has-text-text-55 {
-  --bulma-color-l: var(--bulma-text-55-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-55-l)) !important;
 }
 
-.is-background-text-55,
 .has-background-text-55 {
-  --bulma-background-l: var(--bulma-text-55-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-55-l)) !important;
 }
 
-.is-color-text-55-invert,
 .has-text-text-55-invert {
-  --bulma-color-l: var(--bulma-text-55-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-55-invert-l)) !important;
 }
 
-.is-background-text-55-invert,
 .has-background-text-55-invert {
-  --bulma-background-l: var(--bulma-text-55-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-55-invert-l)) !important;
 }
 
-.is-color-text-60,
 .has-text-text-60 {
-  --bulma-color-l: var(--bulma-text-60-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-60-l)) !important;
 }
 
-.is-background-text-60,
 .has-background-text-60 {
-  --bulma-background-l: var(--bulma-text-60-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-60-l)) !important;
 }
 
-.is-color-text-60-invert,
 .has-text-text-60-invert {
-  --bulma-color-l: var(--bulma-text-60-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-60-invert-l)) !important;
 }
 
-.is-background-text-60-invert,
 .has-background-text-60-invert {
-  --bulma-background-l: var(--bulma-text-60-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-60-invert-l)) !important;
 }
 
-.is-color-text-65,
 .has-text-text-65 {
-  --bulma-color-l: var(--bulma-text-65-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-65-l)) !important;
 }
 
-.is-background-text-65,
 .has-background-text-65 {
-  --bulma-background-l: var(--bulma-text-65-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-65-l)) !important;
 }
 
-.is-color-text-65-invert,
 .has-text-text-65-invert {
-  --bulma-color-l: var(--bulma-text-65-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-65-invert-l)) !important;
 }
 
-.is-background-text-65-invert,
 .has-background-text-65-invert {
-  --bulma-background-l: var(--bulma-text-65-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-65-invert-l)) !important;
 }
 
-.is-color-text-70,
 .has-text-text-70 {
-  --bulma-color-l: var(--bulma-text-70-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-70-l)) !important;
 }
 
-.is-background-text-70,
 .has-background-text-70 {
-  --bulma-background-l: var(--bulma-text-70-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-70-l)) !important;
 }
 
-.is-color-text-70-invert,
 .has-text-text-70-invert {
-  --bulma-color-l: var(--bulma-text-70-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-70-invert-l)) !important;
 }
 
-.is-background-text-70-invert,
 .has-background-text-70-invert {
-  --bulma-background-l: var(--bulma-text-70-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-70-invert-l)) !important;
 }
 
-.is-color-text-75,
 .has-text-text-75 {
-  --bulma-color-l: var(--bulma-text-75-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-75-l)) !important;
 }
 
-.is-background-text-75,
 .has-background-text-75 {
-  --bulma-background-l: var(--bulma-text-75-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-75-l)) !important;
 }
 
-.is-color-text-75-invert,
 .has-text-text-75-invert {
-  --bulma-color-l: var(--bulma-text-75-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-75-invert-l)) !important;
 }
 
-.is-background-text-75-invert,
 .has-background-text-75-invert {
-  --bulma-background-l: var(--bulma-text-75-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-75-invert-l)) !important;
 }
 
-.is-color-text-80,
 .has-text-text-80 {
-  --bulma-color-l: var(--bulma-text-80-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-80-l)) !important;
 }
 
-.is-background-text-80,
 .has-background-text-80 {
-  --bulma-background-l: var(--bulma-text-80-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-80-l)) !important;
 }
 
-.is-color-text-80-invert,
 .has-text-text-80-invert {
-  --bulma-color-l: var(--bulma-text-80-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-80-invert-l)) !important;
 }
 
-.is-background-text-80-invert,
 .has-background-text-80-invert {
-  --bulma-background-l: var(--bulma-text-80-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-80-invert-l)) !important;
 }
 
-.is-color-text-85,
 .has-text-text-85 {
-  --bulma-color-l: var(--bulma-text-85-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-85-l)) !important;
 }
 
-.is-background-text-85,
 .has-background-text-85 {
-  --bulma-background-l: var(--bulma-text-85-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-85-l)) !important;
 }
 
-.is-color-text-85-invert,
 .has-text-text-85-invert {
-  --bulma-color-l: var(--bulma-text-85-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-85-invert-l)) !important;
 }
 
-.is-background-text-85-invert,
 .has-background-text-85-invert {
-  --bulma-background-l: var(--bulma-text-85-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-85-invert-l)) !important;
 }
 
-.is-color-text-90,
 .has-text-text-90 {
-  --bulma-color-l: var(--bulma-text-90-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-90-l)) !important;
 }
 
-.is-background-text-90,
 .has-background-text-90 {
-  --bulma-background-l: var(--bulma-text-90-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-90-l)) !important;
 }
 
-.is-color-text-90-invert,
 .has-text-text-90-invert {
-  --bulma-color-l: var(--bulma-text-90-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-90-invert-l)) !important;
 }
 
-.is-background-text-90-invert,
 .has-background-text-90-invert {
-  --bulma-background-l: var(--bulma-text-90-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-90-invert-l)) !important;
 }
 
-.is-color-text-95,
 .has-text-text-95 {
-  --bulma-color-l: var(--bulma-text-95-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-l)) !important;
 }
 
-.is-background-text-95,
 .has-background-text-95 {
-  --bulma-background-l: var(--bulma-text-95-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-l)) !important;
 }
 
-.is-color-text-95-invert,
 .has-text-text-95-invert {
-  --bulma-color-l: var(--bulma-text-95-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-invert-l)) !important;
 }
 
-.is-background-text-95-invert,
 .has-background-text-95-invert {
-  --bulma-background-l: var(--bulma-text-95-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-95-invert-l)) !important;
 }
 
-.is-color-text-100,
 .has-text-text-100 {
-  --bulma-color-l: var(--bulma-text-100-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-l)) !important;
 }
 
-.is-background-text-100,
 .has-background-text-100 {
-  --bulma-background-l: var(--bulma-text-100-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-l)) !important;
 }
 
-.is-color-text-100-invert,
 .has-text-text-100-invert {
-  --bulma-color-l: var(--bulma-text-100-invert-l);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-invert-l)) !important;
 }
 
-.is-background-text-100-invert,
 .has-background-text-100-invert {
-  --bulma-background-l: var(--bulma-text-100-invert-l);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), var(--bulma-text-100-invert-l)) !important;
 }
 
-a.is-color-text:hover, a.is-color-text:focus-visible,
-button.is-color-text:hover,
-button.is-color-text:focus-visible,
-is-color-text.is-hoverable:hover,
-is-color-text.is-hoverable:focus-visible,
-a.has-text-text:hover,
-a.has-text-text:focus-visible,
+a.has-text-text:hover, a.has-text-text:focus-visible,
 button.has-text-text:hover,
 button.has-text-text:focus-visible,
 has-text-text.is-hoverable:hover,
 has-text-text.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-text-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-text:active,
-button.is-color-text:active,
-is-color-text.is-hoverable:active,
 a.has-text-text:active,
 button.has-text-text:active,
 has-text-text.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-text-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-text:hover, a.is-background-text:focus-visible,
-button.is-background-text:hover,
-button.is-background-text:focus-visible,
-is-background-text.is-hoverable:hover,
-is-background-text.is-hoverable:focus-visible,
-a.has-background-text:hover,
-a.has-background-text:focus-visible,
+a.has-background-text:hover, a.has-background-text:focus-visible,
 button.has-background-text:hover,
 button.has-background-text:focus-visible,
 has-background-text.is-hoverable:hover,
 has-background-text.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-text-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-text:active,
-button.is-background-text:active,
-is-background-text.is-hoverable:active,
 a.has-background-text:active,
 button.has-background-text:active,
 has-background-text.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-text-h), var(--bulma-text-s), calc(var(--bulma-text-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-text {
@@ -16636,582 +16512,454 @@ has-background-text.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-primary],
-[class*=has-text-primary] {
-  --bulma-color-l: var(--bulma-primary-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-primary {
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) !important;
 }
 
-[class*=is-background-primary],
-[class*=has-background-primary] {
-  --bulma-background-l: var(--bulma-primary-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-primary {
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-l)) !important;
 }
 
-.is-color-primary-invert,
 .has-text-primary-invert {
-  --bulma-color-l: var(--bulma-primary-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-invert-l)) !important;
 }
 
-.is-background-primary-invert,
 .has-background-primary-invert {
-  --bulma-background-l: var(--bulma-primary-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-invert-l)) !important;
 }
 
-.is-color-primary-on-scheme,
 .has-text-primary-on-scheme {
-  --bulma-color-l: var(--bulma-primary-on-scheme-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-on-scheme-l)) !important;
 }
 
-.is-background-primary-on-scheme,
 .has-background-primary-on-scheme {
-  --bulma-background-l: var(--bulma-primary-on-scheme-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-on-scheme-l)) !important;
 }
 
-.is-color-primary-light,
 .has-text-primary-light {
-  --bulma-color-l: var(--bulma-primary-light-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-light-l)) !important;
 }
 
-.is-background-primary-light,
 .has-background-primary-light {
-  --bulma-background-l: var(--bulma-primary-light-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-light-l)) !important;
 }
 
-.is-color-primary-light-invert,
 .has-text-primary-light-invert {
-  --bulma-color-l: var(--bulma-primary-light-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-light-invert-l)) !important;
 }
 
-.is-background-primary-light-invert,
 .has-background-primary-light-invert {
-  --bulma-background-l: var(--bulma-primary-light-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-light-invert-l)) !important;
 }
 
-.is-color-primary-dark,
 .has-text-primary-dark {
-  --bulma-color-l: var(--bulma-primary-dark-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-dark-l)) !important;
 }
 
-.is-background-primary-dark,
 .has-background-primary-dark {
-  --bulma-background-l: var(--bulma-primary-dark-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-dark-l)) !important;
 }
 
-.is-color-primary-dark-invert,
 .has-text-primary-dark-invert {
-  --bulma-color-l: var(--bulma-primary-dark-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-dark-invert-l)) !important;
 }
 
-.is-background-primary-dark-invert,
 .has-background-primary-dark-invert {
-  --bulma-background-l: var(--bulma-primary-dark-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-dark-invert-l)) !important;
 }
 
-.is-color-primary-soft,
 .has-text-primary-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-primary-soft,
 .has-background-primary-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-primary-bold,
 .has-text-primary-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-primary-bold,
 .has-background-primary-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-primary-soft-invert,
 .has-text-primary-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-primary-soft-invert,
 .has-background-primary-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-primary-bold-invert,
 .has-text-primary-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-primary-bold-invert,
 .has-background-primary-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-primary-00,
 .has-text-primary-00 {
-  --bulma-color-l: var(--bulma-primary-00-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-00-l)) !important;
 }
 
-.is-background-primary-00,
 .has-background-primary-00 {
-  --bulma-background-l: var(--bulma-primary-00-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-00-l)) !important;
 }
 
-.is-color-primary-00-invert,
 .has-text-primary-00-invert {
-  --bulma-color-l: var(--bulma-primary-00-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-00-invert-l)) !important;
 }
 
-.is-background-primary-00-invert,
 .has-background-primary-00-invert {
-  --bulma-background-l: var(--bulma-primary-00-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-00-invert-l)) !important;
 }
 
-.is-color-primary-05,
 .has-text-primary-05 {
-  --bulma-color-l: var(--bulma-primary-05-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-05-l)) !important;
 }
 
-.is-background-primary-05,
 .has-background-primary-05 {
-  --bulma-background-l: var(--bulma-primary-05-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-05-l)) !important;
 }
 
-.is-color-primary-05-invert,
 .has-text-primary-05-invert {
-  --bulma-color-l: var(--bulma-primary-05-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-05-invert-l)) !important;
 }
 
-.is-background-primary-05-invert,
 .has-background-primary-05-invert {
-  --bulma-background-l: var(--bulma-primary-05-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-05-invert-l)) !important;
 }
 
-.is-color-primary-10,
 .has-text-primary-10 {
-  --bulma-color-l: var(--bulma-primary-10-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-10-l)) !important;
 }
 
-.is-background-primary-10,
 .has-background-primary-10 {
-  --bulma-background-l: var(--bulma-primary-10-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-10-l)) !important;
 }
 
-.is-color-primary-10-invert,
 .has-text-primary-10-invert {
-  --bulma-color-l: var(--bulma-primary-10-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-10-invert-l)) !important;
 }
 
-.is-background-primary-10-invert,
 .has-background-primary-10-invert {
-  --bulma-background-l: var(--bulma-primary-10-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-10-invert-l)) !important;
 }
 
-.is-color-primary-15,
 .has-text-primary-15 {
-  --bulma-color-l: var(--bulma-primary-15-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-15-l)) !important;
 }
 
-.is-background-primary-15,
 .has-background-primary-15 {
-  --bulma-background-l: var(--bulma-primary-15-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-15-l)) !important;
 }
 
-.is-color-primary-15-invert,
 .has-text-primary-15-invert {
-  --bulma-color-l: var(--bulma-primary-15-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-15-invert-l)) !important;
 }
 
-.is-background-primary-15-invert,
 .has-background-primary-15-invert {
-  --bulma-background-l: var(--bulma-primary-15-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-15-invert-l)) !important;
 }
 
-.is-color-primary-20,
 .has-text-primary-20 {
-  --bulma-color-l: var(--bulma-primary-20-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-20-l)) !important;
 }
 
-.is-background-primary-20,
 .has-background-primary-20 {
-  --bulma-background-l: var(--bulma-primary-20-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-20-l)) !important;
 }
 
-.is-color-primary-20-invert,
 .has-text-primary-20-invert {
-  --bulma-color-l: var(--bulma-primary-20-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-20-invert-l)) !important;
 }
 
-.is-background-primary-20-invert,
 .has-background-primary-20-invert {
-  --bulma-background-l: var(--bulma-primary-20-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-20-invert-l)) !important;
 }
 
-.is-color-primary-25,
 .has-text-primary-25 {
-  --bulma-color-l: var(--bulma-primary-25-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-25-l)) !important;
 }
 
-.is-background-primary-25,
 .has-background-primary-25 {
-  --bulma-background-l: var(--bulma-primary-25-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-25-l)) !important;
 }
 
-.is-color-primary-25-invert,
 .has-text-primary-25-invert {
-  --bulma-color-l: var(--bulma-primary-25-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-25-invert-l)) !important;
 }
 
-.is-background-primary-25-invert,
 .has-background-primary-25-invert {
-  --bulma-background-l: var(--bulma-primary-25-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-25-invert-l)) !important;
 }
 
-.is-color-primary-30,
 .has-text-primary-30 {
-  --bulma-color-l: var(--bulma-primary-30-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-30-l)) !important;
 }
 
-.is-background-primary-30,
 .has-background-primary-30 {
-  --bulma-background-l: var(--bulma-primary-30-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-30-l)) !important;
 }
 
-.is-color-primary-30-invert,
 .has-text-primary-30-invert {
-  --bulma-color-l: var(--bulma-primary-30-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-30-invert-l)) !important;
 }
 
-.is-background-primary-30-invert,
 .has-background-primary-30-invert {
-  --bulma-background-l: var(--bulma-primary-30-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-30-invert-l)) !important;
 }
 
-.is-color-primary-35,
 .has-text-primary-35 {
-  --bulma-color-l: var(--bulma-primary-35-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-35-l)) !important;
 }
 
-.is-background-primary-35,
 .has-background-primary-35 {
-  --bulma-background-l: var(--bulma-primary-35-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-35-l)) !important;
 }
 
-.is-color-primary-35-invert,
 .has-text-primary-35-invert {
-  --bulma-color-l: var(--bulma-primary-35-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-35-invert-l)) !important;
 }
 
-.is-background-primary-35-invert,
 .has-background-primary-35-invert {
-  --bulma-background-l: var(--bulma-primary-35-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-35-invert-l)) !important;
 }
 
-.is-color-primary-40,
 .has-text-primary-40 {
-  --bulma-color-l: var(--bulma-primary-40-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-40-l)) !important;
 }
 
-.is-background-primary-40,
 .has-background-primary-40 {
-  --bulma-background-l: var(--bulma-primary-40-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-40-l)) !important;
 }
 
-.is-color-primary-40-invert,
 .has-text-primary-40-invert {
-  --bulma-color-l: var(--bulma-primary-40-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-40-invert-l)) !important;
 }
 
-.is-background-primary-40-invert,
 .has-background-primary-40-invert {
-  --bulma-background-l: var(--bulma-primary-40-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-40-invert-l)) !important;
 }
 
-.is-color-primary-45,
 .has-text-primary-45 {
-  --bulma-color-l: var(--bulma-primary-45-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-45-l)) !important;
 }
 
-.is-background-primary-45,
 .has-background-primary-45 {
-  --bulma-background-l: var(--bulma-primary-45-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-45-l)) !important;
 }
 
-.is-color-primary-45-invert,
 .has-text-primary-45-invert {
-  --bulma-color-l: var(--bulma-primary-45-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-45-invert-l)) !important;
 }
 
-.is-background-primary-45-invert,
 .has-background-primary-45-invert {
-  --bulma-background-l: var(--bulma-primary-45-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-45-invert-l)) !important;
 }
 
-.is-color-primary-50,
 .has-text-primary-50 {
-  --bulma-color-l: var(--bulma-primary-50-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-50-l)) !important;
 }
 
-.is-background-primary-50,
 .has-background-primary-50 {
-  --bulma-background-l: var(--bulma-primary-50-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-50-l)) !important;
 }
 
-.is-color-primary-50-invert,
 .has-text-primary-50-invert {
-  --bulma-color-l: var(--bulma-primary-50-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-50-invert-l)) !important;
 }
 
-.is-background-primary-50-invert,
 .has-background-primary-50-invert {
-  --bulma-background-l: var(--bulma-primary-50-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-50-invert-l)) !important;
 }
 
-.is-color-primary-55,
 .has-text-primary-55 {
-  --bulma-color-l: var(--bulma-primary-55-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-55-l)) !important;
 }
 
-.is-background-primary-55,
 .has-background-primary-55 {
-  --bulma-background-l: var(--bulma-primary-55-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-55-l)) !important;
 }
 
-.is-color-primary-55-invert,
 .has-text-primary-55-invert {
-  --bulma-color-l: var(--bulma-primary-55-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-55-invert-l)) !important;
 }
 
-.is-background-primary-55-invert,
 .has-background-primary-55-invert {
-  --bulma-background-l: var(--bulma-primary-55-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-55-invert-l)) !important;
 }
 
-.is-color-primary-60,
 .has-text-primary-60 {
-  --bulma-color-l: var(--bulma-primary-60-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-60-l)) !important;
 }
 
-.is-background-primary-60,
 .has-background-primary-60 {
-  --bulma-background-l: var(--bulma-primary-60-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-60-l)) !important;
 }
 
-.is-color-primary-60-invert,
 .has-text-primary-60-invert {
-  --bulma-color-l: var(--bulma-primary-60-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-60-invert-l)) !important;
 }
 
-.is-background-primary-60-invert,
 .has-background-primary-60-invert {
-  --bulma-background-l: var(--bulma-primary-60-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-60-invert-l)) !important;
 }
 
-.is-color-primary-65,
 .has-text-primary-65 {
-  --bulma-color-l: var(--bulma-primary-65-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-65-l)) !important;
 }
 
-.is-background-primary-65,
 .has-background-primary-65 {
-  --bulma-background-l: var(--bulma-primary-65-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-65-l)) !important;
 }
 
-.is-color-primary-65-invert,
 .has-text-primary-65-invert {
-  --bulma-color-l: var(--bulma-primary-65-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-65-invert-l)) !important;
 }
 
-.is-background-primary-65-invert,
 .has-background-primary-65-invert {
-  --bulma-background-l: var(--bulma-primary-65-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-65-invert-l)) !important;
 }
 
-.is-color-primary-70,
 .has-text-primary-70 {
-  --bulma-color-l: var(--bulma-primary-70-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-70-l)) !important;
 }
 
-.is-background-primary-70,
 .has-background-primary-70 {
-  --bulma-background-l: var(--bulma-primary-70-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-70-l)) !important;
 }
 
-.is-color-primary-70-invert,
 .has-text-primary-70-invert {
-  --bulma-color-l: var(--bulma-primary-70-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-70-invert-l)) !important;
 }
 
-.is-background-primary-70-invert,
 .has-background-primary-70-invert {
-  --bulma-background-l: var(--bulma-primary-70-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-70-invert-l)) !important;
 }
 
-.is-color-primary-75,
 .has-text-primary-75 {
-  --bulma-color-l: var(--bulma-primary-75-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-75-l)) !important;
 }
 
-.is-background-primary-75,
 .has-background-primary-75 {
-  --bulma-background-l: var(--bulma-primary-75-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-75-l)) !important;
 }
 
-.is-color-primary-75-invert,
 .has-text-primary-75-invert {
-  --bulma-color-l: var(--bulma-primary-75-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-75-invert-l)) !important;
 }
 
-.is-background-primary-75-invert,
 .has-background-primary-75-invert {
-  --bulma-background-l: var(--bulma-primary-75-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-75-invert-l)) !important;
 }
 
-.is-color-primary-80,
 .has-text-primary-80 {
-  --bulma-color-l: var(--bulma-primary-80-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-80-l)) !important;
 }
 
-.is-background-primary-80,
 .has-background-primary-80 {
-  --bulma-background-l: var(--bulma-primary-80-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-80-l)) !important;
 }
 
-.is-color-primary-80-invert,
 .has-text-primary-80-invert {
-  --bulma-color-l: var(--bulma-primary-80-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-80-invert-l)) !important;
 }
 
-.is-background-primary-80-invert,
 .has-background-primary-80-invert {
-  --bulma-background-l: var(--bulma-primary-80-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-80-invert-l)) !important;
 }
 
-.is-color-primary-85,
 .has-text-primary-85 {
-  --bulma-color-l: var(--bulma-primary-85-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-85-l)) !important;
 }
 
-.is-background-primary-85,
 .has-background-primary-85 {
-  --bulma-background-l: var(--bulma-primary-85-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-85-l)) !important;
 }
 
-.is-color-primary-85-invert,
 .has-text-primary-85-invert {
-  --bulma-color-l: var(--bulma-primary-85-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-85-invert-l)) !important;
 }
 
-.is-background-primary-85-invert,
 .has-background-primary-85-invert {
-  --bulma-background-l: var(--bulma-primary-85-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-85-invert-l)) !important;
 }
 
-.is-color-primary-90,
 .has-text-primary-90 {
-  --bulma-color-l: var(--bulma-primary-90-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-90-l)) !important;
 }
 
-.is-background-primary-90,
 .has-background-primary-90 {
-  --bulma-background-l: var(--bulma-primary-90-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-90-l)) !important;
 }
 
-.is-color-primary-90-invert,
 .has-text-primary-90-invert {
-  --bulma-color-l: var(--bulma-primary-90-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-90-invert-l)) !important;
 }
 
-.is-background-primary-90-invert,
 .has-background-primary-90-invert {
-  --bulma-background-l: var(--bulma-primary-90-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-90-invert-l)) !important;
 }
 
-.is-color-primary-95,
 .has-text-primary-95 {
-  --bulma-color-l: var(--bulma-primary-95-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-95-l)) !important;
 }
 
-.is-background-primary-95,
 .has-background-primary-95 {
-  --bulma-background-l: var(--bulma-primary-95-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-95-l)) !important;
 }
 
-.is-color-primary-95-invert,
 .has-text-primary-95-invert {
-  --bulma-color-l: var(--bulma-primary-95-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-95-invert-l)) !important;
 }
 
-.is-background-primary-95-invert,
 .has-background-primary-95-invert {
-  --bulma-background-l: var(--bulma-primary-95-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-95-invert-l)) !important;
 }
 
-.is-color-primary-100,
 .has-text-primary-100 {
-  --bulma-color-l: var(--bulma-primary-100-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-100-l)) !important;
 }
 
-.is-background-primary-100,
 .has-background-primary-100 {
-  --bulma-background-l: var(--bulma-primary-100-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-100-l)) !important;
 }
 
-.is-color-primary-100-invert,
 .has-text-primary-100-invert {
-  --bulma-color-l: var(--bulma-primary-100-invert-l);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-100-invert-l)) !important;
 }
 
-.is-background-primary-100-invert,
 .has-background-primary-100-invert {
-  --bulma-background-l: var(--bulma-primary-100-invert-l);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), var(--bulma-primary-100-invert-l)) !important;
 }
 
-a.is-color-primary:hover, a.is-color-primary:focus-visible,
-button.is-color-primary:hover,
-button.is-color-primary:focus-visible,
-is-color-primary.is-hoverable:hover,
-is-color-primary.is-hoverable:focus-visible,
-a.has-text-primary:hover,
-a.has-text-primary:focus-visible,
+a.has-text-primary:hover, a.has-text-primary:focus-visible,
 button.has-text-primary:hover,
 button.has-text-primary:focus-visible,
 has-text-primary.is-hoverable:hover,
 has-text-primary.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-primary-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-primary:active,
-button.is-color-primary:active,
-is-color-primary.is-hoverable:active,
 a.has-text-primary:active,
 button.has-text-primary:active,
 has-text-primary.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-primary-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-primary:hover, a.is-background-primary:focus-visible,
-button.is-background-primary:hover,
-button.is-background-primary:focus-visible,
-is-background-primary.is-hoverable:hover,
-is-background-primary.is-hoverable:focus-visible,
-a.has-background-primary:hover,
-a.has-background-primary:focus-visible,
+a.has-background-primary:hover, a.has-background-primary:focus-visible,
 button.has-background-primary:hover,
 button.has-background-primary:focus-visible,
 has-background-primary.is-hoverable:hover,
 has-background-primary.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-primary-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-primary:active,
-button.is-background-primary:active,
-is-background-primary.is-hoverable:active,
 a.has-background-primary:active,
 button.has-background-primary:active,
 has-background-primary.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-primary-h), var(--bulma-primary-s), calc(var(--bulma-primary-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-primary {
@@ -17263,582 +17011,454 @@ has-background-primary.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-link],
-[class*=has-text-link] {
-  --bulma-color-l: var(--bulma-link-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-link {
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-l)) !important;
 }
 
-[class*=is-background-link],
-[class*=has-background-link] {
-  --bulma-background-l: var(--bulma-link-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-link {
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-l)) !important;
 }
 
-.is-color-link-invert,
 .has-text-link-invert {
-  --bulma-color-l: var(--bulma-link-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-invert-l)) !important;
 }
 
-.is-background-link-invert,
 .has-background-link-invert {
-  --bulma-background-l: var(--bulma-link-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-invert-l)) !important;
 }
 
-.is-color-link-on-scheme,
 .has-text-link-on-scheme {
-  --bulma-color-l: var(--bulma-link-on-scheme-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-on-scheme-l)) !important;
 }
 
-.is-background-link-on-scheme,
 .has-background-link-on-scheme {
-  --bulma-background-l: var(--bulma-link-on-scheme-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-on-scheme-l)) !important;
 }
 
-.is-color-link-light,
 .has-text-link-light {
-  --bulma-color-l: var(--bulma-link-light-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-light-l)) !important;
 }
 
-.is-background-link-light,
 .has-background-link-light {
-  --bulma-background-l: var(--bulma-link-light-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-light-l)) !important;
 }
 
-.is-color-link-light-invert,
 .has-text-link-light-invert {
-  --bulma-color-l: var(--bulma-link-light-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-light-invert-l)) !important;
 }
 
-.is-background-link-light-invert,
 .has-background-link-light-invert {
-  --bulma-background-l: var(--bulma-link-light-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-light-invert-l)) !important;
 }
 
-.is-color-link-dark,
 .has-text-link-dark {
-  --bulma-color-l: var(--bulma-link-dark-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-dark-l)) !important;
 }
 
-.is-background-link-dark,
 .has-background-link-dark {
-  --bulma-background-l: var(--bulma-link-dark-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-dark-l)) !important;
 }
 
-.is-color-link-dark-invert,
 .has-text-link-dark-invert {
-  --bulma-color-l: var(--bulma-link-dark-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-dark-invert-l)) !important;
 }
 
-.is-background-link-dark-invert,
 .has-background-link-dark-invert {
-  --bulma-background-l: var(--bulma-link-dark-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-dark-invert-l)) !important;
 }
 
-.is-color-link-soft,
 .has-text-link-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-link-soft,
 .has-background-link-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-link-bold,
 .has-text-link-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-link-bold,
 .has-background-link-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-link-soft-invert,
 .has-text-link-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-link-soft-invert,
 .has-background-link-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-link-bold-invert,
 .has-text-link-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-link-bold-invert,
 .has-background-link-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-link-00,
 .has-text-link-00 {
-  --bulma-color-l: var(--bulma-link-00-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-l)) !important;
 }
 
-.is-background-link-00,
 .has-background-link-00 {
-  --bulma-background-l: var(--bulma-link-00-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-l)) !important;
 }
 
-.is-color-link-00-invert,
 .has-text-link-00-invert {
-  --bulma-color-l: var(--bulma-link-00-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-invert-l)) !important;
 }
 
-.is-background-link-00-invert,
 .has-background-link-00-invert {
-  --bulma-background-l: var(--bulma-link-00-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-00-invert-l)) !important;
 }
 
-.is-color-link-05,
 .has-text-link-05 {
-  --bulma-color-l: var(--bulma-link-05-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-05-l)) !important;
 }
 
-.is-background-link-05,
 .has-background-link-05 {
-  --bulma-background-l: var(--bulma-link-05-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-05-l)) !important;
 }
 
-.is-color-link-05-invert,
 .has-text-link-05-invert {
-  --bulma-color-l: var(--bulma-link-05-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-05-invert-l)) !important;
 }
 
-.is-background-link-05-invert,
 .has-background-link-05-invert {
-  --bulma-background-l: var(--bulma-link-05-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-05-invert-l)) !important;
 }
 
-.is-color-link-10,
 .has-text-link-10 {
-  --bulma-color-l: var(--bulma-link-10-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-10-l)) !important;
 }
 
-.is-background-link-10,
 .has-background-link-10 {
-  --bulma-background-l: var(--bulma-link-10-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-10-l)) !important;
 }
 
-.is-color-link-10-invert,
 .has-text-link-10-invert {
-  --bulma-color-l: var(--bulma-link-10-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-10-invert-l)) !important;
 }
 
-.is-background-link-10-invert,
 .has-background-link-10-invert {
-  --bulma-background-l: var(--bulma-link-10-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-10-invert-l)) !important;
 }
 
-.is-color-link-15,
 .has-text-link-15 {
-  --bulma-color-l: var(--bulma-link-15-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-15-l)) !important;
 }
 
-.is-background-link-15,
 .has-background-link-15 {
-  --bulma-background-l: var(--bulma-link-15-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-15-l)) !important;
 }
 
-.is-color-link-15-invert,
 .has-text-link-15-invert {
-  --bulma-color-l: var(--bulma-link-15-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-15-invert-l)) !important;
 }
 
-.is-background-link-15-invert,
 .has-background-link-15-invert {
-  --bulma-background-l: var(--bulma-link-15-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-15-invert-l)) !important;
 }
 
-.is-color-link-20,
 .has-text-link-20 {
-  --bulma-color-l: var(--bulma-link-20-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-20-l)) !important;
 }
 
-.is-background-link-20,
 .has-background-link-20 {
-  --bulma-background-l: var(--bulma-link-20-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-20-l)) !important;
 }
 
-.is-color-link-20-invert,
 .has-text-link-20-invert {
-  --bulma-color-l: var(--bulma-link-20-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-20-invert-l)) !important;
 }
 
-.is-background-link-20-invert,
 .has-background-link-20-invert {
-  --bulma-background-l: var(--bulma-link-20-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-20-invert-l)) !important;
 }
 
-.is-color-link-25,
 .has-text-link-25 {
-  --bulma-color-l: var(--bulma-link-25-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-25-l)) !important;
 }
 
-.is-background-link-25,
 .has-background-link-25 {
-  --bulma-background-l: var(--bulma-link-25-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-25-l)) !important;
 }
 
-.is-color-link-25-invert,
 .has-text-link-25-invert {
-  --bulma-color-l: var(--bulma-link-25-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-25-invert-l)) !important;
 }
 
-.is-background-link-25-invert,
 .has-background-link-25-invert {
-  --bulma-background-l: var(--bulma-link-25-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-25-invert-l)) !important;
 }
 
-.is-color-link-30,
 .has-text-link-30 {
-  --bulma-color-l: var(--bulma-link-30-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-30-l)) !important;
 }
 
-.is-background-link-30,
 .has-background-link-30 {
-  --bulma-background-l: var(--bulma-link-30-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-30-l)) !important;
 }
 
-.is-color-link-30-invert,
 .has-text-link-30-invert {
-  --bulma-color-l: var(--bulma-link-30-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-30-invert-l)) !important;
 }
 
-.is-background-link-30-invert,
 .has-background-link-30-invert {
-  --bulma-background-l: var(--bulma-link-30-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-30-invert-l)) !important;
 }
 
-.is-color-link-35,
 .has-text-link-35 {
-  --bulma-color-l: var(--bulma-link-35-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-35-l)) !important;
 }
 
-.is-background-link-35,
 .has-background-link-35 {
-  --bulma-background-l: var(--bulma-link-35-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-35-l)) !important;
 }
 
-.is-color-link-35-invert,
 .has-text-link-35-invert {
-  --bulma-color-l: var(--bulma-link-35-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-35-invert-l)) !important;
 }
 
-.is-background-link-35-invert,
 .has-background-link-35-invert {
-  --bulma-background-l: var(--bulma-link-35-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-35-invert-l)) !important;
 }
 
-.is-color-link-40,
 .has-text-link-40 {
-  --bulma-color-l: var(--bulma-link-40-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-40-l)) !important;
 }
 
-.is-background-link-40,
 .has-background-link-40 {
-  --bulma-background-l: var(--bulma-link-40-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-40-l)) !important;
 }
 
-.is-color-link-40-invert,
 .has-text-link-40-invert {
-  --bulma-color-l: var(--bulma-link-40-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-40-invert-l)) !important;
 }
 
-.is-background-link-40-invert,
 .has-background-link-40-invert {
-  --bulma-background-l: var(--bulma-link-40-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-40-invert-l)) !important;
 }
 
-.is-color-link-45,
 .has-text-link-45 {
-  --bulma-color-l: var(--bulma-link-45-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-45-l)) !important;
 }
 
-.is-background-link-45,
 .has-background-link-45 {
-  --bulma-background-l: var(--bulma-link-45-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-45-l)) !important;
 }
 
-.is-color-link-45-invert,
 .has-text-link-45-invert {
-  --bulma-color-l: var(--bulma-link-45-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-45-invert-l)) !important;
 }
 
-.is-background-link-45-invert,
 .has-background-link-45-invert {
-  --bulma-background-l: var(--bulma-link-45-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-45-invert-l)) !important;
 }
 
-.is-color-link-50,
 .has-text-link-50 {
-  --bulma-color-l: var(--bulma-link-50-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-50-l)) !important;
 }
 
-.is-background-link-50,
 .has-background-link-50 {
-  --bulma-background-l: var(--bulma-link-50-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-50-l)) !important;
 }
 
-.is-color-link-50-invert,
 .has-text-link-50-invert {
-  --bulma-color-l: var(--bulma-link-50-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-50-invert-l)) !important;
 }
 
-.is-background-link-50-invert,
 .has-background-link-50-invert {
-  --bulma-background-l: var(--bulma-link-50-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-50-invert-l)) !important;
 }
 
-.is-color-link-55,
 .has-text-link-55 {
-  --bulma-color-l: var(--bulma-link-55-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-55-l)) !important;
 }
 
-.is-background-link-55,
 .has-background-link-55 {
-  --bulma-background-l: var(--bulma-link-55-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-55-l)) !important;
 }
 
-.is-color-link-55-invert,
 .has-text-link-55-invert {
-  --bulma-color-l: var(--bulma-link-55-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-55-invert-l)) !important;
 }
 
-.is-background-link-55-invert,
 .has-background-link-55-invert {
-  --bulma-background-l: var(--bulma-link-55-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-55-invert-l)) !important;
 }
 
-.is-color-link-60,
 .has-text-link-60 {
-  --bulma-color-l: var(--bulma-link-60-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-60-l)) !important;
 }
 
-.is-background-link-60,
 .has-background-link-60 {
-  --bulma-background-l: var(--bulma-link-60-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-60-l)) !important;
 }
 
-.is-color-link-60-invert,
 .has-text-link-60-invert {
-  --bulma-color-l: var(--bulma-link-60-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-60-invert-l)) !important;
 }
 
-.is-background-link-60-invert,
 .has-background-link-60-invert {
-  --bulma-background-l: var(--bulma-link-60-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-60-invert-l)) !important;
 }
 
-.is-color-link-65,
 .has-text-link-65 {
-  --bulma-color-l: var(--bulma-link-65-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-65-l)) !important;
 }
 
-.is-background-link-65,
 .has-background-link-65 {
-  --bulma-background-l: var(--bulma-link-65-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-65-l)) !important;
 }
 
-.is-color-link-65-invert,
 .has-text-link-65-invert {
-  --bulma-color-l: var(--bulma-link-65-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-65-invert-l)) !important;
 }
 
-.is-background-link-65-invert,
 .has-background-link-65-invert {
-  --bulma-background-l: var(--bulma-link-65-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-65-invert-l)) !important;
 }
 
-.is-color-link-70,
 .has-text-link-70 {
-  --bulma-color-l: var(--bulma-link-70-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-70-l)) !important;
 }
 
-.is-background-link-70,
 .has-background-link-70 {
-  --bulma-background-l: var(--bulma-link-70-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-70-l)) !important;
 }
 
-.is-color-link-70-invert,
 .has-text-link-70-invert {
-  --bulma-color-l: var(--bulma-link-70-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-70-invert-l)) !important;
 }
 
-.is-background-link-70-invert,
 .has-background-link-70-invert {
-  --bulma-background-l: var(--bulma-link-70-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-70-invert-l)) !important;
 }
 
-.is-color-link-75,
 .has-text-link-75 {
-  --bulma-color-l: var(--bulma-link-75-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-75-l)) !important;
 }
 
-.is-background-link-75,
 .has-background-link-75 {
-  --bulma-background-l: var(--bulma-link-75-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-75-l)) !important;
 }
 
-.is-color-link-75-invert,
 .has-text-link-75-invert {
-  --bulma-color-l: var(--bulma-link-75-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-75-invert-l)) !important;
 }
 
-.is-background-link-75-invert,
 .has-background-link-75-invert {
-  --bulma-background-l: var(--bulma-link-75-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-75-invert-l)) !important;
 }
 
-.is-color-link-80,
 .has-text-link-80 {
-  --bulma-color-l: var(--bulma-link-80-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-80-l)) !important;
 }
 
-.is-background-link-80,
 .has-background-link-80 {
-  --bulma-background-l: var(--bulma-link-80-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-80-l)) !important;
 }
 
-.is-color-link-80-invert,
 .has-text-link-80-invert {
-  --bulma-color-l: var(--bulma-link-80-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-80-invert-l)) !important;
 }
 
-.is-background-link-80-invert,
 .has-background-link-80-invert {
-  --bulma-background-l: var(--bulma-link-80-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-80-invert-l)) !important;
 }
 
-.is-color-link-85,
 .has-text-link-85 {
-  --bulma-color-l: var(--bulma-link-85-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-85-l)) !important;
 }
 
-.is-background-link-85,
 .has-background-link-85 {
-  --bulma-background-l: var(--bulma-link-85-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-85-l)) !important;
 }
 
-.is-color-link-85-invert,
 .has-text-link-85-invert {
-  --bulma-color-l: var(--bulma-link-85-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-85-invert-l)) !important;
 }
 
-.is-background-link-85-invert,
 .has-background-link-85-invert {
-  --bulma-background-l: var(--bulma-link-85-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-85-invert-l)) !important;
 }
 
-.is-color-link-90,
 .has-text-link-90 {
-  --bulma-color-l: var(--bulma-link-90-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-90-l)) !important;
 }
 
-.is-background-link-90,
 .has-background-link-90 {
-  --bulma-background-l: var(--bulma-link-90-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-90-l)) !important;
 }
 
-.is-color-link-90-invert,
 .has-text-link-90-invert {
-  --bulma-color-l: var(--bulma-link-90-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-90-invert-l)) !important;
 }
 
-.is-background-link-90-invert,
 .has-background-link-90-invert {
-  --bulma-background-l: var(--bulma-link-90-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-90-invert-l)) !important;
 }
 
-.is-color-link-95,
 .has-text-link-95 {
-  --bulma-color-l: var(--bulma-link-95-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-95-l)) !important;
 }
 
-.is-background-link-95,
 .has-background-link-95 {
-  --bulma-background-l: var(--bulma-link-95-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-95-l)) !important;
 }
 
-.is-color-link-95-invert,
 .has-text-link-95-invert {
-  --bulma-color-l: var(--bulma-link-95-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-95-invert-l)) !important;
 }
 
-.is-background-link-95-invert,
 .has-background-link-95-invert {
-  --bulma-background-l: var(--bulma-link-95-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-95-invert-l)) !important;
 }
 
-.is-color-link-100,
 .has-text-link-100 {
-  --bulma-color-l: var(--bulma-link-100-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-100-l)) !important;
 }
 
-.is-background-link-100,
 .has-background-link-100 {
-  --bulma-background-l: var(--bulma-link-100-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-100-l)) !important;
 }
 
-.is-color-link-100-invert,
 .has-text-link-100-invert {
-  --bulma-color-l: var(--bulma-link-100-invert-l);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-100-invert-l)) !important;
 }
 
-.is-background-link-100-invert,
 .has-background-link-100-invert {
-  --bulma-background-l: var(--bulma-link-100-invert-l);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), var(--bulma-link-100-invert-l)) !important;
 }
 
-a.is-color-link:hover, a.is-color-link:focus-visible,
-button.is-color-link:hover,
-button.is-color-link:focus-visible,
-is-color-link.is-hoverable:hover,
-is-color-link.is-hoverable:focus-visible,
-a.has-text-link:hover,
-a.has-text-link:focus-visible,
+a.has-text-link:hover, a.has-text-link:focus-visible,
 button.has-text-link:hover,
 button.has-text-link:focus-visible,
 has-text-link.is-hoverable:hover,
 has-text-link.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-link-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-link:active,
-button.is-color-link:active,
-is-color-link.is-hoverable:active,
 a.has-text-link:active,
 button.has-text-link:active,
 has-text-link.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-link-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-link:hover, a.is-background-link:focus-visible,
-button.is-background-link:hover,
-button.is-background-link:focus-visible,
-is-background-link.is-hoverable:hover,
-is-background-link.is-hoverable:focus-visible,
-a.has-background-link:hover,
-a.has-background-link:focus-visible,
+a.has-background-link:hover, a.has-background-link:focus-visible,
 button.has-background-link:hover,
 button.has-background-link:focus-visible,
 has-background-link.is-hoverable:hover,
 has-background-link.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-link-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-link:active,
-button.is-background-link:active,
-is-background-link.is-hoverable:active,
 a.has-background-link:active,
 button.has-background-link:active,
 has-background-link.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-link-h), var(--bulma-link-s), calc(var(--bulma-link-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-link {
@@ -17890,582 +17510,454 @@ has-background-link.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-info],
-[class*=has-text-info] {
-  --bulma-color-l: var(--bulma-info-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-info {
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-l)) !important;
 }
 
-[class*=is-background-info],
-[class*=has-background-info] {
-  --bulma-background-l: var(--bulma-info-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-info {
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-l)) !important;
 }
 
-.is-color-info-invert,
 .has-text-info-invert {
-  --bulma-color-l: var(--bulma-info-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-invert-l)) !important;
 }
 
-.is-background-info-invert,
 .has-background-info-invert {
-  --bulma-background-l: var(--bulma-info-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-invert-l)) !important;
 }
 
-.is-color-info-on-scheme,
 .has-text-info-on-scheme {
-  --bulma-color-l: var(--bulma-info-on-scheme-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-on-scheme-l)) !important;
 }
 
-.is-background-info-on-scheme,
 .has-background-info-on-scheme {
-  --bulma-background-l: var(--bulma-info-on-scheme-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-on-scheme-l)) !important;
 }
 
-.is-color-info-light,
 .has-text-info-light {
-  --bulma-color-l: var(--bulma-info-light-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-light-l)) !important;
 }
 
-.is-background-info-light,
 .has-background-info-light {
-  --bulma-background-l: var(--bulma-info-light-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-light-l)) !important;
 }
 
-.is-color-info-light-invert,
 .has-text-info-light-invert {
-  --bulma-color-l: var(--bulma-info-light-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-light-invert-l)) !important;
 }
 
-.is-background-info-light-invert,
 .has-background-info-light-invert {
-  --bulma-background-l: var(--bulma-info-light-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-light-invert-l)) !important;
 }
 
-.is-color-info-dark,
 .has-text-info-dark {
-  --bulma-color-l: var(--bulma-info-dark-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-dark-l)) !important;
 }
 
-.is-background-info-dark,
 .has-background-info-dark {
-  --bulma-background-l: var(--bulma-info-dark-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-dark-l)) !important;
 }
 
-.is-color-info-dark-invert,
 .has-text-info-dark-invert {
-  --bulma-color-l: var(--bulma-info-dark-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-dark-invert-l)) !important;
 }
 
-.is-background-info-dark-invert,
 .has-background-info-dark-invert {
-  --bulma-background-l: var(--bulma-info-dark-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-dark-invert-l)) !important;
 }
 
-.is-color-info-soft,
 .has-text-info-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-info-soft,
 .has-background-info-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-info-bold,
 .has-text-info-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-info-bold,
 .has-background-info-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-info-soft-invert,
 .has-text-info-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-info-soft-invert,
 .has-background-info-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-info-bold-invert,
 .has-text-info-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-info-bold-invert,
 .has-background-info-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-info-00,
 .has-text-info-00 {
-  --bulma-color-l: var(--bulma-info-00-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-00-l)) !important;
 }
 
-.is-background-info-00,
 .has-background-info-00 {
-  --bulma-background-l: var(--bulma-info-00-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-00-l)) !important;
 }
 
-.is-color-info-00-invert,
 .has-text-info-00-invert {
-  --bulma-color-l: var(--bulma-info-00-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-00-invert-l)) !important;
 }
 
-.is-background-info-00-invert,
 .has-background-info-00-invert {
-  --bulma-background-l: var(--bulma-info-00-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-00-invert-l)) !important;
 }
 
-.is-color-info-05,
 .has-text-info-05 {
-  --bulma-color-l: var(--bulma-info-05-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-05-l)) !important;
 }
 
-.is-background-info-05,
 .has-background-info-05 {
-  --bulma-background-l: var(--bulma-info-05-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-05-l)) !important;
 }
 
-.is-color-info-05-invert,
 .has-text-info-05-invert {
-  --bulma-color-l: var(--bulma-info-05-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-05-invert-l)) !important;
 }
 
-.is-background-info-05-invert,
 .has-background-info-05-invert {
-  --bulma-background-l: var(--bulma-info-05-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-05-invert-l)) !important;
 }
 
-.is-color-info-10,
 .has-text-info-10 {
-  --bulma-color-l: var(--bulma-info-10-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-10-l)) !important;
 }
 
-.is-background-info-10,
 .has-background-info-10 {
-  --bulma-background-l: var(--bulma-info-10-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-10-l)) !important;
 }
 
-.is-color-info-10-invert,
 .has-text-info-10-invert {
-  --bulma-color-l: var(--bulma-info-10-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-10-invert-l)) !important;
 }
 
-.is-background-info-10-invert,
 .has-background-info-10-invert {
-  --bulma-background-l: var(--bulma-info-10-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-10-invert-l)) !important;
 }
 
-.is-color-info-15,
 .has-text-info-15 {
-  --bulma-color-l: var(--bulma-info-15-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-15-l)) !important;
 }
 
-.is-background-info-15,
 .has-background-info-15 {
-  --bulma-background-l: var(--bulma-info-15-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-15-l)) !important;
 }
 
-.is-color-info-15-invert,
 .has-text-info-15-invert {
-  --bulma-color-l: var(--bulma-info-15-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-15-invert-l)) !important;
 }
 
-.is-background-info-15-invert,
 .has-background-info-15-invert {
-  --bulma-background-l: var(--bulma-info-15-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-15-invert-l)) !important;
 }
 
-.is-color-info-20,
 .has-text-info-20 {
-  --bulma-color-l: var(--bulma-info-20-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-20-l)) !important;
 }
 
-.is-background-info-20,
 .has-background-info-20 {
-  --bulma-background-l: var(--bulma-info-20-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-20-l)) !important;
 }
 
-.is-color-info-20-invert,
 .has-text-info-20-invert {
-  --bulma-color-l: var(--bulma-info-20-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-20-invert-l)) !important;
 }
 
-.is-background-info-20-invert,
 .has-background-info-20-invert {
-  --bulma-background-l: var(--bulma-info-20-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-20-invert-l)) !important;
 }
 
-.is-color-info-25,
 .has-text-info-25 {
-  --bulma-color-l: var(--bulma-info-25-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-25-l)) !important;
 }
 
-.is-background-info-25,
 .has-background-info-25 {
-  --bulma-background-l: var(--bulma-info-25-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-25-l)) !important;
 }
 
-.is-color-info-25-invert,
 .has-text-info-25-invert {
-  --bulma-color-l: var(--bulma-info-25-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-25-invert-l)) !important;
 }
 
-.is-background-info-25-invert,
 .has-background-info-25-invert {
-  --bulma-background-l: var(--bulma-info-25-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-25-invert-l)) !important;
 }
 
-.is-color-info-30,
 .has-text-info-30 {
-  --bulma-color-l: var(--bulma-info-30-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-30-l)) !important;
 }
 
-.is-background-info-30,
 .has-background-info-30 {
-  --bulma-background-l: var(--bulma-info-30-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-30-l)) !important;
 }
 
-.is-color-info-30-invert,
 .has-text-info-30-invert {
-  --bulma-color-l: var(--bulma-info-30-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-30-invert-l)) !important;
 }
 
-.is-background-info-30-invert,
 .has-background-info-30-invert {
-  --bulma-background-l: var(--bulma-info-30-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-30-invert-l)) !important;
 }
 
-.is-color-info-35,
 .has-text-info-35 {
-  --bulma-color-l: var(--bulma-info-35-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-35-l)) !important;
 }
 
-.is-background-info-35,
 .has-background-info-35 {
-  --bulma-background-l: var(--bulma-info-35-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-35-l)) !important;
 }
 
-.is-color-info-35-invert,
 .has-text-info-35-invert {
-  --bulma-color-l: var(--bulma-info-35-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-35-invert-l)) !important;
 }
 
-.is-background-info-35-invert,
 .has-background-info-35-invert {
-  --bulma-background-l: var(--bulma-info-35-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-35-invert-l)) !important;
 }
 
-.is-color-info-40,
 .has-text-info-40 {
-  --bulma-color-l: var(--bulma-info-40-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-40-l)) !important;
 }
 
-.is-background-info-40,
 .has-background-info-40 {
-  --bulma-background-l: var(--bulma-info-40-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-40-l)) !important;
 }
 
-.is-color-info-40-invert,
 .has-text-info-40-invert {
-  --bulma-color-l: var(--bulma-info-40-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-40-invert-l)) !important;
 }
 
-.is-background-info-40-invert,
 .has-background-info-40-invert {
-  --bulma-background-l: var(--bulma-info-40-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-40-invert-l)) !important;
 }
 
-.is-color-info-45,
 .has-text-info-45 {
-  --bulma-color-l: var(--bulma-info-45-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-45-l)) !important;
 }
 
-.is-background-info-45,
 .has-background-info-45 {
-  --bulma-background-l: var(--bulma-info-45-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-45-l)) !important;
 }
 
-.is-color-info-45-invert,
 .has-text-info-45-invert {
-  --bulma-color-l: var(--bulma-info-45-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-45-invert-l)) !important;
 }
 
-.is-background-info-45-invert,
 .has-background-info-45-invert {
-  --bulma-background-l: var(--bulma-info-45-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-45-invert-l)) !important;
 }
 
-.is-color-info-50,
 .has-text-info-50 {
-  --bulma-color-l: var(--bulma-info-50-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-50-l)) !important;
 }
 
-.is-background-info-50,
 .has-background-info-50 {
-  --bulma-background-l: var(--bulma-info-50-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-50-l)) !important;
 }
 
-.is-color-info-50-invert,
 .has-text-info-50-invert {
-  --bulma-color-l: var(--bulma-info-50-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-50-invert-l)) !important;
 }
 
-.is-background-info-50-invert,
 .has-background-info-50-invert {
-  --bulma-background-l: var(--bulma-info-50-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-50-invert-l)) !important;
 }
 
-.is-color-info-55,
 .has-text-info-55 {
-  --bulma-color-l: var(--bulma-info-55-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-55-l)) !important;
 }
 
-.is-background-info-55,
 .has-background-info-55 {
-  --bulma-background-l: var(--bulma-info-55-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-55-l)) !important;
 }
 
-.is-color-info-55-invert,
 .has-text-info-55-invert {
-  --bulma-color-l: var(--bulma-info-55-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-55-invert-l)) !important;
 }
 
-.is-background-info-55-invert,
 .has-background-info-55-invert {
-  --bulma-background-l: var(--bulma-info-55-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-55-invert-l)) !important;
 }
 
-.is-color-info-60,
 .has-text-info-60 {
-  --bulma-color-l: var(--bulma-info-60-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-60-l)) !important;
 }
 
-.is-background-info-60,
 .has-background-info-60 {
-  --bulma-background-l: var(--bulma-info-60-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-60-l)) !important;
 }
 
-.is-color-info-60-invert,
 .has-text-info-60-invert {
-  --bulma-color-l: var(--bulma-info-60-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-60-invert-l)) !important;
 }
 
-.is-background-info-60-invert,
 .has-background-info-60-invert {
-  --bulma-background-l: var(--bulma-info-60-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-60-invert-l)) !important;
 }
 
-.is-color-info-65,
 .has-text-info-65 {
-  --bulma-color-l: var(--bulma-info-65-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-65-l)) !important;
 }
 
-.is-background-info-65,
 .has-background-info-65 {
-  --bulma-background-l: var(--bulma-info-65-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-65-l)) !important;
 }
 
-.is-color-info-65-invert,
 .has-text-info-65-invert {
-  --bulma-color-l: var(--bulma-info-65-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-65-invert-l)) !important;
 }
 
-.is-background-info-65-invert,
 .has-background-info-65-invert {
-  --bulma-background-l: var(--bulma-info-65-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-65-invert-l)) !important;
 }
 
-.is-color-info-70,
 .has-text-info-70 {
-  --bulma-color-l: var(--bulma-info-70-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-70-l)) !important;
 }
 
-.is-background-info-70,
 .has-background-info-70 {
-  --bulma-background-l: var(--bulma-info-70-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-70-l)) !important;
 }
 
-.is-color-info-70-invert,
 .has-text-info-70-invert {
-  --bulma-color-l: var(--bulma-info-70-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-70-invert-l)) !important;
 }
 
-.is-background-info-70-invert,
 .has-background-info-70-invert {
-  --bulma-background-l: var(--bulma-info-70-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-70-invert-l)) !important;
 }
 
-.is-color-info-75,
 .has-text-info-75 {
-  --bulma-color-l: var(--bulma-info-75-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-75-l)) !important;
 }
 
-.is-background-info-75,
 .has-background-info-75 {
-  --bulma-background-l: var(--bulma-info-75-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-75-l)) !important;
 }
 
-.is-color-info-75-invert,
 .has-text-info-75-invert {
-  --bulma-color-l: var(--bulma-info-75-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-75-invert-l)) !important;
 }
 
-.is-background-info-75-invert,
 .has-background-info-75-invert {
-  --bulma-background-l: var(--bulma-info-75-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-75-invert-l)) !important;
 }
 
-.is-color-info-80,
 .has-text-info-80 {
-  --bulma-color-l: var(--bulma-info-80-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-80-l)) !important;
 }
 
-.is-background-info-80,
 .has-background-info-80 {
-  --bulma-background-l: var(--bulma-info-80-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-80-l)) !important;
 }
 
-.is-color-info-80-invert,
 .has-text-info-80-invert {
-  --bulma-color-l: var(--bulma-info-80-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-80-invert-l)) !important;
 }
 
-.is-background-info-80-invert,
 .has-background-info-80-invert {
-  --bulma-background-l: var(--bulma-info-80-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-80-invert-l)) !important;
 }
 
-.is-color-info-85,
 .has-text-info-85 {
-  --bulma-color-l: var(--bulma-info-85-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-85-l)) !important;
 }
 
-.is-background-info-85,
 .has-background-info-85 {
-  --bulma-background-l: var(--bulma-info-85-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-85-l)) !important;
 }
 
-.is-color-info-85-invert,
 .has-text-info-85-invert {
-  --bulma-color-l: var(--bulma-info-85-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-85-invert-l)) !important;
 }
 
-.is-background-info-85-invert,
 .has-background-info-85-invert {
-  --bulma-background-l: var(--bulma-info-85-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-85-invert-l)) !important;
 }
 
-.is-color-info-90,
 .has-text-info-90 {
-  --bulma-color-l: var(--bulma-info-90-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-90-l)) !important;
 }
 
-.is-background-info-90,
 .has-background-info-90 {
-  --bulma-background-l: var(--bulma-info-90-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-90-l)) !important;
 }
 
-.is-color-info-90-invert,
 .has-text-info-90-invert {
-  --bulma-color-l: var(--bulma-info-90-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-90-invert-l)) !important;
 }
 
-.is-background-info-90-invert,
 .has-background-info-90-invert {
-  --bulma-background-l: var(--bulma-info-90-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-90-invert-l)) !important;
 }
 
-.is-color-info-95,
 .has-text-info-95 {
-  --bulma-color-l: var(--bulma-info-95-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-95-l)) !important;
 }
 
-.is-background-info-95,
 .has-background-info-95 {
-  --bulma-background-l: var(--bulma-info-95-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-95-l)) !important;
 }
 
-.is-color-info-95-invert,
 .has-text-info-95-invert {
-  --bulma-color-l: var(--bulma-info-95-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-95-invert-l)) !important;
 }
 
-.is-background-info-95-invert,
 .has-background-info-95-invert {
-  --bulma-background-l: var(--bulma-info-95-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-95-invert-l)) !important;
 }
 
-.is-color-info-100,
 .has-text-info-100 {
-  --bulma-color-l: var(--bulma-info-100-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-100-l)) !important;
 }
 
-.is-background-info-100,
 .has-background-info-100 {
-  --bulma-background-l: var(--bulma-info-100-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-100-l)) !important;
 }
 
-.is-color-info-100-invert,
 .has-text-info-100-invert {
-  --bulma-color-l: var(--bulma-info-100-invert-l);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-100-invert-l)) !important;
 }
 
-.is-background-info-100-invert,
 .has-background-info-100-invert {
-  --bulma-background-l: var(--bulma-info-100-invert-l);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), var(--bulma-info-100-invert-l)) !important;
 }
 
-a.is-color-info:hover, a.is-color-info:focus-visible,
-button.is-color-info:hover,
-button.is-color-info:focus-visible,
-is-color-info.is-hoverable:hover,
-is-color-info.is-hoverable:focus-visible,
-a.has-text-info:hover,
-a.has-text-info:focus-visible,
+a.has-text-info:hover, a.has-text-info:focus-visible,
 button.has-text-info:hover,
 button.has-text-info:focus-visible,
 has-text-info.is-hoverable:hover,
 has-text-info.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-info-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-info:active,
-button.is-color-info:active,
-is-color-info.is-hoverable:active,
 a.has-text-info:active,
 button.has-text-info:active,
 has-text-info.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-info-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-info:hover, a.is-background-info:focus-visible,
-button.is-background-info:hover,
-button.is-background-info:focus-visible,
-is-background-info.is-hoverable:hover,
-is-background-info.is-hoverable:focus-visible,
-a.has-background-info:hover,
-a.has-background-info:focus-visible,
+a.has-background-info:hover, a.has-background-info:focus-visible,
 button.has-background-info:hover,
 button.has-background-info:focus-visible,
 has-background-info.is-hoverable:hover,
 has-background-info.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-info-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-info:active,
-button.is-background-info:active,
-is-background-info.is-hoverable:active,
 a.has-background-info:active,
 button.has-background-info:active,
 has-background-info.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-info-h), var(--bulma-info-s), calc(var(--bulma-info-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-info {
@@ -18517,582 +18009,454 @@ has-background-info.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-success],
-[class*=has-text-success] {
-  --bulma-color-l: var(--bulma-success-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-success {
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-l)) !important;
 }
 
-[class*=is-background-success],
-[class*=has-background-success] {
-  --bulma-background-l: var(--bulma-success-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-success {
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-l)) !important;
 }
 
-.is-color-success-invert,
 .has-text-success-invert {
-  --bulma-color-l: var(--bulma-success-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-invert-l)) !important;
 }
 
-.is-background-success-invert,
 .has-background-success-invert {
-  --bulma-background-l: var(--bulma-success-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-invert-l)) !important;
 }
 
-.is-color-success-on-scheme,
 .has-text-success-on-scheme {
-  --bulma-color-l: var(--bulma-success-on-scheme-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-on-scheme-l)) !important;
 }
 
-.is-background-success-on-scheme,
 .has-background-success-on-scheme {
-  --bulma-background-l: var(--bulma-success-on-scheme-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-on-scheme-l)) !important;
 }
 
-.is-color-success-light,
 .has-text-success-light {
-  --bulma-color-l: var(--bulma-success-light-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-light-l)) !important;
 }
 
-.is-background-success-light,
 .has-background-success-light {
-  --bulma-background-l: var(--bulma-success-light-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-light-l)) !important;
 }
 
-.is-color-success-light-invert,
 .has-text-success-light-invert {
-  --bulma-color-l: var(--bulma-success-light-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-light-invert-l)) !important;
 }
 
-.is-background-success-light-invert,
 .has-background-success-light-invert {
-  --bulma-background-l: var(--bulma-success-light-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-light-invert-l)) !important;
 }
 
-.is-color-success-dark,
 .has-text-success-dark {
-  --bulma-color-l: var(--bulma-success-dark-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-dark-l)) !important;
 }
 
-.is-background-success-dark,
 .has-background-success-dark {
-  --bulma-background-l: var(--bulma-success-dark-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-dark-l)) !important;
 }
 
-.is-color-success-dark-invert,
 .has-text-success-dark-invert {
-  --bulma-color-l: var(--bulma-success-dark-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-dark-invert-l)) !important;
 }
 
-.is-background-success-dark-invert,
 .has-background-success-dark-invert {
-  --bulma-background-l: var(--bulma-success-dark-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-dark-invert-l)) !important;
 }
 
-.is-color-success-soft,
 .has-text-success-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-success-soft,
 .has-background-success-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-success-bold,
 .has-text-success-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-success-bold,
 .has-background-success-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-success-soft-invert,
 .has-text-success-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-success-soft-invert,
 .has-background-success-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-success-bold-invert,
 .has-text-success-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-success-bold-invert,
 .has-background-success-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-success-00,
 .has-text-success-00 {
-  --bulma-color-l: var(--bulma-success-00-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-l)) !important;
 }
 
-.is-background-success-00,
 .has-background-success-00 {
-  --bulma-background-l: var(--bulma-success-00-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-l)) !important;
 }
 
-.is-color-success-00-invert,
 .has-text-success-00-invert {
-  --bulma-color-l: var(--bulma-success-00-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-invert-l)) !important;
 }
 
-.is-background-success-00-invert,
 .has-background-success-00-invert {
-  --bulma-background-l: var(--bulma-success-00-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-00-invert-l)) !important;
 }
 
-.is-color-success-05,
 .has-text-success-05 {
-  --bulma-color-l: var(--bulma-success-05-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-05-l)) !important;
 }
 
-.is-background-success-05,
 .has-background-success-05 {
-  --bulma-background-l: var(--bulma-success-05-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-05-l)) !important;
 }
 
-.is-color-success-05-invert,
 .has-text-success-05-invert {
-  --bulma-color-l: var(--bulma-success-05-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-05-invert-l)) !important;
 }
 
-.is-background-success-05-invert,
 .has-background-success-05-invert {
-  --bulma-background-l: var(--bulma-success-05-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-05-invert-l)) !important;
 }
 
-.is-color-success-10,
 .has-text-success-10 {
-  --bulma-color-l: var(--bulma-success-10-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-10-l)) !important;
 }
 
-.is-background-success-10,
 .has-background-success-10 {
-  --bulma-background-l: var(--bulma-success-10-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-10-l)) !important;
 }
 
-.is-color-success-10-invert,
 .has-text-success-10-invert {
-  --bulma-color-l: var(--bulma-success-10-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-10-invert-l)) !important;
 }
 
-.is-background-success-10-invert,
 .has-background-success-10-invert {
-  --bulma-background-l: var(--bulma-success-10-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-10-invert-l)) !important;
 }
 
-.is-color-success-15,
 .has-text-success-15 {
-  --bulma-color-l: var(--bulma-success-15-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-15-l)) !important;
 }
 
-.is-background-success-15,
 .has-background-success-15 {
-  --bulma-background-l: var(--bulma-success-15-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-15-l)) !important;
 }
 
-.is-color-success-15-invert,
 .has-text-success-15-invert {
-  --bulma-color-l: var(--bulma-success-15-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-15-invert-l)) !important;
 }
 
-.is-background-success-15-invert,
 .has-background-success-15-invert {
-  --bulma-background-l: var(--bulma-success-15-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-15-invert-l)) !important;
 }
 
-.is-color-success-20,
 .has-text-success-20 {
-  --bulma-color-l: var(--bulma-success-20-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-20-l)) !important;
 }
 
-.is-background-success-20,
 .has-background-success-20 {
-  --bulma-background-l: var(--bulma-success-20-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-20-l)) !important;
 }
 
-.is-color-success-20-invert,
 .has-text-success-20-invert {
-  --bulma-color-l: var(--bulma-success-20-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-20-invert-l)) !important;
 }
 
-.is-background-success-20-invert,
 .has-background-success-20-invert {
-  --bulma-background-l: var(--bulma-success-20-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-20-invert-l)) !important;
 }
 
-.is-color-success-25,
 .has-text-success-25 {
-  --bulma-color-l: var(--bulma-success-25-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-25-l)) !important;
 }
 
-.is-background-success-25,
 .has-background-success-25 {
-  --bulma-background-l: var(--bulma-success-25-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-25-l)) !important;
 }
 
-.is-color-success-25-invert,
 .has-text-success-25-invert {
-  --bulma-color-l: var(--bulma-success-25-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-25-invert-l)) !important;
 }
 
-.is-background-success-25-invert,
 .has-background-success-25-invert {
-  --bulma-background-l: var(--bulma-success-25-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-25-invert-l)) !important;
 }
 
-.is-color-success-30,
 .has-text-success-30 {
-  --bulma-color-l: var(--bulma-success-30-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-30-l)) !important;
 }
 
-.is-background-success-30,
 .has-background-success-30 {
-  --bulma-background-l: var(--bulma-success-30-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-30-l)) !important;
 }
 
-.is-color-success-30-invert,
 .has-text-success-30-invert {
-  --bulma-color-l: var(--bulma-success-30-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-30-invert-l)) !important;
 }
 
-.is-background-success-30-invert,
 .has-background-success-30-invert {
-  --bulma-background-l: var(--bulma-success-30-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-30-invert-l)) !important;
 }
 
-.is-color-success-35,
 .has-text-success-35 {
-  --bulma-color-l: var(--bulma-success-35-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-35-l)) !important;
 }
 
-.is-background-success-35,
 .has-background-success-35 {
-  --bulma-background-l: var(--bulma-success-35-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-35-l)) !important;
 }
 
-.is-color-success-35-invert,
 .has-text-success-35-invert {
-  --bulma-color-l: var(--bulma-success-35-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-35-invert-l)) !important;
 }
 
-.is-background-success-35-invert,
 .has-background-success-35-invert {
-  --bulma-background-l: var(--bulma-success-35-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-35-invert-l)) !important;
 }
 
-.is-color-success-40,
 .has-text-success-40 {
-  --bulma-color-l: var(--bulma-success-40-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-40-l)) !important;
 }
 
-.is-background-success-40,
 .has-background-success-40 {
-  --bulma-background-l: var(--bulma-success-40-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-40-l)) !important;
 }
 
-.is-color-success-40-invert,
 .has-text-success-40-invert {
-  --bulma-color-l: var(--bulma-success-40-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-40-invert-l)) !important;
 }
 
-.is-background-success-40-invert,
 .has-background-success-40-invert {
-  --bulma-background-l: var(--bulma-success-40-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-40-invert-l)) !important;
 }
 
-.is-color-success-45,
 .has-text-success-45 {
-  --bulma-color-l: var(--bulma-success-45-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-45-l)) !important;
 }
 
-.is-background-success-45,
 .has-background-success-45 {
-  --bulma-background-l: var(--bulma-success-45-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-45-l)) !important;
 }
 
-.is-color-success-45-invert,
 .has-text-success-45-invert {
-  --bulma-color-l: var(--bulma-success-45-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-45-invert-l)) !important;
 }
 
-.is-background-success-45-invert,
 .has-background-success-45-invert {
-  --bulma-background-l: var(--bulma-success-45-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-45-invert-l)) !important;
 }
 
-.is-color-success-50,
 .has-text-success-50 {
-  --bulma-color-l: var(--bulma-success-50-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-50-l)) !important;
 }
 
-.is-background-success-50,
 .has-background-success-50 {
-  --bulma-background-l: var(--bulma-success-50-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-50-l)) !important;
 }
 
-.is-color-success-50-invert,
 .has-text-success-50-invert {
-  --bulma-color-l: var(--bulma-success-50-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-50-invert-l)) !important;
 }
 
-.is-background-success-50-invert,
 .has-background-success-50-invert {
-  --bulma-background-l: var(--bulma-success-50-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-50-invert-l)) !important;
 }
 
-.is-color-success-55,
 .has-text-success-55 {
-  --bulma-color-l: var(--bulma-success-55-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-55-l)) !important;
 }
 
-.is-background-success-55,
 .has-background-success-55 {
-  --bulma-background-l: var(--bulma-success-55-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-55-l)) !important;
 }
 
-.is-color-success-55-invert,
 .has-text-success-55-invert {
-  --bulma-color-l: var(--bulma-success-55-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-55-invert-l)) !important;
 }
 
-.is-background-success-55-invert,
 .has-background-success-55-invert {
-  --bulma-background-l: var(--bulma-success-55-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-55-invert-l)) !important;
 }
 
-.is-color-success-60,
 .has-text-success-60 {
-  --bulma-color-l: var(--bulma-success-60-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-60-l)) !important;
 }
 
-.is-background-success-60,
 .has-background-success-60 {
-  --bulma-background-l: var(--bulma-success-60-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-60-l)) !important;
 }
 
-.is-color-success-60-invert,
 .has-text-success-60-invert {
-  --bulma-color-l: var(--bulma-success-60-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-60-invert-l)) !important;
 }
 
-.is-background-success-60-invert,
 .has-background-success-60-invert {
-  --bulma-background-l: var(--bulma-success-60-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-60-invert-l)) !important;
 }
 
-.is-color-success-65,
 .has-text-success-65 {
-  --bulma-color-l: var(--bulma-success-65-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-65-l)) !important;
 }
 
-.is-background-success-65,
 .has-background-success-65 {
-  --bulma-background-l: var(--bulma-success-65-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-65-l)) !important;
 }
 
-.is-color-success-65-invert,
 .has-text-success-65-invert {
-  --bulma-color-l: var(--bulma-success-65-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-65-invert-l)) !important;
 }
 
-.is-background-success-65-invert,
 .has-background-success-65-invert {
-  --bulma-background-l: var(--bulma-success-65-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-65-invert-l)) !important;
 }
 
-.is-color-success-70,
 .has-text-success-70 {
-  --bulma-color-l: var(--bulma-success-70-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-70-l)) !important;
 }
 
-.is-background-success-70,
 .has-background-success-70 {
-  --bulma-background-l: var(--bulma-success-70-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-70-l)) !important;
 }
 
-.is-color-success-70-invert,
 .has-text-success-70-invert {
-  --bulma-color-l: var(--bulma-success-70-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-70-invert-l)) !important;
 }
 
-.is-background-success-70-invert,
 .has-background-success-70-invert {
-  --bulma-background-l: var(--bulma-success-70-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-70-invert-l)) !important;
 }
 
-.is-color-success-75,
 .has-text-success-75 {
-  --bulma-color-l: var(--bulma-success-75-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-75-l)) !important;
 }
 
-.is-background-success-75,
 .has-background-success-75 {
-  --bulma-background-l: var(--bulma-success-75-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-75-l)) !important;
 }
 
-.is-color-success-75-invert,
 .has-text-success-75-invert {
-  --bulma-color-l: var(--bulma-success-75-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-75-invert-l)) !important;
 }
 
-.is-background-success-75-invert,
 .has-background-success-75-invert {
-  --bulma-background-l: var(--bulma-success-75-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-75-invert-l)) !important;
 }
 
-.is-color-success-80,
 .has-text-success-80 {
-  --bulma-color-l: var(--bulma-success-80-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-80-l)) !important;
 }
 
-.is-background-success-80,
 .has-background-success-80 {
-  --bulma-background-l: var(--bulma-success-80-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-80-l)) !important;
 }
 
-.is-color-success-80-invert,
 .has-text-success-80-invert {
-  --bulma-color-l: var(--bulma-success-80-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-80-invert-l)) !important;
 }
 
-.is-background-success-80-invert,
 .has-background-success-80-invert {
-  --bulma-background-l: var(--bulma-success-80-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-80-invert-l)) !important;
 }
 
-.is-color-success-85,
 .has-text-success-85 {
-  --bulma-color-l: var(--bulma-success-85-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-85-l)) !important;
 }
 
-.is-background-success-85,
 .has-background-success-85 {
-  --bulma-background-l: var(--bulma-success-85-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-85-l)) !important;
 }
 
-.is-color-success-85-invert,
 .has-text-success-85-invert {
-  --bulma-color-l: var(--bulma-success-85-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-85-invert-l)) !important;
 }
 
-.is-background-success-85-invert,
 .has-background-success-85-invert {
-  --bulma-background-l: var(--bulma-success-85-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-85-invert-l)) !important;
 }
 
-.is-color-success-90,
 .has-text-success-90 {
-  --bulma-color-l: var(--bulma-success-90-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-90-l)) !important;
 }
 
-.is-background-success-90,
 .has-background-success-90 {
-  --bulma-background-l: var(--bulma-success-90-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-90-l)) !important;
 }
 
-.is-color-success-90-invert,
 .has-text-success-90-invert {
-  --bulma-color-l: var(--bulma-success-90-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-90-invert-l)) !important;
 }
 
-.is-background-success-90-invert,
 .has-background-success-90-invert {
-  --bulma-background-l: var(--bulma-success-90-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-90-invert-l)) !important;
 }
 
-.is-color-success-95,
 .has-text-success-95 {
-  --bulma-color-l: var(--bulma-success-95-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-95-l)) !important;
 }
 
-.is-background-success-95,
 .has-background-success-95 {
-  --bulma-background-l: var(--bulma-success-95-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-95-l)) !important;
 }
 
-.is-color-success-95-invert,
 .has-text-success-95-invert {
-  --bulma-color-l: var(--bulma-success-95-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-95-invert-l)) !important;
 }
 
-.is-background-success-95-invert,
 .has-background-success-95-invert {
-  --bulma-background-l: var(--bulma-success-95-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-95-invert-l)) !important;
 }
 
-.is-color-success-100,
 .has-text-success-100 {
-  --bulma-color-l: var(--bulma-success-100-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-100-l)) !important;
 }
 
-.is-background-success-100,
 .has-background-success-100 {
-  --bulma-background-l: var(--bulma-success-100-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-100-l)) !important;
 }
 
-.is-color-success-100-invert,
 .has-text-success-100-invert {
-  --bulma-color-l: var(--bulma-success-100-invert-l);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-100-invert-l)) !important;
 }
 
-.is-background-success-100-invert,
 .has-background-success-100-invert {
-  --bulma-background-l: var(--bulma-success-100-invert-l);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), var(--bulma-success-100-invert-l)) !important;
 }
 
-a.is-color-success:hover, a.is-color-success:focus-visible,
-button.is-color-success:hover,
-button.is-color-success:focus-visible,
-is-color-success.is-hoverable:hover,
-is-color-success.is-hoverable:focus-visible,
-a.has-text-success:hover,
-a.has-text-success:focus-visible,
+a.has-text-success:hover, a.has-text-success:focus-visible,
 button.has-text-success:hover,
 button.has-text-success:focus-visible,
 has-text-success.is-hoverable:hover,
 has-text-success.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-success-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-success:active,
-button.is-color-success:active,
-is-color-success.is-hoverable:active,
 a.has-text-success:active,
 button.has-text-success:active,
 has-text-success.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-success-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-success:hover, a.is-background-success:focus-visible,
-button.is-background-success:hover,
-button.is-background-success:focus-visible,
-is-background-success.is-hoverable:hover,
-is-background-success.is-hoverable:focus-visible,
-a.has-background-success:hover,
-a.has-background-success:focus-visible,
+a.has-background-success:hover, a.has-background-success:focus-visible,
 button.has-background-success:hover,
 button.has-background-success:focus-visible,
 has-background-success.is-hoverable:hover,
 has-background-success.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-success-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-success:active,
-button.is-background-success:active,
-is-background-success.is-hoverable:active,
 a.has-background-success:active,
 button.has-background-success:active,
 has-background-success.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-success-h), var(--bulma-success-s), calc(var(--bulma-success-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-success {
@@ -19144,582 +18508,454 @@ has-background-success.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-warning],
-[class*=has-text-warning] {
-  --bulma-color-l: var(--bulma-warning-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-warning {
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-l)) !important;
 }
 
-[class*=is-background-warning],
-[class*=has-background-warning] {
-  --bulma-background-l: var(--bulma-warning-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-warning {
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-l)) !important;
 }
 
-.is-color-warning-invert,
 .has-text-warning-invert {
-  --bulma-color-l: var(--bulma-warning-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-invert-l)) !important;
 }
 
-.is-background-warning-invert,
 .has-background-warning-invert {
-  --bulma-background-l: var(--bulma-warning-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-invert-l)) !important;
 }
 
-.is-color-warning-on-scheme,
 .has-text-warning-on-scheme {
-  --bulma-color-l: var(--bulma-warning-on-scheme-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-on-scheme-l)) !important;
 }
 
-.is-background-warning-on-scheme,
 .has-background-warning-on-scheme {
-  --bulma-background-l: var(--bulma-warning-on-scheme-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-on-scheme-l)) !important;
 }
 
-.is-color-warning-light,
 .has-text-warning-light {
-  --bulma-color-l: var(--bulma-warning-light-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-light-l)) !important;
 }
 
-.is-background-warning-light,
 .has-background-warning-light {
-  --bulma-background-l: var(--bulma-warning-light-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-light-l)) !important;
 }
 
-.is-color-warning-light-invert,
 .has-text-warning-light-invert {
-  --bulma-color-l: var(--bulma-warning-light-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-light-invert-l)) !important;
 }
 
-.is-background-warning-light-invert,
 .has-background-warning-light-invert {
-  --bulma-background-l: var(--bulma-warning-light-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-light-invert-l)) !important;
 }
 
-.is-color-warning-dark,
 .has-text-warning-dark {
-  --bulma-color-l: var(--bulma-warning-dark-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-dark-l)) !important;
 }
 
-.is-background-warning-dark,
 .has-background-warning-dark {
-  --bulma-background-l: var(--bulma-warning-dark-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-dark-l)) !important;
 }
 
-.is-color-warning-dark-invert,
 .has-text-warning-dark-invert {
-  --bulma-color-l: var(--bulma-warning-dark-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-dark-invert-l)) !important;
 }
 
-.is-background-warning-dark-invert,
 .has-background-warning-dark-invert {
-  --bulma-background-l: var(--bulma-warning-dark-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-dark-invert-l)) !important;
 }
 
-.is-color-warning-soft,
 .has-text-warning-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-warning-soft,
 .has-background-warning-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-warning-bold,
 .has-text-warning-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-warning-bold,
 .has-background-warning-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-warning-soft-invert,
 .has-text-warning-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-warning-soft-invert,
 .has-background-warning-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-warning-bold-invert,
 .has-text-warning-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-warning-bold-invert,
 .has-background-warning-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-warning-00,
 .has-text-warning-00 {
-  --bulma-color-l: var(--bulma-warning-00-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-l)) !important;
 }
 
-.is-background-warning-00,
 .has-background-warning-00 {
-  --bulma-background-l: var(--bulma-warning-00-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-l)) !important;
 }
 
-.is-color-warning-00-invert,
 .has-text-warning-00-invert {
-  --bulma-color-l: var(--bulma-warning-00-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-invert-l)) !important;
 }
 
-.is-background-warning-00-invert,
 .has-background-warning-00-invert {
-  --bulma-background-l: var(--bulma-warning-00-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-00-invert-l)) !important;
 }
 
-.is-color-warning-05,
 .has-text-warning-05 {
-  --bulma-color-l: var(--bulma-warning-05-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-05-l)) !important;
 }
 
-.is-background-warning-05,
 .has-background-warning-05 {
-  --bulma-background-l: var(--bulma-warning-05-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-05-l)) !important;
 }
 
-.is-color-warning-05-invert,
 .has-text-warning-05-invert {
-  --bulma-color-l: var(--bulma-warning-05-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-05-invert-l)) !important;
 }
 
-.is-background-warning-05-invert,
 .has-background-warning-05-invert {
-  --bulma-background-l: var(--bulma-warning-05-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-05-invert-l)) !important;
 }
 
-.is-color-warning-10,
 .has-text-warning-10 {
-  --bulma-color-l: var(--bulma-warning-10-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-10-l)) !important;
 }
 
-.is-background-warning-10,
 .has-background-warning-10 {
-  --bulma-background-l: var(--bulma-warning-10-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-10-l)) !important;
 }
 
-.is-color-warning-10-invert,
 .has-text-warning-10-invert {
-  --bulma-color-l: var(--bulma-warning-10-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-10-invert-l)) !important;
 }
 
-.is-background-warning-10-invert,
 .has-background-warning-10-invert {
-  --bulma-background-l: var(--bulma-warning-10-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-10-invert-l)) !important;
 }
 
-.is-color-warning-15,
 .has-text-warning-15 {
-  --bulma-color-l: var(--bulma-warning-15-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-15-l)) !important;
 }
 
-.is-background-warning-15,
 .has-background-warning-15 {
-  --bulma-background-l: var(--bulma-warning-15-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-15-l)) !important;
 }
 
-.is-color-warning-15-invert,
 .has-text-warning-15-invert {
-  --bulma-color-l: var(--bulma-warning-15-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-15-invert-l)) !important;
 }
 
-.is-background-warning-15-invert,
 .has-background-warning-15-invert {
-  --bulma-background-l: var(--bulma-warning-15-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-15-invert-l)) !important;
 }
 
-.is-color-warning-20,
 .has-text-warning-20 {
-  --bulma-color-l: var(--bulma-warning-20-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-20-l)) !important;
 }
 
-.is-background-warning-20,
 .has-background-warning-20 {
-  --bulma-background-l: var(--bulma-warning-20-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-20-l)) !important;
 }
 
-.is-color-warning-20-invert,
 .has-text-warning-20-invert {
-  --bulma-color-l: var(--bulma-warning-20-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-20-invert-l)) !important;
 }
 
-.is-background-warning-20-invert,
 .has-background-warning-20-invert {
-  --bulma-background-l: var(--bulma-warning-20-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-20-invert-l)) !important;
 }
 
-.is-color-warning-25,
 .has-text-warning-25 {
-  --bulma-color-l: var(--bulma-warning-25-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-25-l)) !important;
 }
 
-.is-background-warning-25,
 .has-background-warning-25 {
-  --bulma-background-l: var(--bulma-warning-25-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-25-l)) !important;
 }
 
-.is-color-warning-25-invert,
 .has-text-warning-25-invert {
-  --bulma-color-l: var(--bulma-warning-25-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-25-invert-l)) !important;
 }
 
-.is-background-warning-25-invert,
 .has-background-warning-25-invert {
-  --bulma-background-l: var(--bulma-warning-25-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-25-invert-l)) !important;
 }
 
-.is-color-warning-30,
 .has-text-warning-30 {
-  --bulma-color-l: var(--bulma-warning-30-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-30-l)) !important;
 }
 
-.is-background-warning-30,
 .has-background-warning-30 {
-  --bulma-background-l: var(--bulma-warning-30-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-30-l)) !important;
 }
 
-.is-color-warning-30-invert,
 .has-text-warning-30-invert {
-  --bulma-color-l: var(--bulma-warning-30-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-30-invert-l)) !important;
 }
 
-.is-background-warning-30-invert,
 .has-background-warning-30-invert {
-  --bulma-background-l: var(--bulma-warning-30-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-30-invert-l)) !important;
 }
 
-.is-color-warning-35,
 .has-text-warning-35 {
-  --bulma-color-l: var(--bulma-warning-35-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-35-l)) !important;
 }
 
-.is-background-warning-35,
 .has-background-warning-35 {
-  --bulma-background-l: var(--bulma-warning-35-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-35-l)) !important;
 }
 
-.is-color-warning-35-invert,
 .has-text-warning-35-invert {
-  --bulma-color-l: var(--bulma-warning-35-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-35-invert-l)) !important;
 }
 
-.is-background-warning-35-invert,
 .has-background-warning-35-invert {
-  --bulma-background-l: var(--bulma-warning-35-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-35-invert-l)) !important;
 }
 
-.is-color-warning-40,
 .has-text-warning-40 {
-  --bulma-color-l: var(--bulma-warning-40-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-40-l)) !important;
 }
 
-.is-background-warning-40,
 .has-background-warning-40 {
-  --bulma-background-l: var(--bulma-warning-40-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-40-l)) !important;
 }
 
-.is-color-warning-40-invert,
 .has-text-warning-40-invert {
-  --bulma-color-l: var(--bulma-warning-40-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-40-invert-l)) !important;
 }
 
-.is-background-warning-40-invert,
 .has-background-warning-40-invert {
-  --bulma-background-l: var(--bulma-warning-40-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-40-invert-l)) !important;
 }
 
-.is-color-warning-45,
 .has-text-warning-45 {
-  --bulma-color-l: var(--bulma-warning-45-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-45-l)) !important;
 }
 
-.is-background-warning-45,
 .has-background-warning-45 {
-  --bulma-background-l: var(--bulma-warning-45-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-45-l)) !important;
 }
 
-.is-color-warning-45-invert,
 .has-text-warning-45-invert {
-  --bulma-color-l: var(--bulma-warning-45-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-45-invert-l)) !important;
 }
 
-.is-background-warning-45-invert,
 .has-background-warning-45-invert {
-  --bulma-background-l: var(--bulma-warning-45-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-45-invert-l)) !important;
 }
 
-.is-color-warning-50,
 .has-text-warning-50 {
-  --bulma-color-l: var(--bulma-warning-50-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-50-l)) !important;
 }
 
-.is-background-warning-50,
 .has-background-warning-50 {
-  --bulma-background-l: var(--bulma-warning-50-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-50-l)) !important;
 }
 
-.is-color-warning-50-invert,
 .has-text-warning-50-invert {
-  --bulma-color-l: var(--bulma-warning-50-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-50-invert-l)) !important;
 }
 
-.is-background-warning-50-invert,
 .has-background-warning-50-invert {
-  --bulma-background-l: var(--bulma-warning-50-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-50-invert-l)) !important;
 }
 
-.is-color-warning-55,
 .has-text-warning-55 {
-  --bulma-color-l: var(--bulma-warning-55-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-55-l)) !important;
 }
 
-.is-background-warning-55,
 .has-background-warning-55 {
-  --bulma-background-l: var(--bulma-warning-55-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-55-l)) !important;
 }
 
-.is-color-warning-55-invert,
 .has-text-warning-55-invert {
-  --bulma-color-l: var(--bulma-warning-55-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-55-invert-l)) !important;
 }
 
-.is-background-warning-55-invert,
 .has-background-warning-55-invert {
-  --bulma-background-l: var(--bulma-warning-55-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-55-invert-l)) !important;
 }
 
-.is-color-warning-60,
 .has-text-warning-60 {
-  --bulma-color-l: var(--bulma-warning-60-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-60-l)) !important;
 }
 
-.is-background-warning-60,
 .has-background-warning-60 {
-  --bulma-background-l: var(--bulma-warning-60-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-60-l)) !important;
 }
 
-.is-color-warning-60-invert,
 .has-text-warning-60-invert {
-  --bulma-color-l: var(--bulma-warning-60-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-60-invert-l)) !important;
 }
 
-.is-background-warning-60-invert,
 .has-background-warning-60-invert {
-  --bulma-background-l: var(--bulma-warning-60-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-60-invert-l)) !important;
 }
 
-.is-color-warning-65,
 .has-text-warning-65 {
-  --bulma-color-l: var(--bulma-warning-65-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-65-l)) !important;
 }
 
-.is-background-warning-65,
 .has-background-warning-65 {
-  --bulma-background-l: var(--bulma-warning-65-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-65-l)) !important;
 }
 
-.is-color-warning-65-invert,
 .has-text-warning-65-invert {
-  --bulma-color-l: var(--bulma-warning-65-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-65-invert-l)) !important;
 }
 
-.is-background-warning-65-invert,
 .has-background-warning-65-invert {
-  --bulma-background-l: var(--bulma-warning-65-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-65-invert-l)) !important;
 }
 
-.is-color-warning-70,
 .has-text-warning-70 {
-  --bulma-color-l: var(--bulma-warning-70-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-70-l)) !important;
 }
 
-.is-background-warning-70,
 .has-background-warning-70 {
-  --bulma-background-l: var(--bulma-warning-70-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-70-l)) !important;
 }
 
-.is-color-warning-70-invert,
 .has-text-warning-70-invert {
-  --bulma-color-l: var(--bulma-warning-70-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-70-invert-l)) !important;
 }
 
-.is-background-warning-70-invert,
 .has-background-warning-70-invert {
-  --bulma-background-l: var(--bulma-warning-70-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-70-invert-l)) !important;
 }
 
-.is-color-warning-75,
 .has-text-warning-75 {
-  --bulma-color-l: var(--bulma-warning-75-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-75-l)) !important;
 }
 
-.is-background-warning-75,
 .has-background-warning-75 {
-  --bulma-background-l: var(--bulma-warning-75-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-75-l)) !important;
 }
 
-.is-color-warning-75-invert,
 .has-text-warning-75-invert {
-  --bulma-color-l: var(--bulma-warning-75-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-75-invert-l)) !important;
 }
 
-.is-background-warning-75-invert,
 .has-background-warning-75-invert {
-  --bulma-background-l: var(--bulma-warning-75-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-75-invert-l)) !important;
 }
 
-.is-color-warning-80,
 .has-text-warning-80 {
-  --bulma-color-l: var(--bulma-warning-80-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-80-l)) !important;
 }
 
-.is-background-warning-80,
 .has-background-warning-80 {
-  --bulma-background-l: var(--bulma-warning-80-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-80-l)) !important;
 }
 
-.is-color-warning-80-invert,
 .has-text-warning-80-invert {
-  --bulma-color-l: var(--bulma-warning-80-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-80-invert-l)) !important;
 }
 
-.is-background-warning-80-invert,
 .has-background-warning-80-invert {
-  --bulma-background-l: var(--bulma-warning-80-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-80-invert-l)) !important;
 }
 
-.is-color-warning-85,
 .has-text-warning-85 {
-  --bulma-color-l: var(--bulma-warning-85-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-85-l)) !important;
 }
 
-.is-background-warning-85,
 .has-background-warning-85 {
-  --bulma-background-l: var(--bulma-warning-85-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-85-l)) !important;
 }
 
-.is-color-warning-85-invert,
 .has-text-warning-85-invert {
-  --bulma-color-l: var(--bulma-warning-85-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-85-invert-l)) !important;
 }
 
-.is-background-warning-85-invert,
 .has-background-warning-85-invert {
-  --bulma-background-l: var(--bulma-warning-85-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-85-invert-l)) !important;
 }
 
-.is-color-warning-90,
 .has-text-warning-90 {
-  --bulma-color-l: var(--bulma-warning-90-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-90-l)) !important;
 }
 
-.is-background-warning-90,
 .has-background-warning-90 {
-  --bulma-background-l: var(--bulma-warning-90-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-90-l)) !important;
 }
 
-.is-color-warning-90-invert,
 .has-text-warning-90-invert {
-  --bulma-color-l: var(--bulma-warning-90-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-90-invert-l)) !important;
 }
 
-.is-background-warning-90-invert,
 .has-background-warning-90-invert {
-  --bulma-background-l: var(--bulma-warning-90-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-90-invert-l)) !important;
 }
 
-.is-color-warning-95,
 .has-text-warning-95 {
-  --bulma-color-l: var(--bulma-warning-95-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-95-l)) !important;
 }
 
-.is-background-warning-95,
 .has-background-warning-95 {
-  --bulma-background-l: var(--bulma-warning-95-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-95-l)) !important;
 }
 
-.is-color-warning-95-invert,
 .has-text-warning-95-invert {
-  --bulma-color-l: var(--bulma-warning-95-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-95-invert-l)) !important;
 }
 
-.is-background-warning-95-invert,
 .has-background-warning-95-invert {
-  --bulma-background-l: var(--bulma-warning-95-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-95-invert-l)) !important;
 }
 
-.is-color-warning-100,
 .has-text-warning-100 {
-  --bulma-color-l: var(--bulma-warning-100-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-100-l)) !important;
 }
 
-.is-background-warning-100,
 .has-background-warning-100 {
-  --bulma-background-l: var(--bulma-warning-100-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-100-l)) !important;
 }
 
-.is-color-warning-100-invert,
 .has-text-warning-100-invert {
-  --bulma-color-l: var(--bulma-warning-100-invert-l);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-100-invert-l)) !important;
 }
 
-.is-background-warning-100-invert,
 .has-background-warning-100-invert {
-  --bulma-background-l: var(--bulma-warning-100-invert-l);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), var(--bulma-warning-100-invert-l)) !important;
 }
 
-a.is-color-warning:hover, a.is-color-warning:focus-visible,
-button.is-color-warning:hover,
-button.is-color-warning:focus-visible,
-is-color-warning.is-hoverable:hover,
-is-color-warning.is-hoverable:focus-visible,
-a.has-text-warning:hover,
-a.has-text-warning:focus-visible,
+a.has-text-warning:hover, a.has-text-warning:focus-visible,
 button.has-text-warning:hover,
 button.has-text-warning:focus-visible,
 has-text-warning.is-hoverable:hover,
 has-text-warning.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-warning-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-warning:active,
-button.is-color-warning:active,
-is-color-warning.is-hoverable:active,
 a.has-text-warning:active,
 button.has-text-warning:active,
 has-text-warning.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-warning-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-warning:hover, a.is-background-warning:focus-visible,
-button.is-background-warning:hover,
-button.is-background-warning:focus-visible,
-is-background-warning.is-hoverable:hover,
-is-background-warning.is-hoverable:focus-visible,
-a.has-background-warning:hover,
-a.has-background-warning:focus-visible,
+a.has-background-warning:hover, a.has-background-warning:focus-visible,
 button.has-background-warning:hover,
 button.has-background-warning:focus-visible,
 has-background-warning.is-hoverable:hover,
 has-background-warning.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-warning-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-warning:active,
-button.is-background-warning:active,
-is-background-warning.is-hoverable:active,
 a.has-background-warning:active,
 button.has-background-warning:active,
 has-background-warning.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-warning-h), var(--bulma-warning-s), calc(var(--bulma-warning-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-warning {
@@ -19771,582 +19007,454 @@ has-background-warning.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-[class*=is-color-danger],
-[class*=has-text-danger] {
-  --bulma-color-l: var(--bulma-danger-l);
-  --bulma-color-l-delta: 0%;
-  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-color-l) + var(--bulma-color-l-delta))) !important;
+.has-text-danger {
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-l)) !important;
 }
 
-[class*=is-background-danger],
-[class*=has-background-danger] {
-  --bulma-background-l: var(--bulma-danger-l);
-  --bulma-background-l-delta: 0%;
-  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-background-l) + var(--bulma-background-l-delta))) !important;
+.has-background-danger {
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-l)) !important;
 }
 
-.is-color-danger-invert,
 .has-text-danger-invert {
-  --bulma-color-l: var(--bulma-danger-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-invert-l)) !important;
 }
 
-.is-background-danger-invert,
 .has-background-danger-invert {
-  --bulma-background-l: var(--bulma-danger-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-invert-l)) !important;
 }
 
-.is-color-danger-on-scheme,
 .has-text-danger-on-scheme {
-  --bulma-color-l: var(--bulma-danger-on-scheme-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-on-scheme-l)) !important;
 }
 
-.is-background-danger-on-scheme,
 .has-background-danger-on-scheme {
-  --bulma-background-l: var(--bulma-danger-on-scheme-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-on-scheme-l)) !important;
 }
 
-.is-color-danger-light,
 .has-text-danger-light {
-  --bulma-color-l: var(--bulma-danger-light-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-light-l)) !important;
 }
 
-.is-background-danger-light,
 .has-background-danger-light {
-  --bulma-background-l: var(--bulma-danger-light-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-light-l)) !important;
 }
 
-.is-color-danger-light-invert,
 .has-text-danger-light-invert {
-  --bulma-color-l: var(--bulma-danger-light-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-light-invert-l)) !important;
 }
 
-.is-background-danger-light-invert,
 .has-background-danger-light-invert {
-  --bulma-background-l: var(--bulma-danger-light-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-light-invert-l)) !important;
 }
 
-.is-color-danger-dark,
 .has-text-danger-dark {
-  --bulma-color-l: var(--bulma-danger-dark-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-dark-l)) !important;
 }
 
-.is-background-danger-dark,
 .has-background-danger-dark {
-  --bulma-background-l: var(--bulma-danger-dark-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-dark-l)) !important;
 }
 
-.is-color-danger-dark-invert,
 .has-text-danger-dark-invert {
-  --bulma-color-l: var(--bulma-danger-dark-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-dark-invert-l)) !important;
 }
 
-.is-background-danger-dark-invert,
 .has-background-danger-dark-invert {
-  --bulma-background-l: var(--bulma-danger-dark-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-dark-invert-l)) !important;
 }
 
-.is-color-danger-soft,
 .has-text-danger-soft {
-  --bulma-color-l: var(--bulma-soft-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-soft-l)) !important;
 }
 
-.is-background-danger-soft,
 .has-background-danger-soft {
-  --bulma-background-l: var(--bulma-soft-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-soft-l)) !important;
 }
 
-.is-color-danger-bold,
 .has-text-danger-bold {
-  --bulma-color-l: var(--bulma-bold-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-bold-l)) !important;
 }
 
-.is-background-danger-bold,
 .has-background-danger-bold {
-  --bulma-background-l: var(--bulma-bold-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-bold-l)) !important;
 }
 
-.is-color-danger-soft-invert,
 .has-text-danger-soft-invert {
-  --bulma-color-l: var(--bulma-soft-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-background-danger-soft-invert,
 .has-background-danger-soft-invert {
-  --bulma-background-l: var(--bulma-soft-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-soft-invert-l)) !important;
 }
 
-.is-color-danger-bold-invert,
 .has-text-danger-bold-invert {
-  --bulma-color-l: var(--bulma-bold-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-background-danger-bold-invert,
 .has-background-danger-bold-invert {
-  --bulma-background-l: var(--bulma-bold-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-bold-invert-l)) !important;
 }
 
-.is-color-danger-00,
 .has-text-danger-00 {
-  --bulma-color-l: var(--bulma-danger-00-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-00-l)) !important;
 }
 
-.is-background-danger-00,
 .has-background-danger-00 {
-  --bulma-background-l: var(--bulma-danger-00-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-00-l)) !important;
 }
 
-.is-color-danger-00-invert,
 .has-text-danger-00-invert {
-  --bulma-color-l: var(--bulma-danger-00-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-00-invert-l)) !important;
 }
 
-.is-background-danger-00-invert,
 .has-background-danger-00-invert {
-  --bulma-background-l: var(--bulma-danger-00-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-00-invert-l)) !important;
 }
 
-.is-color-danger-05,
 .has-text-danger-05 {
-  --bulma-color-l: var(--bulma-danger-05-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-05-l)) !important;
 }
 
-.is-background-danger-05,
 .has-background-danger-05 {
-  --bulma-background-l: var(--bulma-danger-05-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-05-l)) !important;
 }
 
-.is-color-danger-05-invert,
 .has-text-danger-05-invert {
-  --bulma-color-l: var(--bulma-danger-05-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-05-invert-l)) !important;
 }
 
-.is-background-danger-05-invert,
 .has-background-danger-05-invert {
-  --bulma-background-l: var(--bulma-danger-05-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-05-invert-l)) !important;
 }
 
-.is-color-danger-10,
 .has-text-danger-10 {
-  --bulma-color-l: var(--bulma-danger-10-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-10-l)) !important;
 }
 
-.is-background-danger-10,
 .has-background-danger-10 {
-  --bulma-background-l: var(--bulma-danger-10-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-10-l)) !important;
 }
 
-.is-color-danger-10-invert,
 .has-text-danger-10-invert {
-  --bulma-color-l: var(--bulma-danger-10-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-10-invert-l)) !important;
 }
 
-.is-background-danger-10-invert,
 .has-background-danger-10-invert {
-  --bulma-background-l: var(--bulma-danger-10-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-10-invert-l)) !important;
 }
 
-.is-color-danger-15,
 .has-text-danger-15 {
-  --bulma-color-l: var(--bulma-danger-15-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-15-l)) !important;
 }
 
-.is-background-danger-15,
 .has-background-danger-15 {
-  --bulma-background-l: var(--bulma-danger-15-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-15-l)) !important;
 }
 
-.is-color-danger-15-invert,
 .has-text-danger-15-invert {
-  --bulma-color-l: var(--bulma-danger-15-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-15-invert-l)) !important;
 }
 
-.is-background-danger-15-invert,
 .has-background-danger-15-invert {
-  --bulma-background-l: var(--bulma-danger-15-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-15-invert-l)) !important;
 }
 
-.is-color-danger-20,
 .has-text-danger-20 {
-  --bulma-color-l: var(--bulma-danger-20-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-20-l)) !important;
 }
 
-.is-background-danger-20,
 .has-background-danger-20 {
-  --bulma-background-l: var(--bulma-danger-20-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-20-l)) !important;
 }
 
-.is-color-danger-20-invert,
 .has-text-danger-20-invert {
-  --bulma-color-l: var(--bulma-danger-20-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-20-invert-l)) !important;
 }
 
-.is-background-danger-20-invert,
 .has-background-danger-20-invert {
-  --bulma-background-l: var(--bulma-danger-20-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-20-invert-l)) !important;
 }
 
-.is-color-danger-25,
 .has-text-danger-25 {
-  --bulma-color-l: var(--bulma-danger-25-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-25-l)) !important;
 }
 
-.is-background-danger-25,
 .has-background-danger-25 {
-  --bulma-background-l: var(--bulma-danger-25-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-25-l)) !important;
 }
 
-.is-color-danger-25-invert,
 .has-text-danger-25-invert {
-  --bulma-color-l: var(--bulma-danger-25-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-25-invert-l)) !important;
 }
 
-.is-background-danger-25-invert,
 .has-background-danger-25-invert {
-  --bulma-background-l: var(--bulma-danger-25-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-25-invert-l)) !important;
 }
 
-.is-color-danger-30,
 .has-text-danger-30 {
-  --bulma-color-l: var(--bulma-danger-30-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-30-l)) !important;
 }
 
-.is-background-danger-30,
 .has-background-danger-30 {
-  --bulma-background-l: var(--bulma-danger-30-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-30-l)) !important;
 }
 
-.is-color-danger-30-invert,
 .has-text-danger-30-invert {
-  --bulma-color-l: var(--bulma-danger-30-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-30-invert-l)) !important;
 }
 
-.is-background-danger-30-invert,
 .has-background-danger-30-invert {
-  --bulma-background-l: var(--bulma-danger-30-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-30-invert-l)) !important;
 }
 
-.is-color-danger-35,
 .has-text-danger-35 {
-  --bulma-color-l: var(--bulma-danger-35-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-35-l)) !important;
 }
 
-.is-background-danger-35,
 .has-background-danger-35 {
-  --bulma-background-l: var(--bulma-danger-35-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-35-l)) !important;
 }
 
-.is-color-danger-35-invert,
 .has-text-danger-35-invert {
-  --bulma-color-l: var(--bulma-danger-35-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-35-invert-l)) !important;
 }
 
-.is-background-danger-35-invert,
 .has-background-danger-35-invert {
-  --bulma-background-l: var(--bulma-danger-35-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-35-invert-l)) !important;
 }
 
-.is-color-danger-40,
 .has-text-danger-40 {
-  --bulma-color-l: var(--bulma-danger-40-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-40-l)) !important;
 }
 
-.is-background-danger-40,
 .has-background-danger-40 {
-  --bulma-background-l: var(--bulma-danger-40-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-40-l)) !important;
 }
 
-.is-color-danger-40-invert,
 .has-text-danger-40-invert {
-  --bulma-color-l: var(--bulma-danger-40-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-40-invert-l)) !important;
 }
 
-.is-background-danger-40-invert,
 .has-background-danger-40-invert {
-  --bulma-background-l: var(--bulma-danger-40-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-40-invert-l)) !important;
 }
 
-.is-color-danger-45,
 .has-text-danger-45 {
-  --bulma-color-l: var(--bulma-danger-45-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-45-l)) !important;
 }
 
-.is-background-danger-45,
 .has-background-danger-45 {
-  --bulma-background-l: var(--bulma-danger-45-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-45-l)) !important;
 }
 
-.is-color-danger-45-invert,
 .has-text-danger-45-invert {
-  --bulma-color-l: var(--bulma-danger-45-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-45-invert-l)) !important;
 }
 
-.is-background-danger-45-invert,
 .has-background-danger-45-invert {
-  --bulma-background-l: var(--bulma-danger-45-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-45-invert-l)) !important;
 }
 
-.is-color-danger-50,
 .has-text-danger-50 {
-  --bulma-color-l: var(--bulma-danger-50-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-50-l)) !important;
 }
 
-.is-background-danger-50,
 .has-background-danger-50 {
-  --bulma-background-l: var(--bulma-danger-50-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-50-l)) !important;
 }
 
-.is-color-danger-50-invert,
 .has-text-danger-50-invert {
-  --bulma-color-l: var(--bulma-danger-50-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-50-invert-l)) !important;
 }
 
-.is-background-danger-50-invert,
 .has-background-danger-50-invert {
-  --bulma-background-l: var(--bulma-danger-50-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-50-invert-l)) !important;
 }
 
-.is-color-danger-55,
 .has-text-danger-55 {
-  --bulma-color-l: var(--bulma-danger-55-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-55-l)) !important;
 }
 
-.is-background-danger-55,
 .has-background-danger-55 {
-  --bulma-background-l: var(--bulma-danger-55-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-55-l)) !important;
 }
 
-.is-color-danger-55-invert,
 .has-text-danger-55-invert {
-  --bulma-color-l: var(--bulma-danger-55-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-55-invert-l)) !important;
 }
 
-.is-background-danger-55-invert,
 .has-background-danger-55-invert {
-  --bulma-background-l: var(--bulma-danger-55-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-55-invert-l)) !important;
 }
 
-.is-color-danger-60,
 .has-text-danger-60 {
-  --bulma-color-l: var(--bulma-danger-60-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-60-l)) !important;
 }
 
-.is-background-danger-60,
 .has-background-danger-60 {
-  --bulma-background-l: var(--bulma-danger-60-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-60-l)) !important;
 }
 
-.is-color-danger-60-invert,
 .has-text-danger-60-invert {
-  --bulma-color-l: var(--bulma-danger-60-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-60-invert-l)) !important;
 }
 
-.is-background-danger-60-invert,
 .has-background-danger-60-invert {
-  --bulma-background-l: var(--bulma-danger-60-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-60-invert-l)) !important;
 }
 
-.is-color-danger-65,
 .has-text-danger-65 {
-  --bulma-color-l: var(--bulma-danger-65-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-65-l)) !important;
 }
 
-.is-background-danger-65,
 .has-background-danger-65 {
-  --bulma-background-l: var(--bulma-danger-65-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-65-l)) !important;
 }
 
-.is-color-danger-65-invert,
 .has-text-danger-65-invert {
-  --bulma-color-l: var(--bulma-danger-65-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-65-invert-l)) !important;
 }
 
-.is-background-danger-65-invert,
 .has-background-danger-65-invert {
-  --bulma-background-l: var(--bulma-danger-65-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-65-invert-l)) !important;
 }
 
-.is-color-danger-70,
 .has-text-danger-70 {
-  --bulma-color-l: var(--bulma-danger-70-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-70-l)) !important;
 }
 
-.is-background-danger-70,
 .has-background-danger-70 {
-  --bulma-background-l: var(--bulma-danger-70-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-70-l)) !important;
 }
 
-.is-color-danger-70-invert,
 .has-text-danger-70-invert {
-  --bulma-color-l: var(--bulma-danger-70-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-70-invert-l)) !important;
 }
 
-.is-background-danger-70-invert,
 .has-background-danger-70-invert {
-  --bulma-background-l: var(--bulma-danger-70-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-70-invert-l)) !important;
 }
 
-.is-color-danger-75,
 .has-text-danger-75 {
-  --bulma-color-l: var(--bulma-danger-75-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-75-l)) !important;
 }
 
-.is-background-danger-75,
 .has-background-danger-75 {
-  --bulma-background-l: var(--bulma-danger-75-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-75-l)) !important;
 }
 
-.is-color-danger-75-invert,
 .has-text-danger-75-invert {
-  --bulma-color-l: var(--bulma-danger-75-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-75-invert-l)) !important;
 }
 
-.is-background-danger-75-invert,
 .has-background-danger-75-invert {
-  --bulma-background-l: var(--bulma-danger-75-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-75-invert-l)) !important;
 }
 
-.is-color-danger-80,
 .has-text-danger-80 {
-  --bulma-color-l: var(--bulma-danger-80-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-80-l)) !important;
 }
 
-.is-background-danger-80,
 .has-background-danger-80 {
-  --bulma-background-l: var(--bulma-danger-80-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-80-l)) !important;
 }
 
-.is-color-danger-80-invert,
 .has-text-danger-80-invert {
-  --bulma-color-l: var(--bulma-danger-80-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-80-invert-l)) !important;
 }
 
-.is-background-danger-80-invert,
 .has-background-danger-80-invert {
-  --bulma-background-l: var(--bulma-danger-80-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-80-invert-l)) !important;
 }
 
-.is-color-danger-85,
 .has-text-danger-85 {
-  --bulma-color-l: var(--bulma-danger-85-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-85-l)) !important;
 }
 
-.is-background-danger-85,
 .has-background-danger-85 {
-  --bulma-background-l: var(--bulma-danger-85-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-85-l)) !important;
 }
 
-.is-color-danger-85-invert,
 .has-text-danger-85-invert {
-  --bulma-color-l: var(--bulma-danger-85-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-85-invert-l)) !important;
 }
 
-.is-background-danger-85-invert,
 .has-background-danger-85-invert {
-  --bulma-background-l: var(--bulma-danger-85-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-85-invert-l)) !important;
 }
 
-.is-color-danger-90,
 .has-text-danger-90 {
-  --bulma-color-l: var(--bulma-danger-90-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-90-l)) !important;
 }
 
-.is-background-danger-90,
 .has-background-danger-90 {
-  --bulma-background-l: var(--bulma-danger-90-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-90-l)) !important;
 }
 
-.is-color-danger-90-invert,
 .has-text-danger-90-invert {
-  --bulma-color-l: var(--bulma-danger-90-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-90-invert-l)) !important;
 }
 
-.is-background-danger-90-invert,
 .has-background-danger-90-invert {
-  --bulma-background-l: var(--bulma-danger-90-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-90-invert-l)) !important;
 }
 
-.is-color-danger-95,
 .has-text-danger-95 {
-  --bulma-color-l: var(--bulma-danger-95-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-95-l)) !important;
 }
 
-.is-background-danger-95,
 .has-background-danger-95 {
-  --bulma-background-l: var(--bulma-danger-95-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-95-l)) !important;
 }
 
-.is-color-danger-95-invert,
 .has-text-danger-95-invert {
-  --bulma-color-l: var(--bulma-danger-95-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-95-invert-l)) !important;
 }
 
-.is-background-danger-95-invert,
 .has-background-danger-95-invert {
-  --bulma-background-l: var(--bulma-danger-95-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-95-invert-l)) !important;
 }
 
-.is-color-danger-100,
 .has-text-danger-100 {
-  --bulma-color-l: var(--bulma-danger-100-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-100-l)) !important;
 }
 
-.is-background-danger-100,
 .has-background-danger-100 {
-  --bulma-background-l: var(--bulma-danger-100-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-100-l)) !important;
 }
 
-.is-color-danger-100-invert,
 .has-text-danger-100-invert {
-  --bulma-color-l: var(--bulma-danger-100-invert-l);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-100-invert-l)) !important;
 }
 
-.is-background-danger-100-invert,
 .has-background-danger-100-invert {
-  --bulma-background-l: var(--bulma-danger-100-invert-l);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), var(--bulma-danger-100-invert-l)) !important;
 }
 
-a.is-color-danger:hover, a.is-color-danger:focus-visible,
-button.is-color-danger:hover,
-button.is-color-danger:focus-visible,
-is-color-danger.is-hoverable:hover,
-is-color-danger.is-hoverable:focus-visible,
-a.has-text-danger:hover,
-a.has-text-danger:focus-visible,
+a.has-text-danger:hover, a.has-text-danger:focus-visible,
 button.has-text-danger:hover,
 button.has-text-danger:focus-visible,
 has-text-danger.is-hoverable:hover,
 has-text-danger.is-hoverable:focus-visible {
-  --bulma-color-l-delta: var(--bulma-hover-color-l-delta);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-danger-l) + var(--bulma-hover-color-l-delta))) !important;
 }
-a.is-color-danger:active,
-button.is-color-danger:active,
-is-color-danger.is-hoverable:active,
 a.has-text-danger:active,
 button.has-text-danger:active,
 has-text-danger.is-hoverable:active {
-  --bulma-color-l-delta: var(--bulma-active-color-l-delta);
+  color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-danger-l) + var(--bulma-active-color-l-delta))) !important;
 }
 
-a.is-background-danger:hover, a.is-background-danger:focus-visible,
-button.is-background-danger:hover,
-button.is-background-danger:focus-visible,
-is-background-danger.is-hoverable:hover,
-is-background-danger.is-hoverable:focus-visible,
-a.has-background-danger:hover,
-a.has-background-danger:focus-visible,
+a.has-background-danger:hover, a.has-background-danger:focus-visible,
 button.has-background-danger:hover,
 button.has-background-danger:focus-visible,
 has-background-danger.is-hoverable:hover,
 has-background-danger.is-hoverable:focus-visible {
-  --bulma-background-l-delta: var(--bulma-hover-background-l-delta);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-danger-l) + var(--bulma-hover-background-l-delta))) !important;
 }
-a.is-background-danger:active,
-button.is-background-danger:active,
-is-background-danger.is-hoverable:active,
 a.has-background-danger:active,
 button.has-background-danger:active,
 has-background-danger.is-hoverable:active {
-  --bulma-background-l-delta: var(--bulma-active-background-l-delta);
+  background-color: hsl(var(--bulma-danger-h), var(--bulma-danger-s), calc(var(--bulma-danger-l) + var(--bulma-active-background-l-delta))) !important;
 }
 
 .is-palette-danger {
@@ -20398,94 +19506,92 @@ has-background-danger.is-hoverable:active {
   --color-100: hsl(var(--h), var(--s), var(--100-l));
 }
 
-.is-color-black-bis,
 .has-text-black-bis {
   color: hsl(221, 14%, 9%) !important;
 }
 
-.is-background-black-bis,
 .has-background-black-bis {
   background-color: hsl(221, 14%, 9%) !important;
 }
 
-.is-color-black-ter,
 .has-text-black-ter {
   color: hsl(221, 14%, 14%) !important;
 }
 
-.is-background-black-ter,
 .has-background-black-ter {
   background-color: hsl(221, 14%, 14%) !important;
 }
 
-.is-color-grey-darker,
 .has-text-grey-darker {
   color: hsl(221, 14%, 21%) !important;
 }
 
-.is-background-grey-darker,
 .has-background-grey-darker {
   background-color: hsl(221, 14%, 21%) !important;
 }
 
-.is-color-grey-dark,
 .has-text-grey-dark {
   color: hsl(221, 14%, 29%) !important;
 }
 
-.is-background-grey-dark,
 .has-background-grey-dark {
   background-color: hsl(221, 14%, 29%) !important;
 }
 
-.is-color-grey,
 .has-text-grey {
   color: hsl(221, 14%, 48%) !important;
 }
 
-.is-background-grey,
 .has-background-grey {
   background-color: hsl(221, 14%, 48%) !important;
 }
 
-.is-color-grey-light,
 .has-text-grey-light {
   color: hsl(221, 14%, 71%) !important;
 }
 
-.is-background-grey-light,
 .has-background-grey-light {
   background-color: hsl(221, 14%, 71%) !important;
 }
 
-.is-color-grey-lighter,
 .has-text-grey-lighter {
   color: hsl(221, 14%, 86%) !important;
 }
 
-.is-background-grey-lighter,
 .has-background-grey-lighter {
   background-color: hsl(221, 14%, 86%) !important;
 }
 
-.is-color-white-ter,
 .has-text-white-ter {
   color: hsl(221, 14%, 96%) !important;
 }
 
-.is-background-white-ter,
 .has-background-white-ter {
   background-color: hsl(221, 14%, 96%) !important;
 }
 
-.is-color-white-bis,
 .has-text-white-bis {
   color: hsl(221, 14%, 98%) !important;
 }
 
-.is-background-white-bis,
 .has-background-white-bis {
   background-color: hsl(221, 14%, 98%) !important;
+}
+
+.has-text-current {
+  color: currentColor !important;
+}
+
+.has-text-inherit {
+  color: inherit !important;
+}
+
+.has-background-current {
+  background-color: currentColor !important;
+}
+
+.has-background-inherit {
+  background-color: inherit !important;
 }
 
 .is-flex-direction-row {

--- a/flake.lock
+++ b/flake.lock
@@ -73,11 +73,11 @@
     },
     "nixos-24-05": {
       "locked": {
-        "lastModified": 1721686456,
-        "narHash": "sha256-nw/BnNzATDPfzpJVTnY8mcSKKsz6BJMEFRkJ332QSN0=",
+        "lastModified": 1721821769,
+        "narHash": "sha256-PhmkdTJs2SfqKzSyDB74rDKp1MH4mGk0pG/+WqrnGEw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "575f3027caa1e291d24f1e9fb0e3a19c2f26d96b",
+        "rev": "d0907b75146a0ccc1ec0d6c3db287ec287588ef6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Apart from updating the nix flake input for NixOS 24.05 this change includes an update for the Bulma style sheets bundeled with the arbeitszeitapp from version 1.0.1 to 1.0.2.