### PR TITLE
Refactor EndCooperationPresenter

### DIFF
--- a/arbeitszeit_flask/views/end_cooperation_view.py
+++ b/arbeitszeit_flask/views/end_cooperation_view.py
@@ -23,11 +23,12 @@ class EndCooperationView:
 
     @commit_changes
     def POST(self) -> types.Response:
-        use_case_request = self.controller.process_request_data(request=FlaskRequest())
+        request = FlaskRequest()
+        use_case_request = self.controller.process_request_data(request=request)
         if use_case_request is None:
             return http_404()
         use_case_response = self.end_cooperation(use_case_request)
-        view_model = self.presenter.present(use_case_response)
+        view_model = self.presenter.present(use_case_response, web_request=request)
         if view_model.show_404:
             return http_404()
         return redirect(view_model.redirect_url)

--- a/arbeitszeit_web/www/presenters/end_cooperation_presenter.py
+++ b/arbeitszeit_web/www/presenters/end_cooperation_presenter.py
@@ -17,13 +17,14 @@ class EndCooperationPresenter:
         show_404: bool
         redirect_url: str
 
-    request: Request
     notifier: Notifier
     url_index: UrlIndex
     translator: Translator
     session: Session
 
-    def present(self, response: EndCooperationResponse) -> ViewModel:
+    def present(
+        self, response: EndCooperationResponse, *, web_request: Request
+    ) -> ViewModel:
         if response.is_rejected:
             self.notifier.display_warning(
                 self.translator.gettext("Cooperation could not be terminated.")
@@ -32,18 +33,16 @@ class EndCooperationPresenter:
         self.notifier.display_info(
             self.translator.gettext("Cooperation has been terminated.")
         )
-        redirect_url = self._get_redirect_url()
+        redirect_url = self._get_redirect_url(web_request)
         return self.ViewModel(show_404=False, redirect_url=redirect_url)
 
-    def _get_redirect_url(self) -> str:
-        referer = self.request.get_header("Referer")
-        query_string = self.request.query_string()
-        plan_id = query_string.get_last_value("plan_id") or self.request.get_form(
-            "plan_id"
-        )
+    def _get_redirect_url(self, request: Request) -> str:
+        referer = request.get_header("Referer")
+        query_string = request.query_string()
+        plan_id = query_string.get_last_value("plan_id") or request.get_form("plan_id")
         cooperation_id = query_string.get_last_value(
             "cooperation_id"
-        ) or self.request.get_form("cooperation_id")
+        ) or request.get_form("cooperation_id")
         assert plan_id
         assert cooperation_id
         if referer:

--- a/tests/www/presenters/test_end_cooperation_presenter.py
+++ b/tests/www/presenters/test_end_cooperation_presenter.py
@@ -23,27 +23,31 @@ REJECTED_RESPONSE_COOPERATION_NOT_FOUND = EndCooperationResponse(
 class PresenterTests(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
-        self.request = self.injector.get(FakeRequest)
         self.presenter = self.injector.get(EndCooperationPresenter)
         self.session.login_company(company=uuid4())
 
     def test_404_and_empty_url_returned_when_use_case_response_returned_plan_not_found(
         self,
-    ):
-        view_model = self.presenter.present(REJECTED_RESPONSE_PLAN_NOT_FOUND)
+    ) -> None:
+        request = FakeRequest()
+        view_model = self.presenter.present(
+            REJECTED_RESPONSE_PLAN_NOT_FOUND, web_request=request
+        )
         self.assertTrue(view_model.show_404)
         self.assertFalse(view_model.redirect_url)
 
     def test_notification_returned_when_operation_was_rejected_because_plan_was_not_found(
         self,
-    ):
-        self.presenter.present(REJECTED_RESPONSE_PLAN_NOT_FOUND)
+    ) -> None:
+        request = FakeRequest()
+        self.presenter.present(REJECTED_RESPONSE_PLAN_NOT_FOUND, web_request=request)
         self.assertTrue(self._get_warning_notifications())
 
     def test_correct_notification_is_returned_when_operation_was_rejected_because_plan_was_not_found(
         self,
-    ):
-        self.presenter.present(REJECTED_RESPONSE_PLAN_NOT_FOUND)
+    ) -> None:
+        request = FakeRequest()
+        self.presenter.present(REJECTED_RESPONSE_PLAN_NOT_FOUND, web_request=request)
         self.assertIn(
             self.translator.gettext("Cooperation could not be terminated."),
             self._get_warning_notifications(),
@@ -51,20 +55,22 @@ class PresenterTests(BaseTestCase):
 
     def test_url_gets_returned_when_use_case_response_is_successfull(
         self,
-    ):
-        self.request.set_arg("plan_id", str(uuid4()))
-        self.request.set_arg("cooperation_id", str(uuid4()))
-        view_model = self.presenter.present(SUCCESSFUL_RESPONSE)
+    ) -> None:
+        request = FakeRequest()
+        request.set_arg("plan_id", str(uuid4()))
+        request.set_arg("cooperation_id", str(uuid4()))
+        view_model = self.presenter.present(SUCCESSFUL_RESPONSE, web_request=request)
         self.assertFalse(view_model.show_404)
         self.assertTrue(view_model.redirect_url)
 
     def test_coop_summary_url_gets_returned_as_default_when_no_referer_is_given(
         self,
-    ):
+    ) -> None:
+        request = FakeRequest()
         coop_id = uuid4()
-        self.request.set_arg("plan_id", str(uuid4()))
-        self.request.set_arg("cooperation_id", str(coop_id))
-        view_model = self.presenter.present(SUCCESSFUL_RESPONSE)
+        request.set_arg("plan_id", str(uuid4()))
+        request.set_arg("cooperation_id", str(coop_id))
+        view_model = self.presenter.present(SUCCESSFUL_RESPONSE, web_request=request)
         self.assertFalse(view_model.show_404)
         self.assertEqual(
             view_model.redirect_url,
@@ -73,12 +79,13 @@ class PresenterTests(BaseTestCase):
 
     def test_plan_details_url_gets_returned_when_plan_details_url_was_referer(
         self,
-    ):
+    ) -> None:
+        request = FakeRequest()
         plan_id = uuid4()
-        self.request.set_header("Referer", f"/company/plan_details/{str(plan_id)}")
-        self.request.set_arg("plan_id", str(plan_id))
-        self.request.set_arg("cooperation_id", str(uuid4()))
-        view_model = self.presenter.present(SUCCESSFUL_RESPONSE)
+        request.set_header("Referer", f"/company/plan_details/{str(plan_id)}")
+        request.set_arg("plan_id", str(plan_id))
+        request.set_arg("cooperation_id", str(uuid4()))
+        view_model = self.presenter.present(SUCCESSFUL_RESPONSE, web_request=request)
         self.assertFalse(view_model.show_404)
         self.assertEqual(
             view_model.redirect_url,
@@ -89,10 +96,11 @@ class PresenterTests(BaseTestCase):
 
     def test_correct_notification_is_returned_when_operation_was_successfull(
         self,
-    ):
-        self.request.set_arg("plan_id", str(uuid4()))
-        self.request.set_arg("cooperation_id", str(uuid4()))
-        self.presenter.present(SUCCESSFUL_RESPONSE)
+    ) -> None:
+        request = FakeRequest()
+        request.set_arg("plan_id", str(uuid4()))
+        request.set_arg("cooperation_id", str(uuid4()))
+        self.presenter.present(SUCCESSFUL_RESPONSE, web_request=request)
         self.assertIn(
             self.translator.gettext("Cooperation has been terminated."),
             self._get_info_notifications(),


### PR DESCRIPTION
This commit changes how the EnCooperationPresenter receives request objects that its supposed to generate responses for. Before this commit the presenter class would receive Request instances via a paramter of the `__init__` method of the presenter class. Now it receives request objects via a paramter of the `present` method.