### PR TITLE
Allow QueryString objects to yield multiple values for one key

### DIFF
--- a/arbeitszeit_flask/flask_request.py
+++ b/arbeitszeit_flask/flask_request.py
@@ -1,26 +1,34 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, Iterable, Optional, Tuple
+from typing import Iterable, Optional, Tuple
 
 from flask import request
+from werkzeug.datastructures import MultiDict
 
 
 @dataclass
 class QueryStringImpl:
-    args: Dict[str, str]
+    args: MultiDict[str, str]
 
-    def get(self, key: str) -> Optional[str]:
-        return self.args.get(key)
+    def get(self, key: str) -> list[str]:
+        return self.args.getlist(key)
 
     def items(self) -> Iterable[Tuple[str, str]]:
-        return self.args.items()
+        return self.args.items(multi=True)
+
+    def get_last_value(self, key: str) -> str | None:
+        match self.args.getlist(key):
+            case []:
+                return None
+            case values:
+                return values[-1]
 
 
 class FlaskRequest:
     def query_string(self) -> QueryStringImpl:
         return QueryStringImpl(
-            args=dict(request.args),
+            args=request.args,
         )
 
     def get_form(self, key: str) -> Optional[str]:

--- a/arbeitszeit_web/api/controllers/query_companies_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_companies_api_controller.py
@@ -40,14 +40,14 @@ class QueryCompaniesApiController:
         )
 
     def _parse_offset(self, request: Request) -> int:
-        offset_string = request.query_string().get("offset")
+        offset_string = request.query_string().get_last_value("offset")
         if not offset_string:
             return DEFAULT_OFFSET
         offset = query_parser.string_to_non_negative_integer(offset_string)
         return offset
 
     def _parse_limit(self, request: Request) -> int:
-        limit_string = request.query_string().get("limit")
+        limit_string = request.query_string().get_last_value("limit")
         if not limit_string:
             return DEFAULT_LIMIT
         limit = query_parser.string_to_non_negative_integer(limit_string)

--- a/arbeitszeit_web/api/controllers/query_plans_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_plans_api_controller.py
@@ -42,14 +42,14 @@ class QueryPlansApiController:
         )
 
     def _parse_offset(self, request: Request) -> int:
-        offset_string = request.query_string().get("offset")
+        offset_string = request.query_string().get_last_value("offset")
         if not offset_string:
             return DEFAULT_OFFSET
         offset = query_parser.string_to_non_negative_integer(offset_string)
         return offset
 
     def _parse_limit(self, request: Request) -> int:
-        limit_string = request.query_string().get("limit")
+        limit_string = request.query_string().get_last_value("limit")
         if not limit_string:
             return DEFAULT_LIMIT
         limit = query_parser.string_to_non_negative_integer(limit_string)

--- a/arbeitszeit_web/request.py
+++ b/arbeitszeit_web/request.py
@@ -16,8 +16,20 @@ class Request(Protocol):
 
 
 class QueryString(Protocol):
-    def get(self, key: str) -> Optional[str]:
-        """Get the value for a particular query arguments."""
+    def get(self, key: str) -> list[str]:
+        """Get all values supplied by the client for a given key.
+
+        Example: Calling `r.get('a')` on a request with the query string
+            `a=1&a=2` will result in the list `['1', '2']`.
+        """
 
     def items(self) -> Iterable[Tuple[str, str]]:
         """Return all query arguments in no particular order."""
+
+    def get_last_value(self, key: str) -> str | None:
+        """Return the last value specified for a given key.
+
+        Example: Given a query string 'a=1&a=2' the call
+            `query.get_last_value('a')` must return '2' since it is the
+            last value specified for the key 'a'.
+        """

--- a/arbeitszeit_web/www/controllers/query_companies_controller.py
+++ b/arbeitszeit_web/www/controllers/query_companies_controller.py
@@ -41,7 +41,7 @@ class QueryCompaniesController:
         )
 
     def _get_pagination_offset(self) -> int:
-        page_str = self.request.query_string().get(PAGE_PARAMETER_NAME)
+        page_str = self.request.query_string().get_last_value(PAGE_PARAMETER_NAME)
         if page_str is None:
             return 0
         try:

--- a/arbeitszeit_web/www/controllers/query_plans_controller.py
+++ b/arbeitszeit_web/www/controllers/query_plans_controller.py
@@ -44,7 +44,7 @@ class QueryPlansController:
         )
 
     def _get_pagination_offset(self, request: Request) -> int:
-        page_str = request.query_string().get(PAGE_PARAMETER_NAME)
+        page_str = request.query_string().get_last_value(PAGE_PARAMETER_NAME)
         if page_str is None:
             return 0
         try:

--- a/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
+++ b/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
@@ -28,7 +28,9 @@ class SelectProductiveConsumptionController:
         )
 
     def _process_plan_id(self) -> UUID | None:
-        plan_id_from_query_string = self.request.query_string().get("plan_id")
+        plan_id_from_query_string = self.request.query_string().get_last_value(
+            "plan_id"
+        )
         plan_id_from_form = self.request.get_form("plan_id")
         if not plan_id_from_query_string and not plan_id_from_form:
             return None
@@ -48,7 +50,7 @@ class SelectProductiveConsumptionController:
             raise self.InputDataError()
 
     def _process_amount(self) -> int | None:
-        amount_from_query_string = self.request.query_string().get("amount")
+        amount_from_query_string = self.request.query_string().get_last_value("amount")
         amount_from_form = self.request.get_form("amount")
         if not amount_from_query_string and not amount_from_form:
             return None
@@ -68,7 +70,7 @@ class SelectProductiveConsumptionController:
             raise self.InputDataError()
 
     def _process_consumption_type(self) -> ConsumptionType | None:
-        consumption_type_from_query_string = self.request.query_string().get(
+        consumption_type_from_query_string = self.request.query_string().get_last_value(
             "type_of_consumption"
         )
         consumption_type_from_form = self.request.get_form("type_of_consumption")

--- a/arbeitszeit_web/www/presenters/end_cooperation_presenter.py
+++ b/arbeitszeit_web/www/presenters/end_cooperation_presenter.py
@@ -38,10 +38,12 @@ class EndCooperationPresenter:
     def _get_redirect_url(self) -> str:
         referer = self.request.get_header("Referer")
         query_string = self.request.query_string()
-        plan_id = query_string.get("plan_id") or self.request.get_form("plan_id")
-        cooperation_id = query_string.get("cooperation_id") or self.request.get_form(
-            "cooperation_id"
+        plan_id = query_string.get_last_value("plan_id") or self.request.get_form(
+            "plan_id"
         )
+        cooperation_id = query_string.get_last_value(
+            "cooperation_id"
+        ) or self.request.get_form("cooperation_id")
         assert plan_id
         assert cooperation_id
         if referer:

--- a/tests/flask_integration/test_query_string_impl.py
+++ b/tests/flask_integration/test_query_string_impl.py
@@ -1,3 +1,5 @@
+from werkzeug.datastructures import MultiDict
+
 from arbeitszeit_flask.flask_request import QueryStringImpl
 
 from .flask import FlaskTestCase
@@ -5,9 +7,9 @@ from .flask import FlaskTestCase
 
 class QueryStringTests(FlaskTestCase):
     def test_can_get_values_passed_in(self) -> None:
-        query_string = QueryStringImpl(dict(a="1"))
-        self.assertEqual(query_string.get("a"), "1")
+        query_string = QueryStringImpl(MultiDict(mapping=dict(a="1")))
+        assert query_string.get("a") == ["1"]
 
     def test_getting_values_that_are_not_in_arguments_yields_none(self) -> None:
-        query_string = QueryStringImpl(dict(a="1"))
-        self.assertIsNone(query_string.get("b"))
+        query_string = QueryStringImpl(MultiDict(mapping=dict(a="1")))
+        assert query_string.get("b") == []


### PR DESCRIPTION
This commit changes the interface to `QueryString` objects. Before this change `QueryString` objects were only able to yield a single value for a given key. Now the method `QueryString.get` returns a list of all values supplied for a given key. The `get_last_value` method was added for convenient access to (possible) single value for cases where the app does not need to handle multiple for a single key.

This change was made because the old interface to the query string part of a URI was overly simplistic. It hid the fact that a query string can have multiple values for a single key from the developer. The new interface makes easier to remember the fact that a query string does not need to have only a single value for a key and makes it explicit that we choose a particular value from a possible set of values, which is currently always the last specified value in a query string.