### PR TITLE
Remove NixOS 23.11 from flake inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,22 +55,6 @@
         "type": "github"
       }
     },
-    "nixos-23-11": {
-      "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixos-24-05": {
       "locked": {
         "lastModified": 1721821769,
@@ -123,7 +107,6 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-23-11": "nixos-23-11",
         "nixos-24-05": "nixos-24-05",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   description = "Arbeitszeitapp";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-23-11.url = "github:NixOS/nixpkgs/nixos-23.11";
     nixos-24-05.url = "github:NixOS/nixpkgs/nixos-24.05";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
@@ -14,7 +13,6 @@
       nixpkgs,
       flake-utils,
       flask-profiler,
-      nixos-23-11,
       nixos-24-05,
     }:
     let
@@ -31,10 +29,6 @@
             inherit system;
             overlays = [ self.overlays.default ];
           };
-          pkgs-23-11 = import nixos-23-11 {
-            inherit system;
-            overlays = [ self.overlays.default ];
-          };
           pkgs-24-05 = import nixos-24-05 {
             inherit system;
             overlays = [ self.overlays.default ];
@@ -43,7 +37,6 @@
         {
           devShells = rec {
             default = nixos-unstable;
-            nixos-23-11 = pkgs-23-11.callPackage nix/devShell.nix { includeGlibcLocales = !isMacOs; };
             nixos-24-05 = pkgs-24-05.callPackage nix/devShell.nix { includeGlibcLocales = !isMacOs; };
             nixos-unstable = pkgs.callPackage nix/devShell.nix {
               includeGlibcLocales = !isMacOs;
@@ -68,8 +61,6 @@
             arbeitszeit-python311-nixpkgs-unstable = pkgs.python311.pkgs.arbeitszeitapp;
             arbeitszeit-python3-nixpkgs-stable = pkgs-24-05.python3.pkgs.arbeitszeitapp;
             arbeitszeit-python311-nixpkgs-stable = pkgs-24-05.python311.pkgs.arbeitszeitapp;
-            arbeitszeit-python3-nixpkgs-old-stable = pkgs-23-11.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python311-nixpkgs-old-stable = pkgs-23-11.python311.pkgs.arbeitszeitapp;
           };
         }
       );


### PR DESCRIPTION
This commit removes the definitions for NixOS 23.11 from the flake inputs of this repository.  This was done to reduce build and test times. Since all systems that (are currently known to) run the arbeitszeitapp are on NixOS 24.05 there is no practical need for testing with the older stable version of NixOS.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975