### PR TITLE
Refactor RegisterHoursWorkedController

### DIFF
--- a/arbeitszeit_flask/views/register_hours_worked_view.py
+++ b/arbeitszeit_flask/views/register_hours_worked_view.py
@@ -8,6 +8,7 @@ from flask_login import current_user
 from arbeitszeit.use_cases.list_workers import ListWorkers, ListWorkersRequest
 from arbeitszeit.use_cases.register_hours_worked import RegisterHoursWorked
 from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.types import Response
 from arbeitszeit_web.www.controllers.register_hours_worked_controller import (
     ControllerRejection,
@@ -30,7 +31,7 @@ class RegisterHoursWorkedView:
 
     @commit_changes
     def POST(self) -> Response:
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(FlaskRequest())
         if isinstance(controller_response, ControllerRejection):
             self.presenter.present_controller_warnings(controller_response)
             return self.create_response(status=400)

--- a/arbeitszeit_web/www/controllers/register_hours_worked_controller.py
+++ b/arbeitszeit_web/www/controllers/register_hours_worked_controller.py
@@ -21,14 +21,13 @@ class ControllerRejection:
 @dataclass
 class RegisterHoursWorkedController:
     session: Session
-    request: Request
 
     def create_use_case_request(
-        self,
+        self, request: Request
     ) -> Union[RegisterHoursWorkedRequest, ControllerRejection]:
         company_uuid = self.session.get_current_user()
-        worker_id = self.request.get_form("member_id")
-        amount_str = self.request.get_form("amount")
+        worker_id = request.get_form("member_id")
+        amount_str = request.get_form("amount")
         if not all([company_uuid, worker_id, amount_str]):
             return ControllerRejection(
                 reason=ControllerRejection.RejectionReason.invalid_input

--- a/tests/www/controllers/test_register_hours_worked_controller.py
+++ b/tests/www/controllers/test_register_hours_worked_controller.py
@@ -13,16 +13,16 @@ from tests.www.base_test_case import BaseTestCase
 class RegisterHoursWorkedControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.request = self.injector.get(FakeRequest)
         self.controller = self.injector.get(RegisterHoursWorkedController)
 
     def test_when_company_is_not_authenticated_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", str(uuid4()))
-        self.request.set_form("amount", "10")
+        request = FakeRequest()
+        request.set_form("member_id", str(uuid4()))
+        request.set_form("amount", "10")
         self.session.logout()
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -32,10 +32,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_when_there_is_no_member_id_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", "")
-        self.request.set_form("amount", "10")
+        request = FakeRequest()
+        request.set_form("member_id", "")
+        request.set_form("amount", "10")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -45,10 +46,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_when_there_is_malformed_member_id_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", "invalid_id")
-        self.request.set_form("amount", "10")
+        request = FakeRequest()
+        request.set_form("member_id", "invalid_id")
+        request.set_form("amount", "10")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -58,10 +60,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_when_there_is_no_amount_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", str(uuid4()))
-        self.request.set_form("amount", "")
+        request = FakeRequest()
+        request.set_form("member_id", str(uuid4()))
+        request.set_form("amount", "")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -71,10 +74,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_when_there_is_malformed_amount_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", str(uuid4()))
-        self.request.set_form("amount", "abc")
+        request = FakeRequest()
+        request.set_form("member_id", str(uuid4()))
+        request.set_form("amount", "abc")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -84,10 +88,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_when_there_is_negative_amount_then_we_get_the_adequate_controller_rejection(
         self,
     ) -> None:
-        self.request.set_form("member_id", str(uuid4()))
-        self.request.set_form("amount", "-1")
+        request = FakeRequest()
+        request.set_form("member_id", str(uuid4()))
+        request.set_form("amount", "-1")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, ControllerRejection)
         self.assertEqual(
             controller_response.reason,
@@ -97,21 +102,23 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_a_use_case_request_can_get_returned(
         self,
     ) -> None:
-        self.request.set_form("member_id", str(uuid4()))
-        self.request.set_form("amount", "10")
+        request = FakeRequest()
+        request.set_form("member_id", str(uuid4()))
+        request.set_form("amount", "10")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         self.assertIsInstance(controller_response, RegisterHoursWorkedRequest)
 
     def test_a_use_case_request_with_correct_attributes_can_get_returned(
         self,
     ) -> None:
+        request = FakeRequest()
         member_id = uuid4()
-        self.request.set_form("member_id", str(member_id))
-        self.request.set_form("amount", "10")
+        request.set_form("member_id", str(member_id))
+        request.set_form("amount", "10")
         user_id = uuid4()
         self.session.login_company(user_id)
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, RegisterHoursWorkedRequest)
         self.assertEqual(controller_response.company_id, user_id)
         self.assertEqual(controller_response.worker_id, member_id)
@@ -120,10 +127,11 @@ class RegisterHoursWorkedControllerTests(BaseTestCase):
     def test_worker_uuid_gets_stripped(
         self,
     ) -> None:
+        request = FakeRequest()
         member_id = uuid4()
-        self.request.set_form("member_id", " " + str(member_id) + " ")
-        self.request.set_form("amount", "10")
+        request.set_form("member_id", " " + str(member_id) + " ")
+        request.set_form("amount", "10")
         self.session.login_company(uuid4())
-        controller_response = self.controller.create_use_case_request()
+        controller_response = self.controller.create_use_case_request(request)
         assert isinstance(controller_response, RegisterHoursWorkedRequest)
         self.assertEqual(controller_response.worker_id, member_id)


### PR DESCRIPTION
This commit changes the RegisterHoursWorkedController with regards to how it receives the current request object. Before this commit the request object was injected into the controller via the `__init__` method. This limited the reusability of the class because it tied its lifetime artificially to the lifetime of a request object. After this change the controller receives the request object via a paramter of the `create_use_case_request` method.