### PR TITLE
Redirect unautherized users for register_private_consumption

### DIFF
--- a/arbeitszeit_flask/url_index.py
+++ b/arbeitszeit_flask/url_index.py
@@ -244,3 +244,6 @@ class GeneralUrlIndex:
 
     def get_company_transactions_url(self, *, company_id: UUID) -> str:
         return url_for("main_user.get_company_transactions", company_id=company_id)
+
+    def get_member_login_url(self) -> str:
+        return url_for("auth.login_member")

--- a/arbeitszeit_flask/views/register_private_consumption.py
+++ b/arbeitszeit_flask/views/register_private_consumption.py
@@ -5,6 +5,7 @@ from flask import redirect, render_template, request
 
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumption,
+    RegisterPrivateConsumptionRequest,
 )
 from arbeitszeit_flask.database import commit_changes
 from arbeitszeit_flask.flask_request import FlaskRequest
@@ -12,13 +13,14 @@ from arbeitszeit_flask.flask_session import FlaskSession
 from arbeitszeit_flask.types import Response
 from arbeitszeit_web.forms import RegisterPrivateConsumptionForm
 from arbeitszeit_web.www.controllers.register_private_consumption_controller import (
+    FormError,
     RegisterPrivateConsumptionController,
 )
 from arbeitszeit_web.www.presenters.register_private_consumption_presenter import (
-    Redirect,
     RegisterPrivateConsumptionPresenter,
     RenderForm,
 )
+from arbeitszeit_web.www.response import Redirect
 
 
 @dataclass
@@ -38,14 +40,13 @@ class RegisterPrivateConsumptionView:
 
     @commit_changes
     def POST(self) -> Response:
-        current_user = self.flask_session.get_current_user()
-        assert current_user
-        try:
-            use_case_request = self.controller.import_form_data(
-                current_user, FlaskRequest()
-            )
-        except self.controller.FormError as error:
-            return FlaskResponse(self._render_template(error.form), status=400)
+        match self.controller.import_form_data(FlaskRequest()):
+            case FormError() as error:
+                return FlaskResponse(self._render_template(error.form), status=400)
+            case Redirect(url=url):
+                return redirect(url)
+            case RegisterPrivateConsumptionRequest() as use_case_request:
+                pass
         response = self.register_private_consumption.register_private_consumption(
             use_case_request
         )

--- a/arbeitszeit_web/url_index.py
+++ b/arbeitszeit_web/url_index.py
@@ -140,6 +140,8 @@ class UrlIndex(Protocol):
 
     def get_company_transactions_url(self, *, company_id: UUID) -> str: ...
 
+    def get_member_login_url(self) -> str: ...
+
 
 @dataclass
 class UserUrlIndex:

--- a/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
+++ b/arbeitszeit_web/www/presenters/register_private_consumption_presenter.py
@@ -9,17 +9,13 @@ from arbeitszeit_web.notification import Notifier
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
+from arbeitszeit_web.www.response import Redirect
 
 
 @dataclass
 class RenderForm:
     status_code: int
     form: RegisterPrivateConsumptionForm
-
-
-@dataclass
-class Redirect:
-    url: str
 
 
 RegisterPrivateConsumptionViewModel = Redirect | RenderForm

--- a/arbeitszeit_web/www/response.py
+++ b/arbeitszeit_web/www/response.py
@@ -1,0 +1,6 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Redirect:
+    url: str

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -490,3 +490,8 @@ class GeneralUrlIndexTests(ViewTestCase):
         url = self.url_index.get_request_change_email_url()
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
+
+    def test_that_get_member_login_url_returns_a_valid_url(self) -> None:
+        url = self.url_index.get_member_login_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/tests/www/controllers/test_register_private_consumption_controller.py
+++ b/tests/www/controllers/test_register_private_consumption_controller.py
@@ -1,112 +1,121 @@
 from typing import Optional
-from uuid import UUID, uuid4
+from uuid import uuid4
 
-import pytest
+from parameterized import parameterized
 
 from arbeitszeit.use_cases.register_private_consumption import (
     RegisterPrivateConsumptionRequest,
 )
 from arbeitszeit_web.www.controllers.register_private_consumption_controller import (
+    FormError,
     RegisterPrivateConsumptionController,
+    ViewModel,
 )
+from arbeitszeit_web.www.response import Redirect
 from tests.request import FakeRequest
 from tests.www.base_test_case import BaseTestCase
-
-ControllerResult = Optional[RegisterPrivateConsumptionRequest]
 
 
 class RegisterPrivateConsumptionControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.controller = self.injector.get(RegisterPrivateConsumptionController)
+        self.session.login_member(uuid4())
 
-    def test_error_is_raised_when_form_data_is_empty_strings(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(plan_id="", amount="")
+    def test_error_is_returned_when_form_data_is_empty_strings(self) -> None:
+        result = self._process_form(plan_id="", amount="")
+        assert isinstance(result, FormError)
 
     def test_errors_message_when_amount_is_empty(self) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(amount="")
-        assert error.value.form.amount_errors == [
+        result = self._process_form(amount="")
+        assert isinstance(result, FormError)
+        assert result.form.amount_errors == [
             self.translator.gettext("You must specify an amount.")
         ]
 
-    def test_error_is_raised_when_plan_id_is_emtpy(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(plan_id="")
+    def test_error_is_returned_when_plan_id_is_emtpy(self) -> None:
+        result = self._process_form(plan_id="")
+        assert isinstance(result, FormError)
 
-    def test_error_is_raised_when_plan_id_is_not_a_valid_uuid(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(plan_id="1872da")
+    def test_error_is_returned_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        result = self._process_form(plan_id="1872da")
+        assert isinstance(result, FormError)
 
-    def test_error_is_raised_when_amount_is_empty(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(amount="")
+    def test_error_is_returned_when_amount_is_empty(self) -> None:
+        result = self._process_form(amount="")
+        assert isinstance(result, FormError)
 
-    def test_error_is_raised_when_amount_is_negative(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(amount="-1")
+    def test_error_is_returned_when_amount_is_negative(self) -> None:
+        result = self._process_form(amount="-1")
+        assert isinstance(result, FormError)
 
-    def test_error_is_raised_when_amount_is_zero(self) -> None:
-        with self.assertRaises(self.controller.FormError):
-            self._process_form(amount="0")
+    def test_error_is_returned_when_amount_is_zero(self) -> None:
+        result = self._process_form(amount="0")
+        assert isinstance(result, FormError)
 
-    def test_error_is_raised_when_amount_is_a_floating_number(self) -> None:
-        for amount in ["1.1", "-1.1"]:
-            with self.assertRaises(self.controller.FormError):
-                self._process_form(amount=amount)
+    @parameterized.expand(
+        [
+            ("1.1",),
+            ("-1.1",),
+        ]
+    )
+    def test_error_is_returned_when_amount_is_a_floating_number(
+        self, amount: str
+    ) -> None:
+        result = self._process_form(amount=amount)
+        assert isinstance(result, FormError)
 
     def test_correct_error_message_returned_for_plan_id_when_form_data_is_empty_string(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(plan_id="", amount="")
-        assert error.value.form.plan_id_errors == [
+        result = self._process_form(plan_id="", amount="")
+        assert isinstance(result, FormError)
+        assert result.form.plan_id_errors == [
             self.translator.gettext("Plan ID is invalid.")
         ]
 
     def test_correct_error_message_returned_when_plan_id_is_invalid_uuid(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(plan_id="aa18781hh")
-        assert error.value.form.plan_id_errors == [
+        result = self._process_form(plan_id="aa18781hh")
+        assert isinstance(result, FormError)
+        assert result.form.plan_id_errors == [
             self.translator.gettext("Plan ID is invalid.")
         ]
 
     def test_correct_error_message_returned_when_amount_is_negative_int_string(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(amount="-1")
-        assert error.value.form.amount_errors == [
+        result = self._process_form(amount="-1")
+        assert isinstance(result, FormError)
+        assert result.form.amount_errors == [
             self.translator.gettext("Must be a number larger than zero.")
         ]
 
     def test_correct_error_message_returned_when_amount_is_positive_float_string(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(amount="1.1")
-        assert error.value.form.amount_errors == [
+        result = self._process_form(amount="1.1")
+        assert isinstance(result, FormError)
+        assert result.form.amount_errors == [
             self.translator.gettext("This is not an integer."),
         ]
 
     def test_correct_error_message_returned_when_amount_is_negative_float_string(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(amount="-1.1")
-        assert error.value.form.amount_errors == [
+        result = self._process_form(amount="-1.1")
+        assert isinstance(result, FormError)
+        assert result.form.amount_errors == [
             self.translator.gettext("This is not an integer."),
         ]
 
     def test_correct_error_message_returned_when_amount_string_contains_letters(
         self,
     ) -> None:
-        with pytest.raises(self.controller.FormError) as error:
-            self._process_form(amount="1a")
-        assert error.value.form.amount_errors == [
+        result = self._process_form(amount="1a")
+        assert isinstance(result, FormError)
+        assert result.form.amount_errors == [
             self.translator.gettext("This is not an integer.")
         ]
 
@@ -116,27 +125,35 @@ class RegisterPrivateConsumptionControllerTests(BaseTestCase):
 
     def test_correct_amount_is_returned(self) -> None:
         result = self._process_form(amount="1234")
-        assert result
+        assert isinstance(result, RegisterPrivateConsumptionRequest)
         self.assertEqual(result.amount, 1234)
 
     def test_correct_plan_uuid_is_returned(self) -> None:
         plan_uuid = uuid4()
         result = self._process_form(plan_id=str(plan_uuid))
-        assert result
+        assert isinstance(result, RegisterPrivateConsumptionRequest)
         self.assertEqual(result.plan, plan_uuid)
 
     def test_correct_buyer_is_returned(self) -> None:
         buyer_uuid = uuid4()
-        result = self._process_form(buyer=buyer_uuid)
-        assert result
-        self.assertEqual(result.consumer, buyer_uuid)
+        self.session.login_member(buyer_uuid)
+        result = self._process_form()
+        assert isinstance(result, RegisterPrivateConsumptionRequest)
+        assert result.consumer == buyer_uuid
+
+    def test_that_a_logged_out_user_is_redirected_to_the_member_login_page(
+        self,
+    ) -> None:
+        self.session.logout()
+        result = self._process_form()
+        assert isinstance(result, Redirect)
+        assert result.url == self.url_index.get_member_login_url()
 
     def _process_form(
         self,
-        buyer: Optional[UUID] = None,
         plan_id: Optional[str] = None,
         amount: Optional[str] = None,
-    ) -> ControllerResult:
+    ) -> ViewModel:
         request = FakeRequest()
         if plan_id is None:
             request.set_form("plan_id", str(uuid4()))
@@ -146,7 +163,4 @@ class RegisterPrivateConsumptionControllerTests(BaseTestCase):
             request.set_form("amount", "1")
         else:
             request.set_form("amount", amount)
-        return self.controller.import_form_data(
-            current_user=uuid4() if buyer is None else buyer,
-            request=request,
-        )
+        return self.controller.import_form_data(request=request)

--- a/tests/www/presenters/url_index.py
+++ b/tests/www/presenters/url_index.py
@@ -70,6 +70,7 @@ class UrlIndexTestImpl:
     get_list_of_coordinators_url = UrlIndexMethod()
     get_member_confirmation_url = UrlIndexMethod()
     get_member_dashboard_url = UrlIndexMethod()
+    get_member_login_url = UrlIndexMethod()
     get_my_cooperations_url = UrlIndexMethod()
     get_my_plan_drafts_url = UrlIndexMethod()
     get_my_plans_url = UrlIndexMethod()


### PR DESCRIPTION
The commit implements controller based redirection logic for unautherized users on the level of the controller. The RegisterPrivateConsumptionController can now return a `Redirect` object to direct users to the login page when they try to register a private consumption while not being logged in.

Plan-ID: 3a003c51-35a3-41a6-9f0a-076d8d7a0975