### PR TITLE
Refactor LoginMemberApiController

### DIFF
--- a/arbeitszeit_flask/api/auth.py
+++ b/arbeitszeit_flask/api/auth.py
@@ -6,6 +6,7 @@ from arbeitszeit_flask.api.input_documentation import with_input_documentation
 from arbeitszeit_flask.api.response_handling import error_response_handling
 from arbeitszeit_flask.api.schema_converter import SchemaConverter
 from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_web.api.controllers.login_company_api_controller import (
     LoginCompanyApiController,
     login_company_expected_inputs,
@@ -50,10 +51,8 @@ class LoginMember(Resource):
         login_member: LogInMemberUseCase,
         presenter: LoginMemberApiPresenter,
     ):
-        """
-        Login with a member account.
-        """
-        use_case_request = controller.create_request()
+        "Login with a member account."
+        use_case_request = controller.create_request(FlaskRequest())
         response = login_member.log_in_member(use_case_request)
         view_model = presenter.create_view_model(response)
         return view_model

--- a/arbeitszeit_web/api/controllers/login_member_api_controller.py
+++ b/arbeitszeit_web/api/controllers/login_member_api_controller.py
@@ -25,10 +25,8 @@ login_member_expected_inputs = [
 
 @dataclass
 class LoginMemberApiController:
-    request: Request
-
-    def create_request(self) -> LogInMemberUseCase.Request:
-        json_body = self.request.get_json()
+    def create_request(self, request: Request) -> LogInMemberUseCase.Request:
+        json_body = request.get_json()
         if not isinstance(json_body, dict):
             raise BadRequest("Email missing.")
         email = json_body.get("email")

--- a/tests/api/controllers/test_login_member_api_controller.py
+++ b/tests/api/controllers/test_login_member_api_controller.py
@@ -12,32 +12,35 @@ class ControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.controller = self.injector.get(LoginMemberApiController)
-        self.request = self.injector.get(FakeRequest)
 
     def test_bad_request_raised_when_request_has_no_email_and_no_password(
         self,
     ) -> None:
+        request = FakeRequest()
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_bad_request_raised_when_request_has_email_but_no_password(self) -> None:
-        self.request.set_json({"email": "test@test.org"})
+        request = FakeRequest()
+        request.set_json({"email": "test@test.org"})
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Password missing.")
 
     def test_bad_request_raised_when_request_has_password_but_no_email(self) -> None:
-        self.request.set_json({"password": "123safe"})
+        request = FakeRequest()
+        request.set_json({"password": "123safe"})
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(err.exception.message, "Email missing.")
 
     def test_email_and_password_are_passed_to_use_case_request(self) -> None:
         EXPECTED_MAIL = "test@test.org"
         EXPECTED_PASSWORD = "123safe"
-        self.request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        request.set_json({"email": EXPECTED_MAIL, "password": EXPECTED_PASSWORD})
+        use_case_request = self.controller.create_request(request)
         assert use_case_request
         self.assertEqual(use_case_request.email, EXPECTED_MAIL)
         self.assertEqual(use_case_request.password, EXPECTED_PASSWORD)


### PR DESCRIPTION
This commit changes how the LoginMemberApiController receives requests objects to process. Before this change the request object that the controller is supposed to process was passed to the controller via a parameter of the controllers `__init__` method. Now the request object is passed into the controller via a paramter of the `create_request` method.