### PR TITLE
Refactor `EndCooperatoinController` to receive request as argument

### DIFF
--- a/arbeitszeit_flask/views/end_cooperation_view.py
+++ b/arbeitszeit_flask/views/end_cooperation_view.py
@@ -5,6 +5,7 @@ from flask import redirect
 from arbeitszeit.use_cases.end_cooperation import EndCooperation
 from arbeitszeit_flask import types
 from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.views.http_error_view import http_404
 from arbeitszeit_web.www.controllers.end_cooperation_controller import (
     EndCooperationController,
@@ -22,7 +23,7 @@ class EndCooperationView:
 
     @commit_changes
     def POST(self) -> types.Response:
-        use_case_request = self.controller.process_request_data()
+        use_case_request = self.controller.process_request_data(request=FlaskRequest())
         if use_case_request is None:
             return http_404()
         use_case_response = self.end_cooperation(use_case_request)

--- a/arbeitszeit_web/www/controllers/end_cooperation_controller.py
+++ b/arbeitszeit_web/www/controllers/end_cooperation_controller.py
@@ -10,11 +10,10 @@ from arbeitszeit_web.session import Session
 @dataclass
 class EndCooperationController:
     session: Session
-    request: Request
 
-    def process_request_data(self) -> Optional[EndCooperationRequest]:
-        plan_id = self.request.get_form("plan_id")
-        cooperation_id = self.request.get_form("cooperation_id")
+    def process_request_data(self, request: Request) -> Optional[EndCooperationRequest]:
+        plan_id = request.get_form("plan_id")
+        cooperation_id = request.get_form("cooperation_id")
         current_user = self.session.get_current_user()
         if not all([plan_id, cooperation_id, current_user]):
             return None

--- a/tests/www/controllers/test_end_cooperation_controller.py
+++ b/tests/www/controllers/test_end_cooperation_controller.py
@@ -11,69 +11,75 @@ from tests.www.base_test_case import BaseTestCase
 class EndCooperationControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.request = self.injector.get(FakeRequest)
         self.controller = self.injector.get(EndCooperationController)
 
     def test_when_user_is_not_authenticated_then_we_cannot_get_a_use_case_request(
         self,
     ) -> None:
-        self.request.set_form("plan_id", str(uuid4()))
-        self.request.set_form("cooperation_id", str(uuid4()))
+        request = FakeRequest()
+        request.set_form("plan_id", str(uuid4()))
+        request.set_form("cooperation_id", str(uuid4()))
         self.session.logout()
-        self.assertIsNone(self.controller.process_request_data())
+        self.assertIsNone(self.controller.process_request_data(request))
 
     def test_when_request_has_no_plan_id_then_we_cannot_get_a_use_case_request(
         self,
     ) -> None:
-        self.request.set_form("plan_id", "")
-        self.request.set_form("cooperation_id", str(uuid4()))
+        request = FakeRequest()
+        request.set_form("plan_id", "")
+        request.set_form("cooperation_id", str(uuid4()))
         self.session.login_company(uuid4())
-        self.assertIsNone(self.controller.process_request_data())
+        self.assertIsNone(self.controller.process_request_data(request))
 
     def test_when_request_has_a_malformed_plan_id_then_we_cannot_get_a_use_case_request(
         self,
     ) -> None:
-        self.request.set_form("plan_id", "jsbbjs8sjns")
-        self.request.set_form("cooperation_id", str(uuid4()))
+        request = FakeRequest()
+        request.set_form("plan_id", "jsbbjs8sjns")
+        request.set_form("cooperation_id", str(uuid4()))
         self.session.login_company(uuid4())
-        self.assertIsNone(self.controller.process_request_data())
+        self.assertIsNone(self.controller.process_request_data(request))
 
     def test_when_request_has_no_cooperation_id_then_we_cannot_get_a_use_case_request(
         self,
     ) -> None:
-        self.request.set_form("plan_id", str(uuid4()))
-        self.request.set_form("cooperation_id", "")
+        request = FakeRequest()
+        request.set_form("plan_id", str(uuid4()))
+        request.set_form("cooperation_id", "")
         self.session.login_company(uuid4())
-        self.assertIsNone(self.controller.process_request_data())
+        self.assertIsNone(self.controller.process_request_data(request))
 
     def test_when_request_has_malformed_cooperation_id_then_we_cannot_get_a_use_case_request(
         self,
     ) -> None:
-        self.request.set_form("plan_id", str(uuid4()))
-        self.request.set_form("cooperation_id", "jnsjsn8snks")
+        request = FakeRequest()
+        request.set_form("plan_id", str(uuid4()))
+        request.set_form("cooperation_id", "jnsjsn8snks")
         self.session.login_company(uuid4())
-        self.assertIsNone(self.controller.process_request_data())
+        self.assertIsNone(self.controller.process_request_data(request))
 
     def test_a_use_case_request_can_get_returned(
         self,
     ) -> None:
-        self.request.set_form("plan_id", str(uuid4()))
-        self.request.set_form("cooperation_id", str(uuid4()))
+        request = FakeRequest()
+        request.set_form("plan_id", str(uuid4()))
+        request.set_form("cooperation_id", str(uuid4()))
         self.session.login_company(uuid4())
-        use_case_request = self.controller.process_request_data()
+        use_case_request = self.controller.process_request_data(request)
         self.assertIsNotNone(use_case_request)
         self.assertIsInstance(use_case_request, EndCooperationRequest)
 
     def test_a_use_case_request_with_correct_attributes_gets_returned(
         self,
     ) -> None:
+        request = FakeRequest()
         plan_id = str(uuid4())
         cooperation_id = str(uuid4())
         user_id = uuid4()
-        self.request.set_form("plan_id", plan_id)
-        self.request.set_form("cooperation_id", cooperation_id)
+        request.set_form("plan_id", plan_id)
+        request.set_form("cooperation_id", cooperation_id)
         self.session.login_company(user_id)
-        use_case_request = self.controller.process_request_data()
+        use_case_request = self.controller.process_request_data(request)
         assert use_case_request
         self.assertEqual(use_case_request.plan_id, UUID(plan_id))
         self.assertEqual(use_case_request.cooperation_id, UUID(cooperation_id))


### PR DESCRIPTION
Before this commit the `EndCooperationController` would receive request objects to process via its __init__ method. Although this worked it was suboptimal with regards to transparency and code reusability. Receiving request objects through the constructor limits the lifetime of the `EndCooperationController` to the lifetime of a request objects. The refactored implementation receives the request object as an argument to the `process_request_data` method.

The session object that is required by the controller to do its thing remains an argument to the `__init__` method and remains to be refactored in the same way as the request objects was in this change.