### PR TITLE
Reimplement register_private_consumption web logic

### DIFF
--- a/arbeitszeit_flask/forms.py
+++ b/arbeitszeit_flask/forms.py
@@ -208,29 +208,6 @@ class LoginForm(Form):
         return WtFormField(form=self, field_name="remember")
 
 
-class RegisterPrivateConsumptionForm(Form):
-    plan_id = StringField(
-        trans.lazy_gettext("Plan ID"),
-        render_kw={"placeholder": trans.lazy_gettext("Plan ID")},
-        validators=[
-            validators.InputRequired(),
-        ],
-    )
-    amount = StringField(
-        trans.lazy_gettext("Amount"),
-        render_kw={"placeholder": trans.lazy_gettext("Amount")},
-        validators=[
-            validators.InputRequired(),
-        ],
-    )
-
-    def amount_field(self) -> WtFormField[str]:
-        return WtFormField(form=self, field_name="amount")
-
-    def plan_id_field(self) -> WtFormField[str]:
-        return WtFormField(form=self, field_name="plan_id")
-
-
 class CompanySearchForm(Form):
     choices = [
         ("Name", trans.lazy_gettext("Name")),

--- a/arbeitszeit_flask/templates/member/register_private_consumption.html
+++ b/arbeitszeit_flask/templates/member/register_private_consumption.html
@@ -14,26 +14,49 @@
             </h1>
             <br>
             <div class="content">
-                {% for field_name, field_errors in form.errors|dictsort if field_errors %}
-                {% for error in field_errors %}
-                <div class="notification is-danger">
-                    {{ form[field_name].label }}: {{ error }}
-                </div>
-                {% endfor %}
-                {% endfor %}
                 <form method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">
                         <label class="label">{{ gettext("Plan ID") }}</label>
                         <div class="control">
-                            {{ form.plan_id(class_="input") }}
+                          <input
+                            class="input"
+                            id="plan_id"
+                            name="plan_id"
+                            placeholder="{{ gettext('Plan ID') }}"
+                            type="text"
+                            value="{{ form.plan_id_value }}"
+                            required
+                            >
                         </div>
+                        {% if form.plan_id_errors %}
+                        <ul>
+                          {% for error in form.plan_id_errors %}
+                          <li>{{ error }}</li>
+                          {% endfor %}
+                        </ul>
+                        {% endif %}
                     </div>
                     <div class="field">
                         <label class="label">{{ gettext("Amount") }}</label>
                         <div class="control">
-                            {{ form.amount(class_="input") }}
+                          <input
+                            class="input"
+                            id="amount"
+                            name="amount"
+                            placeholder="{{ gettext('Amount') }}"
+                            type="text"
+                            value="{{ form.amount_value }}"
+                            required
+                            >
                         </div>
+                        {% if form.amount_errors %}
+                        <ul>
+                          {% for error in form.amount_errors %}
+                          <li>{{ error }}</li>
+                          {% endfor %}
+                        </ul>
+                        {% endif %}
                     </div>
                     <div class="field">
                         <div class="control">

--- a/arbeitszeit_flask/views/register_private_consumption.py
+++ b/arbeitszeit_flask/views/register_private_consumption.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from flask import Response as FlaskResponse
 from flask import redirect, render_template, request, url_for
@@ -8,9 +7,10 @@ from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumption,
 )
 from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.flask_session import FlaskSession
-from arbeitszeit_flask.forms import RegisterPrivateConsumptionForm
 from arbeitszeit_flask.types import Response
+from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
 from arbeitszeit_web.www.controllers.register_private_consumption_controller import (
     RegisterPrivateConsumptionController,
 )
@@ -28,38 +28,34 @@ class RegisterPrivateConsumptionView:
 
     @commit_changes
     def GET(self) -> Response:
-        form = RegisterPrivateConsumptionForm(request.form)
-        amount: Optional[str] = request.args.get("amount")
-        plan_id: Optional[str] = request.args.get("plan_id")
-        if amount:
-            form.amount_field().set_value(amount)
-        if plan_id:
-            form.plan_id_field().set_value(plan_id)
+        form = RegisterPrivateConsumptionForm(
+            amount_value=request.args.get("amount") or "",
+            plan_id_value=request.args.get("plan_id") or "",
+        )
         return FlaskResponse(self._render_template(form=form))
 
     @commit_changes
     def POST(self) -> Response:
-        form = RegisterPrivateConsumptionForm(request.form)
-        if not form.validate():
-            return self._handle_invalid_form(form)
         current_user = self.flask_session.get_current_user()
         assert current_user
         try:
-            use_case_request = self.controller.import_form_data(current_user, form)
-        except self.controller.FormError:
-            return self._handle_invalid_form(form)
+            use_case_request = self.controller.import_form_data(
+                current_user, FlaskRequest()
+            )
+        except self.controller.FormError as error:
+            return FlaskResponse(self._render_template(error.form), status=400)
         response = self.register_private_consumption.register_private_consumption(
             use_case_request
         )
-        view_model = self.presenter.present(response)
+        view_model = self.presenter.present(response, request=FlaskRequest())
         if view_model.status_code == 200:
             return redirect(url_for("main_member.register_private_consumption"))
         return FlaskResponse(
-            self._render_template(form=form), status=view_model.status_code
+            render_template(
+                "member/register_private_consumption.html", form=view_model.form
+            ),
+            status=view_model.status_code,
         )
 
     def _render_template(self, form: RegisterPrivateConsumptionForm) -> str:
         return render_template("member/register_private_consumption.html", form=form)
-
-    def _handle_invalid_form(self, form: RegisterPrivateConsumptionForm) -> Response:
-        return FlaskResponse(self._render_template(form), status=400)

--- a/arbeitszeit_web/forms.py
+++ b/arbeitszeit_web/forms.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from decimal import Decimal
 from typing import Protocol
 
@@ -56,12 +57,6 @@ class DraftForm(Protocol):
     def is_public_service_field(self) -> FormField[bool]: ...
 
 
-class RegisterPrivateConsumptionForm(Protocol):
-    def amount_field(self) -> FormField[str]: ...
-
-    def plan_id_field(self) -> FormField[str]: ...
-
-
 class RegisterProductiveConsumptionForm(Protocol):
     def amount_field(self) -> FormField[str]: ...
 
@@ -89,3 +84,11 @@ class RequestCoordinationTransferForm(Protocol):
 
 class ConfirmEmailAddressChangeForm(Protocol):
     def is_accepted_field(self) -> FormField[bool]: ...
+
+
+@dataclass
+class RegisterPrivateConsumptionForm:
+    plan_id_value: str
+    amount_value: str
+    plan_id_errors: list[str] = field(default_factory=list)
+    amount_errors: list[str] = field(default_factory=list)

--- a/arbeitszeit_web/www/controllers/register_private_consumption_controller.py
+++ b/arbeitszeit_web/www/controllers/register_private_consumption_controller.py
@@ -6,36 +6,76 @@ from uuid import UUID
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionRequest,
 )
-from arbeitszeit_web.fields import parse_formfield
 from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
+from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
-from arbeitszeit_web.www.formfield_parsers import PositiveIntegerParser, UuidParser
 
 
 @dataclass
 class RegisterPrivateConsumptionController:
+    @dataclass
     class FormError(Exception):
-        pass
+        form: RegisterPrivateConsumptionForm
 
-    positive_integer_parser: PositiveIntegerParser
-    uuid_parser: UuidParser
     translator: Translator
 
     def import_form_data(
-        self, current_user: UUID, form: RegisterPrivateConsumptionForm
+        self, current_user: UUID, request: Request
     ) -> RegisterPrivateConsumptionRequest:
-        plan_id = parse_formfield(
-            form.plan_id_field(),
-            self.uuid_parser.with_invalid_uuid_message(
-                self.translator.gettext("Plan ID is invalid.")
-            ),
-        )
-        amount = parse_formfield(
-            form.amount_field(),
-            self.positive_integer_parser,
-        )
-        if not plan_id or not amount:
-            raise self.FormError()
+        plan_id: UUID
+        amount: int
+        if plan_id_field := request.get_form("plan_id"):
+            try:
+                plan_id = UUID(plan_id_field)
+            except ValueError:
+                raise self.create_form_error(
+                    request,
+                    plan_id_errors=[self.translator.gettext("Plan ID is invalid.")],
+                )
+        else:
+            raise self.create_form_error(
+                request, plan_id_errors=[self.translator.gettext("Plan ID is invalid.")]
+            )
+        if amount_field := request.get_form("amount"):
+            try:
+                amount = int(amount_field)
+            except ValueError:
+                raise self.create_form_error(
+                    request,
+                    amount_errors=[self.translator.gettext("This is not an integer.")],
+                )
+        else:
+            raise self.create_form_error(
+                request,
+                amount_errors=[self.translator.gettext("You must specify an amount.")],
+            )
+        if amount < 1:
+            raise self.create_form_error(
+                request,
+                amount_errors=[
+                    self.translator.gettext("Must be a number larger than zero.")
+                ],
+            )
         return RegisterPrivateConsumptionRequest(
-            consumer=current_user, plan=plan_id.value, amount=amount.value
+            consumer=current_user, plan=plan_id, amount=amount
+        )
+
+    def create_form_error(
+        self,
+        request: Request,
+        *,
+        plan_id_errors: list[str] | None = None,
+        amount_errors: list[str] | None = None,
+    ) -> FormError:
+        if plan_id_errors is None:
+            plan_id_errors = []
+        if amount_errors is None:
+            amount_errors = []
+        return self.FormError(
+            form=RegisterPrivateConsumptionForm(
+                plan_id_value=request.get_form("plan_id") or "",
+                plan_id_errors=plan_id_errors,
+                amount_value=request.get_form("amount") or "",
+                amount_errors=amount_errors,
+            )
         )

--- a/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
+++ b/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
@@ -4,14 +4,16 @@ from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionResponse,
     RejectionReason,
 )
+from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
+from arbeitszeit_web.notification import Notifier
+from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
-
-from ...notification import Notifier
 
 
 @dataclass
 class RegisterPrivateConsumptionViewModel:
     status_code: int
+    form: RegisterPrivateConsumptionForm
 
 
 @dataclass
@@ -20,25 +22,31 @@ class RegisterPrivateConsumptionPresenter:
     translator: Translator
 
     def present(
-        self, use_case_response: RegisterPrivateConsumptionResponse
+        self,
+        use_case_response: RegisterPrivateConsumptionResponse,
+        request: Request,
     ) -> RegisterPrivateConsumptionViewModel:
+        form = RegisterPrivateConsumptionForm(
+            plan_id_value="",
+            amount_value="",
+        )
         if use_case_response.rejection_reason is None:
             self.user_notifier.display_info(
                 self.translator.gettext("Consumption successfully registered.")
             )
-            return RegisterPrivateConsumptionViewModel(status_code=200)
+            return RegisterPrivateConsumptionViewModel(status_code=200, form=form)
         elif use_case_response.rejection_reason == RejectionReason.plan_inactive:
             self.user_notifier.display_warning(
                 self.translator.gettext(
                     "The specified plan has been expired. Please contact the selling company to provide you with an up-to-date plan ID."
                 )
             )
-            return RegisterPrivateConsumptionViewModel(status_code=410)
+            return RegisterPrivateConsumptionViewModel(status_code=410, form=form)
         elif use_case_response.rejection_reason == RejectionReason.insufficient_balance:
             self.user_notifier.display_warning(
                 self.translator.gettext("You do not have enough work certificates.")
             )
-            return RegisterPrivateConsumptionViewModel(status_code=406)
+            return RegisterPrivateConsumptionViewModel(status_code=406, form=form)
         elif (
             use_case_response.rejection_reason
             == RejectionReason.consumer_does_not_exist
@@ -48,11 +56,11 @@ class RegisterPrivateConsumptionPresenter:
                     "Failed to register private consumption. Are you logged in as a member?"
                 )
             )
-            return RegisterPrivateConsumptionViewModel(status_code=404)
+            return RegisterPrivateConsumptionViewModel(status_code=404, form=form)
         else:
             self.user_notifier.display_warning(
                 self.translator.gettext(
                     "There is no plan with the specified ID in the database."
                 )
             )
-            return RegisterPrivateConsumptionViewModel(status_code=404)
+            return RegisterPrivateConsumptionViewModel(status_code=404, form=form)

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Generic, List, Optional, Self, TypeVar
-from uuid import uuid4
 
 T = TypeVar("T")
 
@@ -86,29 +85,6 @@ class DraftForm:
 
     def is_public_service_field(self) -> FormFieldImpl[bool]:
         return self._is_public_service_field
-
-
-class RegisterPrivateConsumptionFakeForm:
-    def __init__(self) -> None:
-        self._amount: str = "1"
-        self._plan_id: str = str(uuid4())
-        self.amount_errors: List[str] = []
-        self.plan_id_errors: List[str] = []
-
-    def amount_field(self) -> FormFieldImpl[str]:
-        return FormFieldImpl(value=self._amount, errors=self.amount_errors)
-
-    def plan_id_field(self) -> FormFieldImpl[str]:
-        return FormFieldImpl(value=self._plan_id, errors=self.plan_id_errors)
-
-    def has_errors(self) -> bool:
-        return bool(self.amount_errors or self.plan_id_errors)
-
-    def set_amount(self, amount: str):
-        self._amount = amount
-
-    def set_plan_id(self, plan_id: str):
-        self._plan_id = plan_id
 
 
 class RegisterProductiveConsumptionFakeForm:

--- a/tests/www/presenters/test_register_private_consumption_presenter.py
+++ b/tests/www/presenters/test_register_private_consumption_presenter.py
@@ -5,6 +5,7 @@ from arbeitszeit.use_cases.register_private_consumption import (
 from arbeitszeit_web.www.presenters.register_private_consumption_presenter import (
     RegisterPrivateConsumptionPresenter,
 )
+from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
 
 
@@ -17,7 +18,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self,
     ) -> None:
         self.presenter.present(
-            RegisterPrivateConsumptionResponse(rejection_reason=None)
+            RegisterPrivateConsumptionResponse(rejection_reason=None),
+            request=FakeRequest(),
         )
         self.assertIn(
             self.translator.gettext("Consumption successfully registered."),
@@ -28,7 +30,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.plan_inactive
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertIn(
             self.translator.gettext(
@@ -41,7 +44,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.plan_not_found
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertIn(
             self.translator.gettext(
@@ -56,7 +60,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.insufficient_balance
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertIn(
             self.translator.gettext("You do not have enough work certificates."),
@@ -67,7 +72,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         view_model = self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.plan_not_found
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertEqual(view_model.status_code, 404)
 
@@ -75,7 +81,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self,
     ) -> None:
         view_model = self.presenter.present(
-            RegisterPrivateConsumptionResponse(rejection_reason=None)
+            RegisterPrivateConsumptionResponse(rejection_reason=None),
+            request=FakeRequest(),
         )
         self.assertEqual(view_model.status_code, 200)
 
@@ -83,7 +90,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         view_model = self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.plan_inactive
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertEqual(view_model.status_code, 410)
 
@@ -93,7 +101,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         view_model = self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.insufficient_balance
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertEqual(view_model.status_code, 406)
 
@@ -103,7 +112,8 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.consumer_does_not_exist
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertIn(
             self.translator.gettext(
@@ -118,6 +128,7 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         view_model = self.presenter.present(
             RegisterPrivateConsumptionResponse(
                 rejection_reason=RejectionReason.consumer_does_not_exist
-            )
+            ),
+            request=FakeRequest(),
         )
         self.assertEqual(view_model.status_code, 404)


### PR DESCRIPTION
This commit reimplements the web logic for registering a private consumption in the arbeitszeitapp. Previously our approach relied heavily on wtforms. This approarch proved inflexible since it is very hard to manipulate field properties of wtforms forms reliably and safely. Hence, we reimplemented the web logic with standard templating techniques where the forms data in encoded in a basic "dataclass".

This change is made in preparation for an upcoming change where the individual fields of the form in question can be set to "readonly" conditionally.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975