### PR TITLE
Allow for handling all possible json values via Request interface

### DIFF
--- a/arbeitszeit_flask/flask_request.py
+++ b/arbeitszeit_flask/flask_request.py
@@ -6,6 +6,8 @@ from typing import Iterable, Optional, Tuple
 from flask import request
 from werkzeug.datastructures import MultiDict
 
+from arbeitszeit_web.json import JsonValue
+
 
 @dataclass
 class QueryStringImpl:
@@ -34,8 +36,8 @@ class FlaskRequest:
     def get_form(self, key: str) -> Optional[str]:
         return request.form.get(key, None)
 
-    def get_json(self, key: str) -> Optional[str]:
-        return request.get_json().get(key, None)
+    def get_json(self) -> JsonValue | None:
+        return request.get_json()
 
     def get_header(self, key: str) -> Optional[str]:
         return request.headers.get(key, None)

--- a/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
+++ b/arbeitszeit_web/api/controllers/liquid_means_consumption_controller.py
@@ -56,9 +56,13 @@ class LiquidMeansConsumptionController:
         return current_user
 
     def _parse_plan_id(self) -> UUID:
-        plan_id = self.request.get_json("plan_id")
+        json_body = self.request.get_json()
+        if not isinstance(json_body, dict):
+            raise BadRequest(message="Plan id missing.")
+        plan_id = json_body.get("plan_id")
         if not plan_id:
             raise BadRequest(message="Plan id missing.")
+        assert isinstance(plan_id, str)
         try:
             plan_uuid = UUID(plan_id)
         except ValueError:
@@ -66,9 +70,13 @@ class LiquidMeansConsumptionController:
         return plan_uuid
 
     def _parse_amount(self) -> int:
-        amount = self.request.get_json("amount")
+        json_body = self.request.get_json()
+        assert isinstance(json_body, dict)
+        amount = json_body.get("amount")
         if not amount:
             raise BadRequest(message="Amount missing.")
+        if not isinstance(amount, (int, str, float)):
+            raise BadRequest(message=f"Amount must be an integer, got {amount}.")
         try:
             amount_int = int(amount)
         except ValueError:

--- a/arbeitszeit_web/api/controllers/login_company_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_company_api_controller.py
@@ -28,10 +28,15 @@ class LoginCompanyApiController:
     request: Request
 
     def create_request(self) -> LogInCompanyUseCase.Request:
-        email = self.request.get_json("email")
-        password = self.request.get_json("password")
+        json_body = self.request.get_json()
+        if not isinstance(json_body, dict):
+            raise BadRequest("Email missing.")
+        email = json_body.get("email")
+        password = json_body.get("password")
         if not email:
             raise BadRequest(message="Email missing.")
         if not password:
             raise BadRequest(message="Password missing.")
+        assert isinstance(email, str)
+        assert isinstance(password, str)
         return LogInCompanyUseCase.Request(email_address=email, password=password)

--- a/arbeitszeit_web/api/controllers/login_member_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_member_api_controller.py
@@ -28,10 +28,15 @@ class LoginMemberApiController:
     request: Request
 
     def create_request(self) -> LogInMemberUseCase.Request:
-        email = self.request.get_json("email")
-        password = self.request.get_json("password")
+        json_body = self.request.get_json()
+        if not isinstance(json_body, dict):
+            raise BadRequest("Email missing.")
+        email = json_body.get("email")
+        password = json_body.get("password")
         if not email:
             raise BadRequest(message="Email missing.")
         if not password:
             raise BadRequest(message="Password missing.")
+        assert isinstance(email, str)
+        assert isinstance(password, str)
         return LogInMemberUseCase.Request(email=email, password=password)

--- a/arbeitszeit_web/json.py
+++ b/arbeitszeit_web/json.py
@@ -1,0 +1,1 @@
+JsonValue = int | float | str | list["JsonValue"] | None | dict[str, "JsonValue"]

--- a/arbeitszeit_web/request.py
+++ b/arbeitszeit_web/request.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Protocol, Tuple
 
+from arbeitszeit_web.json import JsonValue
+
 
 class Request(Protocol):
     def query_string(self) -> QueryString: ...
 
     def get_form(self, key: str) -> Optional[str]: ...
 
-    def get_json(self, key: str) -> Optional[str]: ...
+    def get_json(self) -> JsonValue | None: ...
 
     def get_header(self, key: str) -> Optional[str]: ...
 

--- a/tests/api/controllers/test_liquid_means_consumption_controller.py
+++ b/tests/api/controllers/test_liquid_means_consumption_controller.py
@@ -46,14 +46,14 @@ class ControllerTests(BaseTestCase):
     def test_controller_raises_bad_request_when_plan_id_is_missing(self) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("amount", "10")
+        self.request.set_json({"amount": "10"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
     def test_controller_raises_bad_request_when_amount_is_missing(self) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
+        self.request.set_json({"plan_id": str(uuid4())})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
@@ -62,16 +62,14 @@ class ControllerTests(BaseTestCase):
     ) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", "invalid_uuid")
-        self.request.set_json("amount", "10")
+        self.request.set_json({"plan_id": "invalid_uuid", "amount": "10"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
     def test_controller_raises_bad_request_when_amount_is_a_character(self) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "invalid_amount")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "invalid_amount"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
@@ -80,24 +78,21 @@ class ControllerTests(BaseTestCase):
     ) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "10.5")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "10.5"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
     def test_controller_raises_bad_request_when_amount_is_zero(self) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "0")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "0"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
     def test_controller_raises_bad_request_when_amount_is_negative(self) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "-10")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "-10"})
         with self.assertRaises(BadRequest):
             self.controller.create_request()
 
@@ -106,8 +101,7 @@ class ControllerTests(BaseTestCase):
     ) -> None:
         expected_company = self.company_generator.create_company()
         self.session.login_company(expected_company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "10")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "10"})
         request = self.controller.create_request()
         self.assertEqual(request.consumer, expected_company)
 
@@ -117,8 +111,7 @@ class ControllerTests(BaseTestCase):
         company = self.company_generator.create_company()
         self.session.login_company(company)
         expected_plan_id = uuid4()
-        self.request.set_json("plan_id", str(expected_plan_id))
-        self.request.set_json("amount", "10")
+        self.request.set_json({"plan_id": str(expected_plan_id), "amount": "10"})
         request = self.controller.create_request()
         self.assertEqual(request.plan, expected_plan_id)
 
@@ -134,8 +127,7 @@ class ControllerTests(BaseTestCase):
     ) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", str(expected_amount))
+        self.request.set_json({"plan_id": str(uuid4()), "amount": str(expected_amount)})
         request = self.controller.create_request()
         self.assertEqual(request.amount, expected_amount)
 
@@ -144,8 +136,7 @@ class ControllerTests(BaseTestCase):
     ) -> None:
         company = self.company_generator.create_company()
         self.session.login_company(company)
-        self.request.set_json("plan_id", str(uuid4()))
-        self.request.set_json("amount", "10")
+        self.request.set_json({"plan_id": str(uuid4()), "amount": "10"})
         request = self.controller.create_request()
         self.assertEqual(request.consumption_type, ConsumptionType.raw_materials)
 

--- a/tests/api/controllers/test_login_company_api_controller.py
+++ b/tests/api/controllers/test_login_company_api_controller.py
@@ -22,13 +22,13 @@ class ControllerTests(BaseTestCase):
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_password_but_no_email(self) -> None:
-        self.request.set_json(key="password", value="123safe")
+        self.request.set_json({"password": "123safe"})
         with self.assertRaises(BadRequest) as err:
             self.controller.create_request()
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_email_but_no_password(self) -> None:
-        self.request.set_json(key="email", value="test@test.org")
+        self.request.set_json({"email": "test@test.org"})
         with self.assertRaises(BadRequest) as err:
             self.controller.create_request()
         self.assertEqual(err.exception.message, "Password missing.")
@@ -36,8 +36,7 @@ class ControllerTests(BaseTestCase):
     def test_email_and_password_are_passed_to_use_case_request(self) -> None:
         EXPECTED_MAIL = "test@test.org"
         EXPECTED_PASSWORD = "123safe"
-        self.request.set_json(key="email", value=EXPECTED_MAIL)
-        self.request.set_json(key="password", value=EXPECTED_PASSWORD)
+        self.request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
         use_case_request = self.controller.create_request()
         assert use_case_request
         self.assertEqual(use_case_request.email_address, EXPECTED_MAIL)

--- a/tests/api/controllers/test_login_member_api_controller.py
+++ b/tests/api/controllers/test_login_member_api_controller.py
@@ -22,13 +22,13 @@ class ControllerTests(BaseTestCase):
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_email_but_no_password(self) -> None:
-        self.request.set_json(key="email", value="test@test.org")
+        self.request.set_json({"email": "test@test.org"})
         with self.assertRaises(BadRequest) as err:
             self.controller.create_request()
         self.assertEqual(err.exception.message, "Password missing.")
 
     def test_bad_request_raised_when_request_has_password_but_no_email(self) -> None:
-        self.request.set_json(key="password", value="123safe")
+        self.request.set_json({"password": "123safe"})
         with self.assertRaises(BadRequest) as err:
             self.controller.create_request()
         self.assertEqual(err.exception.message, "Email missing.")
@@ -36,8 +36,7 @@ class ControllerTests(BaseTestCase):
     def test_email_and_password_are_passed_to_use_case_request(self) -> None:
         EXPECTED_MAIL = "test@test.org"
         EXPECTED_PASSWORD = "123safe"
-        self.request.set_json(key="email", value=EXPECTED_MAIL)
-        self.request.set_json(key="password", value=EXPECTED_PASSWORD)
+        self.request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
         use_case_request = self.controller.create_request()
         assert use_case_request
         self.assertEqual(use_case_request.email, EXPECTED_MAIL)

--- a/tests/request.py
+++ b/tests/request.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Iterable, Optional
 
 from arbeitszeit.injector import singleton
+from arbeitszeit_web.json import JsonValue
 
 
 @dataclass
@@ -29,7 +30,7 @@ class FakeRequest:
     def __init__(self) -> None:
         self._args = FakeQueryString()
         self._form: Dict[str, str] = dict()
-        self._json: Dict[str, str] = dict()
+        self._json: JsonValue | None = None
         self._environ: Dict[str, str] = dict()
 
     def query_string(self) -> FakeQueryString:
@@ -41,8 +42,8 @@ class FakeRequest:
     def get_header(self, key: str) -> Optional[str]:
         return self._environ.get(key, None)
 
-    def get_json(self, key: str) -> Optional[str]:
-        return self._json.get(key, None)
+    def get_json(self) -> JsonValue | None:
+        return self._json
 
     def set_arg(self, arg: str, value: object) -> None:
         self._args.values[arg] = [str(value)]
@@ -57,8 +58,8 @@ class FakeRequest:
         else:
             self._environ[key] = value
 
-    def set_json(self, key: str, value: str) -> None:
-        self._json[key] = value
+    def set_json(self, value: JsonValue) -> None:
+        self._json = value
 
     def get_request_target(self) -> str:
         return "/"


### PR DESCRIPTION
This commit changes the interface to `Request` objects with respect to request body parsing slightly. This affects the `get_json` method only.

Before the `get_json` method would have the signature `get_json(str) -> str | None`. This signature only allows for json values to be handled that are objects with strings as values. This is only a very narrow subset of possible json values.

We introduced a type `JsonValue` that models all possible json values after parsing. Json objects are mapped to `dict` and json arrays to `list`. Numbers are mapped to either `int` or `float`. The `get_json` method now returns an object of that type or `None`.