### PR TITLE
Refactor SelectProductiveConsumptionController

### DIFF
--- a/arbeitszeit_flask/views/register_productive_consumption.py
+++ b/arbeitszeit_flask/views/register_productive_consumption.py
@@ -10,6 +10,7 @@ from arbeitszeit.use_cases.select_productive_consumption import (
     SelectProductiveConsumptionUseCase,
 )
 from arbeitszeit_flask.database import commit_changes
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_flask.forms import RegisterProductiveConsumptionForm
 from arbeitszeit_flask.types import Response
 from arbeitszeit_web.www.controllers.register_productive_consumption_controller import (
@@ -38,7 +39,9 @@ class RegisterProductiveConsumptionView:
     def GET(self) -> Response:
         try:
             use_case_request = (
-                self.select_productive_consumption_controller.process_input_data()
+                self.select_productive_consumption_controller.process_input_data(
+                    FlaskRequest()
+                )
             )
         except self.select_productive_consumption_controller.InputDataError:
             return self._handle_invalid_form(RegisterProductiveConsumptionForm())

--- a/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
+++ b/arbeitszeit_web/www/controllers/select_productive_consumption_controller.py
@@ -15,23 +15,20 @@ class SelectProductiveConsumptionController:
     class InputDataError(Exception):
         pass
 
-    request: Request
     notifier: Notifier
     translator: Translator
 
-    def process_input_data(self) -> UseCaseRequest:
-        plan_id = self._process_plan_id()
-        amount = self._process_amount()
-        consumption_type = self._process_consumption_type()
+    def process_input_data(self, request: Request) -> UseCaseRequest:
+        plan_id = self._process_plan_id(request)
+        amount = self._process_amount(request)
+        consumption_type = self._process_consumption_type(request)
         return UseCaseRequest(
             plan_id=plan_id, amount=amount, consumption_type=consumption_type
         )
 
-    def _process_plan_id(self) -> UUID | None:
-        plan_id_from_query_string = self.request.query_string().get_last_value(
-            "plan_id"
-        )
-        plan_id_from_form = self.request.get_form("plan_id")
+    def _process_plan_id(self, request: Request) -> UUID | None:
+        plan_id_from_query_string = request.query_string().get_last_value("plan_id")
+        plan_id_from_form = request.get_form("plan_id")
         if not plan_id_from_query_string and not plan_id_from_form:
             return None
         elif plan_id_from_query_string:
@@ -49,9 +46,9 @@ class SelectProductiveConsumptionController:
             )
             raise self.InputDataError()
 
-    def _process_amount(self) -> int | None:
-        amount_from_query_string = self.request.query_string().get_last_value("amount")
-        amount_from_form = self.request.get_form("amount")
+    def _process_amount(self, request: Request) -> int | None:
+        amount_from_query_string = request.query_string().get_last_value("amount")
+        amount_from_form = request.get_form("amount")
         if not amount_from_query_string and not amount_from_form:
             return None
         elif amount_from_query_string:
@@ -69,11 +66,11 @@ class SelectProductiveConsumptionController:
             )
             raise self.InputDataError()
 
-    def _process_consumption_type(self) -> ConsumptionType | None:
-        consumption_type_from_query_string = self.request.query_string().get_last_value(
+    def _process_consumption_type(self, request: Request) -> ConsumptionType | None:
+        consumption_type_from_query_string = request.query_string().get_last_value(
             "type_of_consumption"
         )
-        consumption_type_from_form = self.request.get_form("type_of_consumption")
+        consumption_type_from_form = request.get_form("type_of_consumption")
         if not consumption_type_from_query_string and not consumption_type_from_form:
             return None
         elif consumption_type_from_query_string:

--- a/tests/www/controllers/test_select_productive_consumption_controller.py
+++ b/tests/www/controllers/test_select_productive_consumption_controller.py
@@ -11,115 +11,131 @@ from tests.www.base_test_case import BaseTestCase
 class SelectProductiveConsumptionControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.request = self.injector.get(FakeRequest)
         self.controller = self.injector.get(SelectProductiveConsumptionController)
 
     def test_that_none_is_returned_when_no_plan_id_is_provided(self) -> None:
-        response = self.controller.process_input_data()
+        request = FakeRequest()
+        response = self.controller.process_input_data(request=request)
         assert response.plan_id is None
 
     def test_that_input_error_is_raised_when_plan_id_is_not_a_valid_uuid(self) -> None:
-        self.request.set_arg("plan_id", "not_a_valid_uuid")
+        request = FakeRequest()
+        request.set_arg("plan_id", "not_a_valid_uuid")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
 
     def test_that_a_warning_is_displayed_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        request = FakeRequest()
         assert not self.notifier.warnings
-        self.request.set_arg("plan_id", "not_a_valid_uuid")
+        request.set_arg("plan_id", "not_a_valid_uuid")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
         assert self.notifier.warnings
 
     def test_that_plan_id_from_url_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
         plan_id = uuid4()
-        self.request.set_arg("plan_id", str(plan_id))
-        response = self.controller.process_input_data()
+        request.set_arg("plan_id", str(plan_id))
+        response = self.controller.process_input_data(request=request)
         assert response.plan_id == plan_id
 
     def test_that_plan_id_from_form_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
         plan_id = uuid4()
-        self.request.set_form("plan_id", str(plan_id))
-        response = self.controller.process_input_data()
+        request.set_form("plan_id", str(plan_id))
+        response = self.controller.process_input_data(request=request)
         assert response.plan_id == plan_id
 
     def test_that_none_is_returned_when_no_amount_is_provided(self) -> None:
-        response = self.controller.process_input_data()
+        request = FakeRequest()
+        response = self.controller.process_input_data(request=request)
         assert response.amount is None
 
     def test_that_input_error_is_raised_when_amount_is_not_a_valid_number(self) -> None:
-        self.request.set_arg("amount", "not_a_valid_number")
+        request = FakeRequest()
+        request.set_arg("amount", "not_a_valid_number")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
 
     def test_that_a_warning_is_displayed_when_amount_is_not_a_valid_number(
         self,
     ) -> None:
+        request = FakeRequest()
         assert not self.notifier.warnings
-        self.request.set_arg("amount", "not_a_valid_number")
+        request.set_arg("amount", "not_a_valid_number")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
         assert self.notifier.warnings
 
     def test_that_amount_from_url_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
         amount = 10
-        self.request.set_arg("amount", str(amount))
-        response = self.controller.process_input_data()
+        request.set_arg("amount", str(amount))
+        response = self.controller.process_input_data(request=request)
         assert response.amount == amount
 
     def test_that_amount_from_form_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
         amount = 10
-        self.request.set_form("amount", str(amount))
-        response = self.controller.process_input_data()
+        request.set_form("amount", str(amount))
+        response = self.controller.process_input_data(request=request)
         assert response.amount == amount
 
     def test_that_none_is_returned_when_no_consumption_type_is_provided(self) -> None:
-        response = self.controller.process_input_data()
+        request = FakeRequest()
+        response = self.controller.process_input_data(request=request)
         assert response.consumption_type is None
 
     def test_that_input_error_is_raised_when_consumption_type_is_not_fixed_or_liquid(
         self,
     ) -> None:
-        self.request.set_arg("type_of_consumption", "not_fixed_or_liquid")
+        request = FakeRequest()
+        request.set_arg("type_of_consumption", "not_fixed_or_liquid")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
 
     def test_that_warning_is_displayed_when_consumption_type_is_not_fixed_or_liquid(
         self,
     ) -> None:
+        request = FakeRequest()
         assert not self.notifier.warnings
-        self.request.set_arg("type_of_consumption", "not_fixed_or_liquid")
+        request.set_arg("type_of_consumption", "not_fixed_or_liquid")
         with self.assertRaises(SelectProductiveConsumptionController.InputDataError):
-            self.controller.process_input_data()
+            self.controller.process_input_data(request=request)
         assert self.notifier.warnings
 
     def test_that_fixed_consumption_type_from_url_gets_passed_to_response_object(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_consumption_type = ConsumptionType.means_of_prod
-        self.request.set_arg("type_of_consumption", "fixed")
-        response = self.controller.process_input_data()
+        request.set_arg("type_of_consumption", "fixed")
+        response = self.controller.process_input_data(request=request)
         assert response.consumption_type == expected_consumption_type
 
     def test_that_liquid_consumption_type_from_url_gets_passed_to_response_object(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_consumption_type = ConsumptionType.raw_materials
-        self.request.set_arg("type_of_consumption", "liquid")
-        response = self.controller.process_input_data()
+        request.set_arg("type_of_consumption", "liquid")
+        response = self.controller.process_input_data(request=request)
         assert response.consumption_type == expected_consumption_type
 
     def test_that_fixed_consumption_type_from_form_gets_passed_to_response_object(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_consumption_type = ConsumptionType.means_of_prod
-        self.request.set_form("type_of_consumption", "fixed")
-        response = self.controller.process_input_data()
+        request.set_form("type_of_consumption", "fixed")
+        response = self.controller.process_input_data(request=request)
         assert response.consumption_type == expected_consumption_type
 
     def test_that_liquid_consumption_type_from_form_gets_passed_to_response_object(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_consumption_type = ConsumptionType.raw_materials
-        self.request.set_form("type_of_consumption", "liquid")
-        response = self.controller.process_input_data()
+        request.set_form("type_of_consumption", "liquid")
+        response = self.controller.process_input_data(request=request)
         assert response.consumption_type == expected_consumption_type


### PR DESCRIPTION
This commit changes how the SelectProductiveConsumptionController receives request objects. Before this commit instances of the controller were receiving the request objects via the `__init__` method. This approach limited reusability of this class in production and testing scenarios. After this commit the controller receives request objects through a parameter of `process_input_data`.