### PR TITLE
Fix bug in CreateDraftView

### DIFF
--- a/arbeitszeit_flask/views/create_draft_view.py
+++ b/arbeitszeit_flask/views/create_draft_view.py
@@ -27,6 +27,8 @@ class CreateDraftView:
     @commit_changes
     def POST(self) -> Response:
         form = CreateDraftForm(request.form)
+        if not form.validate():
+            return self._render_form(form, status_code=400)
         use_case_request = self.controller.import_form_data(form)
         response = self.use_case.create_draft(use_case_request)
         if response.is_rejected:
@@ -35,10 +37,17 @@ class CreateDraftView:
         return redirect(self.url_index.get_my_plan_drafts_url())
 
     def GET(self) -> Response:
+        return self._render_form(
+            form=CreateDraftForm(),
+            status_code=200,
+        )
+
+    def _render_form(self, form: CreateDraftForm, status_code: int) -> Response:
         return FlaskResponse(
             render_template(
                 "company/create_draft.html",
-                form=CreateDraftForm(),
+                form=form,
                 cancel_url=self.url_index.get_my_plan_drafts_url(),
-            )
+            ),
+            status=status_code,
         )

--- a/tests/flask_integration/test_create_draft_view.py
+++ b/tests/flask_integration/test_create_draft_view.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from typing import Dict
 
+from parameterized import parameterized
+
 from arbeitszeit.use_cases.show_my_plans import ShowMyPlansRequest, ShowMyPlansUseCase
 from tests.data_generators import PlanGenerator
 from tests.request import FakeRequest
@@ -47,6 +49,24 @@ class AuthenticatedCompanyTestsForPost(ViewTestCase):
             self._count_drafts_of_company(),
             1,
         )
+
+    def test_posting_invalid_form_data_yields_status_code_400(self) -> None:
+        response = self.client.post("/company/create_draft", data={})
+        assert response.status_code == 400
+
+    @parameterized.expand(
+        [
+            ("testname 123",),
+            ("other test name",),
+        ]
+    )
+    def test_posting_invalid_form_data_yields_response_that_contains_the_original_form_field_values(
+        self, expected_product_name
+    ) -> None:
+        response = self.client.post(
+            "/company/create_draft", data=dict(prd_name=expected_product_name)
+        )
+        assert expected_product_name in response.text
 
     def _create_form_data(self) -> Dict:
         return dict(


### PR DESCRIPTION
Before this change there was a bug in CreateDraftView. The was long undetected as it is hard to trigger the failure resulting from the bug. The user would need to submit form data to the view that contained erroneous planning data. This would have led to an exception being raised in a CreatePlanDraft use case object. The application would have "crashed" with a 500 error response instead of rendering the original form back to the user with an error message. The bug was addressed by including proper form validation in POST handler of the method and returning the rendered form to the user when form validation fails.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975