### PR TITLE
Implement PreviewPrivateConsumptionUseCase

### DIFF
--- a/arbeitszeit/use_cases/preview_private_consumption.py
+++ b/arbeitszeit/use_cases/preview_private_consumption.py
@@ -1,0 +1,46 @@
+from dataclasses import dataclass
+from decimal import Decimal
+from uuid import UUID
+
+from arbeitszeit.repositories import DatabaseGateway
+
+
+@dataclass
+class Request:
+    plan: UUID | None = None
+    amount: int | None = None
+
+
+@dataclass
+class ProductInformation:
+    name: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class Response:
+    product: ProductInformation | None = None
+    total_cost: Decimal | None = None
+
+
+@dataclass
+class PreviewPrivateConsumptionUseCase:
+    database: DatabaseGateway
+
+    def preview_private_consumption(self, request: Request) -> Response:
+        if not request.plan:
+            return Response()
+        plan = self.database.get_plans().with_id(request.plan).first()
+        if not plan:
+            return Response()
+        product = ProductInformation(
+            name=plan.prd_name,
+            description=plan.description,
+        )
+        if request.amount is None or request.amount <= 0:
+            return Response(product=product)
+        total_cost = plan.production_costs.total_cost() * request.amount
+        return Response(
+            product=product,
+            total_cost=total_cost,
+        )

--- a/tests/use_cases/test_preview_private_consumption.py
+++ b/tests/use_cases/test_preview_private_consumption.py
@@ -1,0 +1,94 @@
+from decimal import Decimal
+
+from parameterized import parameterized
+
+from arbeitszeit.records import ProductionCosts
+from arbeitszeit.use_cases import preview_private_consumption
+
+from .base_test_case import BaseTestCase
+
+
+class PreviewPrivateConsumptionTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.use_case = self.injector.get(
+            preview_private_consumption.PreviewPrivateConsumptionUseCase
+        )
+
+    def test_that_request_without_plan_id_yields_response_without_product_info(
+        self,
+    ) -> None:
+        request = preview_private_consumption.Request()
+        response = self.use_case.preview_private_consumption(request)
+        assert response.product is None
+
+    @parameterized.expand(
+        [
+            ("test name",),
+            ("other test name",),
+        ]
+    )
+    def test_that_with_plan_id_for_active_plan_supplied_the_product_name_is_included_in_response(
+        self, expected_product_name: str
+    ) -> None:
+        plan = self.plan_generator.create_plan(product_name=expected_product_name)
+        request = preview_private_consumption.Request(plan=plan)
+        response = self.use_case.preview_private_consumption(request)
+        assert response.product and response.product.name == expected_product_name
+
+    @parameterized.expand(
+        [
+            ("test description",),
+            ("other description",),
+        ]
+    )
+    def test_that_with_plan_id_for_active_plan_supplied_the_product_description_is_included_in_response(
+        self, expected_product_description: str
+    ) -> None:
+        plan = self.plan_generator.create_plan(description=expected_product_description)
+        request = preview_private_consumption.Request(plan=plan)
+        response = self.use_case.preview_private_consumption(request)
+        assert (
+            response.product
+            and response.product.description == expected_product_description
+        )
+
+    def test_that_with_amount_unset_there_is_no_total_cost_in_response(self) -> None:
+        request = preview_private_consumption.Request(amount=None)
+        response = self.use_case.preview_private_consumption(request)
+        assert response.total_cost is None
+
+    @parameterized.expand(
+        [
+            (Decimal(1),),
+            (Decimal(5),),
+        ]
+    )
+    def test_that_with_amount_of_1_the_total_cost_is_equal_to_individual_production_cost(
+        self, individual_cost: Decimal
+    ) -> None:
+        plan = self.plan_generator.create_plan(
+            costs=ProductionCosts(
+                labour_cost=individual_cost,
+                means_cost=Decimal(0),
+                resource_cost=Decimal(0),
+            ),
+            amount=1,
+        )
+        request = preview_private_consumption.Request(amount=1, plan=plan)
+        response = self.use_case.preview_private_consumption(request)
+        assert response.total_cost == individual_cost
+
+    @parameterized.expand(
+        [
+            (0,),
+            (-1,),
+        ]
+    )
+    def test_that_total_cost_is_only_available_for_positive_amount(
+        self, amount: int
+    ) -> None:
+        plan = self.plan_generator.create_plan()
+        request = preview_private_consumption.Request(amount=amount, plan=plan)
+        response = self.use_case.preview_private_consumption(request)
+        assert response.total_cost is None


### PR DESCRIPTION
This PreviewPrivateConsumptionUseCase implemented in this commit is supposed to be included in the workflow for members to register their individual consumption of goods and services through the app.  The use case is not yet hooked into the web code of the app. If hooked into the web code this use case would provide basic product information for a given plan id and the total consumption cost in case the amount is also provided. The information will be displayed for the user so that they can more easily identify what kind of product and how much they are about to "consume".

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975