### PR TITLE
Refactor QueryCompaniesApiController

### DIFF
--- a/arbeitszeit_flask/api/companies.py
+++ b/arbeitszeit_flask/api/companies.py
@@ -8,6 +8,7 @@ from arbeitszeit_flask.api.input_documentation import with_input_documentation
 from arbeitszeit_flask.api.response_handling import error_response_handling
 from arbeitszeit_flask.api.schema_converter import SchemaConverter
 from arbeitszeit_flask.dependency_injection import with_injection
+from arbeitszeit_flask.flask_request import FlaskRequest
 from arbeitszeit_web.api.controllers.query_companies_api_controller import (
     QueryCompaniesApiController,
     query_companies_expected_inputs,
@@ -42,7 +43,7 @@ class QueryCompanies(Resource):
         presenter: QueryCompaniesApiPresenter,
     ):
         """Query companies."""
-        use_case_request = controller.create_request()
+        use_case_request = controller.create_request(FlaskRequest())
         response = query_companies(use_case_request)
         view_model = presenter.create_view_model(response)
         return view_model

--- a/arbeitszeit_web/api/controllers/query_companies_api_controller.py
+++ b/arbeitszeit_web/api/controllers/query_companies_api_controller.py
@@ -27,11 +27,9 @@ query_companies_expected_inputs = [
 
 @dataclass
 class QueryCompaniesApiController:
-    request: Request
-
-    def create_request(self) -> QueryCompaniesRequest:
-        offset = self._parse_offset(self.request)
-        limit = self._parse_limit(self.request)
+    def create_request(self, request: Request) -> QueryCompaniesRequest:
+        offset = self._parse_offset(request)
+        limit = self._parse_limit(request)
         return QueryCompaniesRequest(
             query_string=None,
             filter_category=CompanyFilter.by_name,

--- a/tests/api/controllers/test_query_companies_api_controller.py
+++ b/tests/api/controllers/test_query_companies_api_controller.py
@@ -13,60 +13,65 @@ class ControllerTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.controller = self.injector.get(QueryCompaniesApiController)
-        self.request = self.injector.get(FakeRequest)
 
     def test_that_by_default_a_request_gets_returned_which_filters_by_company_name(
         self,
     ) -> None:
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.filter_category, CompanyFilter.by_name)
 
     def test_that_by_default_a_request_gets_returned_without_query_string(self) -> None:
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        use_case_request = self.controller.create_request(request)
         self.assertIsNone(use_case_request.query_string)
 
     def test_that_by_default_a_use_case_request_with_offset_0_gets_returned_if_offset_query_string_was_empty(
         self,
     ):
-        assert not self.request.query_string().get("offset")
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.offset, 0)
 
     def test_that_by_default_a_use_case_request_with_limit_30_gets_returned_if_limit_query_string_was_empty(
         self,
     ) -> None:
-        assert not self.request.query_string().get("limit")
-        use_case_request = self.controller.create_request()
+        request = FakeRequest()
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.limit, 30)
 
     def test_correct_offset_gets_returned_if_it_was_set_in_query_string(self) -> None:
+        request = FakeRequest()
         expected_offset = 8
-        self.request.set_arg(arg="offset", value=str(expected_offset))
-        use_case_request = self.controller.create_request()
+        request.set_arg(arg="offset", value=str(expected_offset))
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.offset, expected_offset)
 
     def test_correct_limit_gets_returned_if_it_was_set_in_query_string(self) -> None:
+        request = FakeRequest()
         expected_limit = 7
-        self.request.set_arg(arg="limit", value=expected_limit)
-        use_case_request = self.controller.create_request()
+        request.set_arg(arg="limit", value=expected_limit)
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.limit, expected_limit)
 
     def test_both_correct_limit_and_offset_get_returned_if_specified_in_query_string(
         self,
     ) -> None:
+        request = FakeRequest()
         expected_limit = 7
-        self.request.set_arg(arg="limit", value=expected_limit)
+        request.set_arg(arg="limit", value=expected_limit)
         expected_offset = 8
-        self.request.set_arg(arg="offset", value=str(expected_offset))
-        use_case_request = self.controller.create_request()
+        request.set_arg(arg="offset", value=str(expected_offset))
+        use_case_request = self.controller.create_request(request)
         self.assertEqual(use_case_request.limit, expected_limit)
         self.assertEqual(use_case_request.offset, expected_offset)
 
     def test_controller_raises_bad_request_if_offset_query_string_has_letters(self):
+        request = FakeRequest()
         input = "123abc"
-        self.request.set_arg(arg="offset", value=input)
+        request.set_arg(arg="offset", value=input)
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(
             err.exception.message, f"Input must be an integer, not {input}."
         )
@@ -74,19 +79,21 @@ class ControllerTests(BaseTestCase):
     def test_controller_raises_bad_request_if_offset_query_string_is_negative_number(
         self,
     ):
+        request = FakeRequest()
         input = "-123"
-        self.request.set_arg(arg="offset", value=input)
+        request.set_arg(arg="offset", value=input)
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(
             err.exception.message, f"Input must be greater or equal zero, not {input}."
         )
 
     def test_controller_raises_bad_request_if_limit_query_string_has_letters(self):
+        request = FakeRequest()
         input = "123abc"
-        self.request.set_arg(arg="limit", value=input)
+        request.set_arg(arg="limit", value=input)
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(
             err.exception.message, f"Input must be an integer, not {input}."
         )
@@ -94,10 +101,11 @@ class ControllerTests(BaseTestCase):
     def test_controller_raises_bad_request_if_limit_query_string_is_negative_number(
         self,
     ):
+        request = FakeRequest()
         input = "-123"
-        self.request.set_arg(arg="limit", value=input)
+        request.set_arg(arg="limit", value=input)
         with self.assertRaises(BadRequest) as err:
-            self.controller.create_request()
+            self.controller.create_request(request)
         self.assertEqual(
             err.exception.message, f"Input must be greater or equal zero, not {input}."
         )


### PR DESCRIPTION
This commit changes how the QueryCompaniesApiController receives request objects to process. Before this change the controller in question would receive the request object via a parameter of its `__init__` method. After this change the controller receives it via the `create_request` method as a paramter.