### PR TITLE
Refactor LoginCompanyApiController

### DIFF
--- a/arbeitszeit_flask/api/auth.py
+++ b/arbeitszeit_flask/api/auth.py
@@ -6,6 +6,7 @@ from arbeitszeit_flask.api.input_documentation import with_input_documentation
 from arbeitszeit_flask.api.response_handling import error_response_handling
 from arbeitszeit_flask.api.schema_converter import SchemaConverter
 from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_web.api.controllers.login_company_api_controller import (
     LoginCompanyApiController,
     login_company_expected_inputs,
@@ -84,7 +85,7 @@ class LoginCompany(Resource):
         """
         Login with a company account.
         """
-        use_case_request = controller.create_request()
+        use_case_request = controller.create_request(FlaskRequest())
         response = login_company.log_in_company(use_case_request)
         view_model = presenter.create_view_model(response)
         return view_model

--- a/arbeitszeit_web/api/controllers/login_company_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_company_api_controller.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 from arbeitszeit.use_cases.log_in_company import LogInCompanyUseCase
 from arbeitszeit_web.api.controllers.parameters import FormParameter
 from arbeitszeit_web.api.response_errors import BadRequest
@@ -23,12 +21,9 @@ login_company_expected_inputs = [
 ]
 
 
-@dataclass
 class LoginCompanyApiController:
-    request: Request
-
-    def create_request(self) -> LogInCompanyUseCase.Request:
-        json_body = self.request.get_json()
+    def create_request(self, request: Request) -> LogInCompanyUseCase.Request:
+        json_body = request.get_json()
         if not isinstance(json_body, dict):
             raise BadRequest("Email missing.")
         email = json_body.get("email")

--- a/tests/api/controllers/test_login_company_api_controller.py
+++ b/tests/api/controllers/test_login_company_api_controller.py
@@ -12,32 +12,35 @@ class ControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.controller = self.injector.get(LoginCompanyApiController)
-        self.request = self.injector.get(FakeRequest)
 
     def test_bad_request_raised_when_request_has_no_email_and_no_password(
         self,
     ) -> None:
+        request = FakeRequest()
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_password_but_no_email(self) -> None:
-        self.request.set_json({"password": "123safe"})
+        request = FakeRequest()
+        request.set_json({"password": "123safe"})
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_email_but_no_password(self) -> None:
-        self.request.set_json({"email": "test@test.org"})
+        request = FakeRequest()
+        request.set_json({"email": "test@test.org"})
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Password missing.")
 
     def test_email_and_password_are_passed_to_use_case_request(self) -> None:
         EXPECTED_MAIL = "test@test.org"
         EXPECTED_PASSWORD = "123safe"
-        self.request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
+        use_case_request = self.controller.create_request(request)
         assert use_case_request
         self.assertEqual(use_case_request.email_address, EXPECTED_MAIL)
         self.assertEqual(use_case_request.password, EXPECTED_PASSWORD)


### PR DESCRIPTION
This commit refactors the LoginCompanyApiController. Before the change the controller in question would receive the request object to process via a parameter of its `__init__` method. Now the controller receives the request object as a paramter of the `create_request` method.