### PR TITLE
Move redirection decision into register_private_consumption presenter

### DIFF
--- a/arbeitszeit_flask/views/register_private_consumption.py
+++ b/arbeitszeit_flask/views/register_private_consumption.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 
 from flask import Response as FlaskResponse
-from flask import redirect, render_template, request, url_for
+from flask import redirect, render_template, request
 
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumption,
@@ -48,8 +48,8 @@ class RegisterPrivateConsumptionView:
             use_case_request
         )
         view_model = self.presenter.present(response, request=FlaskRequest())
-        if view_model.status_code == 200:
-            return redirect(url_for("main_member.register_private_consumption"))
+        if view_model.redirect_url:
+            return redirect(view_model.redirect_url)
         return FlaskResponse(
             render_template(
                 "member/register_private_consumption.html", form=view_model.form

--- a/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
+++ b/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
@@ -8,18 +8,21 @@ from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
 from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
+from arbeitszeit_web.url_index import UrlIndex
 
 
 @dataclass
 class RegisterPrivateConsumptionViewModel:
-    status_code: int
+    status_code: int | None
     form: RegisterPrivateConsumptionForm
+    redirect_url: str | None = None
 
 
 @dataclass
 class RegisterPrivateConsumptionPresenter:
     user_notifier: Notifier
     translator: Translator
+    url_index: UrlIndex
 
     def present(
         self,
@@ -34,7 +37,11 @@ class RegisterPrivateConsumptionPresenter:
             self.user_notifier.display_info(
                 self.translator.gettext("Consumption successfully registered.")
             )
-            return RegisterPrivateConsumptionViewModel(status_code=200, form=form)
+            return RegisterPrivateConsumptionViewModel(
+                status_code=None,
+                form=form,
+                redirect_url=self.url_index.get_register_private_consumption_url(),
+            )
         elif use_case_response.rejection_reason == RejectionReason.plan_inactive:
             self.user_notifier.display_warning(
                 self.translator.gettext(
@@ -63,4 +70,6 @@ class RegisterPrivateConsumptionPresenter:
                     "There is no plan with the specified ID in the database."
                 )
             )
-            return RegisterPrivateConsumptionViewModel(status_code=404, form=form)
+            return RegisterPrivateConsumptionViewModel(
+                status_code=404, form=form, redirect_url=None
+            )

--- a/tests/www/presenters/test_register_private_consumption_presenter.py
+++ b/tests/www/presenters/test_register_private_consumption_presenter.py
@@ -1,3 +1,5 @@
+from parameterized import parameterized
+
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionResponse,
     RejectionReason,
@@ -77,14 +79,43 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         )
         self.assertEqual(view_model.status_code, 404)
 
-    def test_presenter_returns_200_status_code_when_registration_was_accepted(
+    def test_status_code_is_none_when_response_is_success(
         self,
     ) -> None:
         view_model = self.presenter.present(
             RegisterPrivateConsumptionResponse(rejection_reason=None),
             request=FakeRequest(),
         )
-        self.assertEqual(view_model.status_code, 200)
+        assert view_model.status_code is None
+
+    def test_that_successful_response_results_in_redirect_url_being_set(self) -> None:
+        view_model = self.presenter.present(
+            RegisterPrivateConsumptionResponse(rejection_reason=None),
+            request=FakeRequest(),
+        )
+        assert view_model.redirect_url
+
+    def test_that_successful_response_results_in_redirect_to_register_private_consumption_url(
+        self,
+    ) -> None:
+        view_model = self.presenter.present(
+            RegisterPrivateConsumptionResponse(rejection_reason=None),
+            request=FakeRequest(),
+        )
+        assert (
+            view_model.redirect_url
+            == self.url_index.get_register_private_consumption_url()
+        )
+
+    @parameterized.expand([(reason,) for reason in RejectionReason])
+    def test_that_error_response_results_in_redirect_url_not_being_set(
+        self, reason: RejectionReason
+    ) -> None:
+        view_model = self.presenter.present(
+            RegisterPrivateConsumptionResponse(rejection_reason=reason),
+            request=FakeRequest(),
+        )
+        assert view_model.redirect_url is None
 
     def test_presenter_returns_410_status_code_when_plan_is_inactive(self) -> None:
         view_model = self.presenter.present(


### PR DESCRIPTION
This commit moves the responsibility for a possible redirect into the presenter when dealing with forms for registering private consumptions.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975