### PR TITLE
Refactor CreateDraftFromPlanPresenter

### DIFF
--- a/arbeitszeit_flask/company/routes.py
+++ b/arbeitszeit_flask/company/routes.py
@@ -145,7 +145,10 @@ def create_draft_from_plan(
 ) -> Response:
     uc_request = controller.create_use_case_request(plan_id)
     uc_response = use_case.create_draft_from_plan(uc_request)
-    view_model = presenter.render_response(uc_response)
+    view_model = presenter.render_response(
+        use_case_response=uc_response,
+        request=FlaskRequest(),
+    )
     return redirect(view_model.redirect_url)
 
 

--- a/arbeitszeit_web/www/presenters/create_draft_from_plan_presenter.py
+++ b/arbeitszeit_web/www/presenters/create_draft_from_plan_presenter.py
@@ -15,20 +15,25 @@ class ViewModel:
 @dataclass
 class CreateDraftFromPlanPresenter:
     url_index: UrlIndex
-    request: Request
     notifier: Notifier
     translator: Translator
 
-    def render_response(self, response: use_case.Response) -> ViewModel:
+    def render_response(
+        self,
+        use_case_response: use_case.Response,
+        request: Request,
+    ) -> ViewModel:
         self.notifier.display_info(
             self.translator.gettext("A new draft was created from an expired plan.")
         )
-        if response.draft:
+        if use_case_response.draft:
             return ViewModel(
-                redirect_url=self.url_index.get_draft_details_url(response.draft)
+                redirect_url=self.url_index.get_draft_details_url(
+                    use_case_response.draft
+                )
             )
         else:
             return ViewModel(
-                redirect_url=self.request.get_header("Referer")
+                redirect_url=request.get_header("Referer")
                 or self.url_index.get_my_plans_url()
             )

--- a/tests/www/presenters/test_create_draft_from_plan_presenter.py
+++ b/tests/www/presenters/test_create_draft_from_plan_presenter.py
@@ -14,12 +14,12 @@ class CreateDraftFromPlanPresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.presenter = self.injector.get(CreateDraftFromPlanPresenter)
-        self.request = self.injector.get(FakeRequest)
 
     def test_that_user_is_redirected_to_plan_details_view_on_success(self) -> None:
+        request = FakeRequest()
         expected_draft_id = uuid4()
         response = use_case.Response(draft=expected_draft_id)
-        view_model = self.presenter.render_response(response)
+        view_model = self.presenter.render_response(response, request)
         assert view_model.redirect_url == self.url_index.get_draft_details_url(
             expected_draft_id
         )
@@ -33,25 +33,28 @@ class CreateDraftFromPlanPresenterTests(BaseTestCase):
     def test_that_user_is_redirected_to_last_visited_page_on_failure(
         self, expected_url: str
     ) -> None:
+        request = FakeRequest()
         response = use_case.Response(draft=None)
-        self.request.set_header("Referer", expected_url)
-        view_model = self.presenter.render_response(response)
+        request.set_header("Referer", expected_url)
+        view_model = self.presenter.render_response(response, request)
         assert view_model.redirect_url == expected_url
 
     def test_that_user_is_redirected_to_company_plans_list_if_referer_is_not_set(
         self,
     ) -> None:
+        request = FakeRequest()
         response = use_case.Response(draft=None)
-        self.request.set_header("Referer", None)
-        view_model = self.presenter.render_response(response)
+        request.set_header("Referer", None)
+        view_model = self.presenter.render_response(response, request)
         assert view_model.redirect_url == self.url_index.get_my_plans_url()
 
     def test_that_user_is_notified_about_successful_draft_creation_on_success(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_draft_id = uuid4()
         response = use_case.Response(draft=expected_draft_id)
-        self.presenter.render_response(response)
+        self.presenter.render_response(response, request)
         assert (
             self.translator.gettext("A new draft was created from an expired plan.")
             in self.notifier.infos


### PR DESCRIPTION
This change refactors the CreateDraftFromPlanPresenter. Before this change the presenter in question would receive the currently processed request object via a paramter to its `__init__` function. After this change the request object is passed as an argument to the `render_response` method of the presenter. This refactoring allows for greater code reuse as the lifetime of presenter objects now independent of the lifetime of a request.