### PR TITLE
Multiple error messages via RegisterPrivateConsumptionController

### DIFF
--- a/arbeitszeit_web/www/controllers/register_private_consumption_form_validator.py
+++ b/arbeitszeit_web/www/controllers/register_private_consumption_form_validator.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import TypeAlias, TypeVar
+from uuid import UUID
+
+from arbeitszeit_web.translator import Translator
+
+T = TypeVar("T")
+ValidatorResult: TypeAlias = T | list[str]
+
+
+@dataclass
+class RegisterPrivateConsumptionFormValidator:
+    translator: Translator
+
+    def validate_plan_id_string(self, text: str) -> ValidatorResult[UUID]:
+        if text:
+            try:
+                return UUID(text)
+            except ValueError:
+                return [self.translator.gettext("Plan ID is invalid.")]
+        else:
+            return [self.translator.gettext("Plan ID is invalid.")]
+
+    def validate_amount_string(self, text: str) -> ValidatorResult[int]:
+        if text:
+            try:
+                amount = int(text)
+            except ValueError:
+                return [self.translator.gettext("This is not an integer.")]
+        else:
+            return [self.translator.gettext("You must specify an amount.")]
+        if amount is not None and amount < 1:
+            return [self.translator.gettext("Must be a number larger than zero.")]
+        return amount

--- a/tests/www/controllers/test_register_private_consumption_controller.py
+++ b/tests/www/controllers/test_register_private_consumption_controller.py
@@ -119,9 +119,13 @@ class RegisterPrivateConsumptionControllerTests(BaseTestCase):
             self.translator.gettext("This is not an integer.")
         ]
 
-    def test_valid_data_returned_when_uuid_is_valid_and_amount_is_number(self):
-        result = self._process_form()
-        self.assertTrue(result)
+    def test_that_amount_and_plan_id_field_have_errors_messages_when_both_are_empty(
+        self,
+    ) -> None:
+        result = self._process_form(amount="", plan_id="")
+        assert isinstance(result, FormError)
+        assert result.form.plan_id_errors
+        assert result.form.amount_errors
 
     def test_correct_amount_is_returned(self) -> None:
         result = self._process_form(amount="1234")


### PR DESCRIPTION
Before this commit the `RegisterPrivateConsumptionController` was not able to render errors messages for the both the amount field and the plan_id field if they were both malformed or empty. This commit changes the behavior such that errors messages for both fields will be displayed if appropriate.