### PR TITLE
Refactor QueryCompaniesController

### DIFF
--- a/arbeitszeit_flask/views/query_companies.py
+++ b/arbeitszeit_flask/views/query_companies.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from flask import Response, render_template, request
 
 from arbeitszeit.use_cases import query_companies as use_case
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.forms import CompanySearchForm
 from arbeitszeit_web.www.controllers.query_companies_controller import (
     QueryCompaniesController,
@@ -27,7 +28,9 @@ class QueryCompaniesView:
         search_form = CompanySearchForm(request.args)
         if not search_form.validate():
             return self._get_invalid_form_response(form=search_form)
-        use_case_request = self.controller.import_form_data(search_form)
+        use_case_request = self.controller.import_form_data(
+            form=search_form, request=FlaskRequest()
+        )
         return self._handle_use_case_request(
             use_case_request=use_case_request,
             search_form=search_form,

--- a/arbeitszeit_web/www/controllers/query_companies_controller.py
+++ b/arbeitszeit_web/www/controllers/query_companies_controller.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Optional, Protocol
 
 from arbeitszeit.use_cases.query_companies import CompanyFilter, QueryCompaniesRequest
@@ -15,12 +14,11 @@ class QueryCompaniesFormData(Protocol):
 _page_size = DEFAULT_PAGE_SIZE
 
 
-@dataclass
 class QueryCompaniesController:
-    request: Request
-
     def import_form_data(
         self,
+        *,
+        request: Request,
         form: Optional[QueryCompaniesFormData] = None,
     ) -> QueryCompaniesRequest:
         if form is None:
@@ -32,7 +30,7 @@ class QueryCompaniesController:
                 filter_category = CompanyFilter.by_email
             else:
                 filter_category = CompanyFilter.by_name
-        offset = self._get_pagination_offset()
+        offset = self._get_pagination_offset(request)
         return QueryCompaniesRequest(
             query_string=query,
             filter_category=filter_category,
@@ -40,8 +38,8 @@ class QueryCompaniesController:
             limit=_page_size,
         )
 
-    def _get_pagination_offset(self) -> int:
-        page_str = self.request.query_string().get_last_value(PAGE_PARAMETER_NAME)
+    def _get_pagination_offset(self, request: Request) -> int:
+        page_str = request.query_string().get_last_value(PAGE_PARAMETER_NAME)
         if page_str is None:
             return 0
         try:

--- a/tests/www/controllers/test_query_companies_controller.py
+++ b/tests/www/controllers/test_query_companies_controller.py
@@ -19,24 +19,33 @@ class QueryCompaniesControllerTests(BaseTestCase):
     def test_that_empty_query_string_translates_to_no_query_string_in_request(
         self,
     ) -> None:
-        request = self.controller.import_form_data(make_fake_form(query=""))
+        request = self.controller.import_form_data(
+            request=FakeRequest(), form=make_fake_form(query="")
+        )
         self.assertIsNone(request.query_string)
 
     def test_that_a_query_string_is_taken_as_the_literal_string_in_request(
         self,
     ) -> None:
-        request = self.controller.import_form_data(make_fake_form(query="test"))
+        request = self.controller.import_form_data(
+            request=FakeRequest(), form=make_fake_form(query="test")
+        )
         self.assertEqual(request.query_string, "test")
 
     def test_that_leading_and_trailing_whitespaces_are_ignored(self) -> None:
-        request = self.controller.import_form_data(make_fake_form(query=" test  "))
+        request = self.controller.import_form_data(
+            request=FakeRequest(), form=make_fake_form(query=" test  ")
+        )
         self.assertEqual(request.query_string, "test")
-        request = self.controller.import_form_data(make_fake_form(query="   "))
+        request = self.controller.import_form_data(
+            request=FakeRequest(), form=make_fake_form(query="   ")
+        )
         self.assertIsNone(request.query_string)
 
     def test_that_name_choice_produces_requests_filter_by_company_name(self) -> None:
         request = self.controller.import_form_data(
-            make_fake_form(filter_category="Name")
+            form=make_fake_form(filter_category="Name"),
+            request=FakeRequest(),
         )
         self.assertEqual(request.filter_category, CompanyFilter.by_name)
 
@@ -44,7 +53,8 @@ class QueryCompaniesControllerTests(BaseTestCase):
         self,
     ) -> None:
         request = self.controller.import_form_data(
-            make_fake_form(filter_category="Email")
+            form=make_fake_form(filter_category="Email"),
+            request=FakeRequest(),
         )
         self.assertEqual(request.filter_category, CompanyFilter.by_email)
 
@@ -52,14 +62,15 @@ class QueryCompaniesControllerTests(BaseTestCase):
         self,
     ) -> None:
         request = self.controller.import_form_data(
-            make_fake_form(filter_category="awqwrndaj")
+            form=make_fake_form(filter_category="awqwrndaj"),
+            request=FakeRequest(),
         )
         self.assertEqual(request.filter_category, CompanyFilter.by_name)
 
     def test_that_default_request_model_includes_no_search_query(
         self,
     ) -> None:
-        request = self.controller.import_form_data()
+        request = self.controller.import_form_data(request=FakeRequest())
         self.assertIsNone(request.query_string)
 
 
@@ -67,35 +78,38 @@ class PaginationTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.controller = self.injector.get(QueryCompaniesController)
-        self.request = self.injector.get(FakeRequest)
 
     def test_if_no_page_is_specified_in_query_args_use_offset_of_0(
         self,
     ):
-        use_case_request = self.controller.import_form_data()
+        use_case_request = self.controller.import_form_data(request=FakeRequest())
         assert use_case_request.offset == 0
 
     def test_that_without_request_specified_the_offset_is_set_to_0(self) -> None:
-        use_case_request = self.controller.import_form_data()
+        use_case_request = self.controller.import_form_data(request=FakeRequest())
         assert use_case_request.offset == 0
 
     def test_that_page_two_has_an_offset_of_15(self) -> None:
-        self.request.set_arg(arg="page", value="2")
-        use_case_request = self.controller.import_form_data()
+        request = FakeRequest()
+        request.set_arg(arg="page", value="2")
+        use_case_request = self.controller.import_form_data(request=request)
         assert use_case_request.offset == 15
 
     def test_that_offset_0_is_assumed_if_no_valid_integer_is_specified_as_page(self):
-        self.request.set_arg(arg="page", value="123abc")
-        use_case_request = self.controller.import_form_data()
+        request = FakeRequest()
+        request.set_arg(arg="page", value="123abc")
+        use_case_request = self.controller.import_form_data(request=request)
         assert use_case_request.offset == 0
 
     def test_that_offset_is_150_for_page_11(self) -> None:
-        self.request.set_arg(arg="page", value="11")
-        use_case_request = self.controller.import_form_data()
+        request = FakeRequest()
+        request.set_arg(arg="page", value="11")
+        use_case_request = self.controller.import_form_data(request=request)
         assert use_case_request.offset == 150
 
     def test_that_limit_is_15(self) -> None:
-        use_case_request = self.controller.import_form_data()
+        request = FakeRequest()
+        use_case_request = self.controller.import_form_data(request=request)
         assert use_case_request.limit == 15
 
 


### PR DESCRIPTION
Before this commit the QueryCompaniesController would receive http request object its supposed to process via its contructor. After this change it receives the request object via an argument to `import_form_data`. This makes the implementation more flexible since it does not tie the lifetime of the controller to the lifetime of a request object. Thus it can be used more freely in the application and in test contexts.