### PR TITLE
Isolate cancel_cooperation_request view

### DIFF
--- a/arbeitszeit_flask/templates/company/my_cooperations.html
+++ b/arbeitszeit_flask/templates/company/my_cooperations.html
@@ -136,15 +136,15 @@
                 </div>
             </div>
             <div class="media-right">
-                <form action="" method="post">
+                <form action="/company/cancel_cooperation_request" method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <div class="content pt-1">
-                        <button class="button large-button is-danger" name="cancel" 
-                            value="{{ req.plan_id }}" type="submit" title="{{ gettext('Cancel') }}">
-                            {{ "times"|icon }}
-                        </button>
-                    </div>
-                    </form>
+                    <input type="hidden" name="plan_id" value="{{ req.plan_id }}">
+                    <button class="button large-button is-danger"
+                            type="submit"
+                            title="{{ gettext('Cancel') }}">
+                        {{ "times"|icon }}
+                    </button>
+                </form>
             </div>
         </article>
         {% endfor %}

--- a/arbeitszeit_flask/views/cancel_cooperation_request_view.py
+++ b/arbeitszeit_flask/views/cancel_cooperation_request_view.py
@@ -1,0 +1,31 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+import flask
+from flask_login import current_user
+
+from arbeitszeit.use_cases.cancel_cooperation_solicitation import (
+    CancelCooperationSolicitation,
+    CancelCooperationSolicitationRequest,
+)
+from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.types import Response
+from arbeitszeit_web.www.presenters.cancel_cooperation_request_presenter import (
+    CancelCooperationRequestPresenter,
+)
+
+
+@dataclass
+class CancelCooperationRequestView:
+    cancel_cooperation_solicitation: CancelCooperationSolicitation
+    presenter: CancelCooperationRequestPresenter
+
+    @commit_changes
+    def POST(self) -> Response:
+        plan_id = UUID(flask.request.form["plan_id"])
+        requester_id = UUID(current_user.id)
+        uc_response = self.cancel_cooperation_solicitation(
+            CancelCooperationSolicitationRequest(requester_id, plan_id)
+        )
+        view_model = self.presenter.render_response(uc_response)
+        return flask.redirect(view_model.redirection_url)

--- a/arbeitszeit_web/www/presenters/cancel_cooperation_request_presenter.py
+++ b/arbeitszeit_web/www/presenters/cancel_cooperation_request_presenter.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirection_url: str
+
+
+@dataclass
+class CancelCooperationRequestPresenter:
+    translator: Translator
+    notifier: Notifier
+    url_index: UrlIndex
+
+    def render_response(self, response: bool) -> ViewModel:
+        if response:
+            self.notifier.display_info(
+                self.translator.gettext("Cooperation request has been canceled.")
+            )
+        else:
+            self.notifier.display_warning(
+                self.translator.gettext("Error: Not possible to cancel request.")
+            )
+        return ViewModel(redirection_url=self.url_index.get_my_cooperations_url())

--- a/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
+++ b/arbeitszeit_web/www/presenters/show_my_cooperations_presenter.py
@@ -1,5 +1,5 @@
 from dataclasses import asdict, dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from arbeitszeit.use_cases.list_coordinations_of_company import (
     CooperationInfo,
@@ -16,9 +16,7 @@ from arbeitszeit.use_cases.list_outbound_coop_requests import (
     ListedOutboundCoopRequest,
     ListOutboundCoopRequestsResponse,
 )
-from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.session import UserRole
-from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
 
 
@@ -94,8 +92,6 @@ class ShowMyCooperationsViewModel:
 @dataclass
 class ShowMyCooperationsPresenter:
     url_index: UrlIndex
-    translator: Translator
-    notifier: Notifier
 
     def present(
         self,
@@ -104,7 +100,6 @@ class ShowMyCooperationsPresenter:
         list_inbound_coop_requests_response: ListInboundCoopRequestsResponse,
         list_outbound_coop_requests_response: ListOutboundCoopRequestsResponse,
         list_my_cooperating_plans_response: ListMyCooperatingPlansUseCase.Response,
-        cancel_cooperation_solicitation_response: Optional[bool] = None,
     ) -> ShowMyCooperationsViewModel:
         list_of_coordinations = ListOfCoordinationsTable(
             rows=[
@@ -119,8 +114,6 @@ class ShowMyCooperationsPresenter:
             ]
         )
 
-        self._create_cancel_message(cancel_cooperation_solicitation_response)
-
         list_of_outbound_coop_requests = ListOfOutboundCooperationRequestsTable(
             rows=[
                 self._display_outbound_coop_requests(plan)
@@ -133,7 +126,6 @@ class ShowMyCooperationsPresenter:
                 for plan in list_my_cooperating_plans_response.cooperating_plans
             ]
         )
-
         return ShowMyCooperationsViewModel(
             list_of_coordinations,
             list_of_inbound_coop_requests,
@@ -194,15 +186,3 @@ class ShowMyCooperationsPresenter:
             coop_name=plan.coop_name,
             coop_url=self.url_index.get_coop_summary_url(coop_id=plan.coop_id),
         )
-
-    def _create_cancel_message(self, cancel_coop_response: Optional[bool]) -> None:
-        if cancel_coop_response is None:
-            return
-        elif cancel_coop_response == True:
-            self.notifier.display_info(
-                self.translator.gettext("Cooperation request has been canceled.")
-            )
-        else:
-            self.notifier.display_warning(
-                self.translator.gettext("Error: Not possible to cancel request.")
-            )

--- a/tests/flask_integration/test_cancel_cooperation_request_view.py
+++ b/tests/flask_integration/test_cancel_cooperation_request_view.py
@@ -1,0 +1,21 @@
+from uuid import uuid4
+
+from tests.flask_integration.flask import ViewTestCase
+
+URL = "/company/cancel_cooperation_request"
+
+
+class CompanyViewTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_company()
+
+    def test_that_posting_valid_form_data_yields_a_redirect(self) -> None:
+        response = self.client.post(
+            URL,
+            data={
+                "plan_id": str(uuid4()),
+                "cooperation_id": str(uuid4()),
+            },
+        )
+        self.assertEqual(response.status_code, 302)

--- a/tests/www/presenters/test_cancel_cooperation_request_presenter.py
+++ b/tests/www/presenters/test_cancel_cooperation_request_presenter.py
@@ -1,0 +1,40 @@
+from parameterized import parameterized
+
+from arbeitszeit_web.www.presenters.cancel_cooperation_request_presenter import (
+    CancelCooperationRequestPresenter,
+)
+from tests.www.base_test_case import BaseTestCase
+
+
+class CancelCooperationRequestPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(CancelCooperationRequestPresenter)
+
+    def test_successfull_cancel_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(response=True)
+        assert len(self.notifier.infos) == 1
+        assert not self.notifier.warnings
+        assert self.notifier.infos[0] == self.translator.gettext(
+            "Cooperation request has been canceled."
+        )
+
+    def test_failed_cancel_request_response_is_presented_correctly(self) -> None:
+        self.presenter.render_response(response=False)
+        assert len(self.notifier.warnings) == 1
+        assert not self.notifier.infos
+        assert self.notifier.warnings[0] == self.translator.gettext(
+            "Error: Not possible to cancel request."
+        )
+
+    @parameterized.expand(
+        [
+            (True,),
+            (False,),
+        ]
+    )
+    def test_that_user_gets_redirected_to_my_cooperations_view(
+        self, response: bool
+    ) -> None:
+        view_model = self.presenter.render_response(response)
+        assert view_model.redirection_url == self.url_index.get_my_cooperations_url()

--- a/tests/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/www/presenters/test_show_my_cooperations_presenter.py
@@ -138,34 +138,6 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
             str(LIST_COORDINATIONS_RESPONSE_LEN_1.coordinations[0].count_plans_in_coop),
         )
 
-    def test_successfull_cancel_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            cancel_cooperation_solicitation_response=True,
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-        )
-        assert len(self.notifier.infos) == 1
-        assert not self.notifier.warnings
-        assert self.notifier.infos[0] == self.translator.gettext(
-            "Cooperation request has been canceled."
-        )
-
-    def test_failed_cancel_request_response_is_presented_correctly(self) -> None:
-        self.presenter.present(
-            list_coord_response=LIST_COORDINATIONS_RESPONSE_LEN_1,
-            list_inbound_coop_requests_response=get_inbound_response_length_1(),
-            list_outbound_coop_requests_response=get_outbound_response_length_1(),
-            cancel_cooperation_solicitation_response=False,
-            list_my_cooperating_plans_response=get_coop_plans_response_length_1(),
-        )
-        assert len(self.notifier.warnings) == 1
-        assert not self.notifier.infos
-        assert self.notifier.warnings[0] == self.translator.gettext(
-            "Error: Not possible to cancel request."
-        )
-
 
 class InboundTest(BaseTestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
Before this commit the functionality to cancel a cooperation request was all tied up with the logic to present the user an overview over their current cooperations and requests. This commit isolates the CancelCooperationSolicitation use case logic into its own flask route.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975