### PR TITLE
Show proper form errors when registering private consumption fails

### DIFF
--- a/arbeitszeit_flask/templates/member/register_private_consumption.html
+++ b/arbeitszeit_flask/templates/member/register_private_consumption.html
@@ -14,6 +14,13 @@
             </h1>
             <br>
             <div class="content">
+                {% if form.general_errors %}
+                <ul>
+                  {% for error in form.general_errors %}
+                  <li>{{ error }}</li>
+                  {% endfor %}
+                </ul>
+                {% endif %}
                 <form method="post">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <div class="field">

--- a/arbeitszeit_flask/views/register_private_consumption.py
+++ b/arbeitszeit_flask/views/register_private_consumption.py
@@ -15,7 +15,9 @@ from arbeitszeit_web.www.controllers.register_private_consumption_controller imp
     RegisterPrivateConsumptionController,
 )
 from arbeitszeit_web.www.presenters.register_private_consumption_presenter import (
+    Redirect,
     RegisterPrivateConsumptionPresenter,
+    RenderForm,
 )
 
 
@@ -48,14 +50,16 @@ class RegisterPrivateConsumptionView:
             use_case_request
         )
         view_model = self.presenter.present(response, request=FlaskRequest())
-        if view_model.redirect_url:
-            return redirect(view_model.redirect_url)
-        return FlaskResponse(
-            render_template(
-                "member/register_private_consumption.html", form=view_model.form
-            ),
-            status=view_model.status_code,
-        )
+        match view_model:
+            case Redirect(url):
+                return redirect(url)
+            case RenderForm(status_code=status_code, form=form):
+                return FlaskResponse(
+                    render_template(
+                        "member/register_private_consumption.html", form=form
+                    ),
+                    status=status_code,
+                )
 
     def _render_template(self, form: RegisterPrivateConsumptionForm) -> str:
         return render_template("member/register_private_consumption.html", form=form)

--- a/arbeitszeit_web/forms.py
+++ b/arbeitszeit_web/forms.py
@@ -86,9 +86,10 @@ class ConfirmEmailAddressChangeForm(Protocol):
     def is_accepted_field(self) -> FormField[bool]: ...
 
 
-@dataclass
+@dataclass(kw_only=True)
 class RegisterPrivateConsumptionForm:
     plan_id_value: str
     amount_value: str
     plan_id_errors: list[str] = field(default_factory=list)
     amount_errors: list[str] = field(default_factory=list)
+    general_errors: list[str] = field(default_factory=list)


### PR DESCRIPTION
Before this commit we would only show problems with registering a private consumption in a errors notification that would flash briefly on the screen of the user. This commit changes the behavior such that errors messages are diplayed "permanently" on the users screen, i.e. those errors messages don't fade out.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975