### PR TITLE
Allow unlimited overdraw of member accounts

### DIFF
--- a/arbeitszeit/control_thresholds.py
+++ b/arbeitszeit/control_thresholds.py
@@ -2,6 +2,8 @@ from typing import Protocol
 
 
 class ControlThresholds(Protocol):
-    def get_allowed_overdraw_of_member_account(self) -> int: ...
+    def get_allowed_overdraw_of_member_account(self) -> int | None:
+        """Return the allowed overdraw limit in hours. None means unlimited overdraw."""
+        ...
 
     def get_acceptable_relative_account_deviation(self) -> int: ...

--- a/arbeitszeit/use_cases/register_private_consumption.py
+++ b/arbeitszeit/use_cases/register_private_consumption.py
@@ -116,10 +116,12 @@ class RegisterPrivateConsumption:
         allowed_overdraw = (
             self.control_thresholds.get_allowed_overdraw_of_member_account()
         )
+        if allowed_overdraw is None:
+            return True
         account_balance = self._get_account_balance(account)
         if account_balance is None:
             return False
-        elif transfer_value > account_balance + allowed_overdraw:
+        if transfer_value > account_balance + allowed_overdraw:
             return False
         return True
 

--- a/arbeitszeit_flask/control_thresholds.py
+++ b/arbeitszeit_flask/control_thresholds.py
@@ -2,8 +2,9 @@ from flask import current_app
 
 
 class ControlThresholdsFlask:
-    def get_allowed_overdraw_of_member_account(self) -> int:
-        return int(current_app.config["ALLOWED_OVERDRAW_MEMBER"])
+    def get_allowed_overdraw_of_member_account(self) -> int | None:
+        value = current_app.config["ALLOWED_OVERDRAW_MEMBER"]
+        return None if value == "unlimited" else int(value)
 
     def get_acceptable_relative_account_deviation(self) -> int:
         return int(current_app.config["ACCEPTABLE_RELATIVE_ACCOUNT_DEVIATION"])

--- a/docs/hosting.rst
+++ b/docs/hosting.rst
@@ -117,7 +117,8 @@ configuration options are available
 
 .. py:data:: ALLOWED_OVERDRAW_MEMBER
    
-   This integer defines how far members can overdraw their account.
+   This integer defines how far members can overdraw their account in hours.
+   Set to ``"unlimited"`` to allow unlimited overdraw.
 
    Default: ``0``
 

--- a/tests/control_thresholds.py
+++ b/tests/control_thresholds.py
@@ -4,13 +4,13 @@ from arbeitszeit.injector import singleton
 @singleton
 class ControlThresholdsTestImpl:
     def __init__(self) -> None:
-        self.allowed_overdraw_of_member_account: int = 10000000
+        self.allowed_overdraw_of_member_account: int | None = None
         self.acceptable_relative_account_deviation: int = 33
 
-    def get_allowed_overdraw_of_member_account(self) -> int:
+    def get_allowed_overdraw_of_member_account(self) -> int | None:
         return self.allowed_overdraw_of_member_account
 
-    def set_allowed_overdraw_of_member_account(self, overdraw: int) -> None:
+    def set_allowed_overdraw_of_member_account(self, overdraw: int | None) -> None:
         self.allowed_overdraw_of_member_account = overdraw
 
     def get_acceptable_relative_account_deviation(self) -> int:

--- a/tests/flask_integration/database_gateway_impl/test_plan_results.py
+++ b/tests/flask_integration/database_gateway_impl/test_plan_results.py
@@ -776,7 +776,7 @@ class JoinedWithProvidedProductAmountTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
-        self.control_thresholds.set_allowed_overdraw_of_member_account(10000)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
 
     @parameterized.expand(
         [

--- a/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
+++ b/tests/flask_integration/database_gateway_impl/test_private_consumption_result.py
@@ -8,7 +8,7 @@ class PrivateConsumptionTests(FlaskTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
-        self.control_thresholds.set_allowed_overdraw_of_member_account(1000)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
 
     def test_that_by_default_no_private_consumptions_are_in_db(self) -> None:
         assert not self.database_gateway.get_private_consumptions()

--- a/tests/use_cases/test_query_private_consumptions.py
+++ b/tests/use_cases/test_query_private_consumptions.py
@@ -11,7 +11,7 @@ class TestQueryPrivateConsumptions(BaseTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.query_consumptions = self.injector.get(QueryPrivateConsumptions)
-        self.control_thresholds.set_allowed_overdraw_of_member_account(10000)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
 
     def test_that_no_consumption_is_returned_when_searching_an_empty_repo(self) -> None:
         member = self.member_generator.create_member()

--- a/tests/use_cases/test_register_private_consumption.py
+++ b/tests/use_cases/test_register_private_consumption.py
@@ -177,20 +177,29 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
             response.rejection_reason, RejectionReason.insufficient_balance
         )
 
-    def test_registration_is_successful_if_member_without_certs_consumes_value_of_10_and_has_account_limit_of_11(
+    @parameterized.expand(
+        [
+            (Decimal("2"), 2),
+            (Decimal("2"), 3),
+            (Decimal("2"), None),
+        ]
+    )
+    def test_registration_is_successful_if_member_without_certs_has_account_limit_that_equals_or_exceeds_the_product_price(
         self,
+        price: Decimal,
+        allowed_overdraw: int | None,
     ) -> None:
         plan = self.plan_generator.create_plan(
             costs=ProductionCosts(
-                means_cost=Decimal("4"),
-                resource_cost=Decimal("4"),
-                labour_cost=Decimal("2"),
+                means_cost=Decimal(price),
+                resource_cost=Decimal(0),
+                labour_cost=Decimal(0),
             ),
             amount=1,
             cooperation=None,
         )
         assert self.balance_checker.get_member_account_balance(self.consumer) == 0
-        self.control_thresholds.set_allowed_overdraw_of_member_account(11)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(allowed_overdraw)
 
         response = self.register_private_consumption.register_private_consumption(
             self.make_request(plan, 1)

--- a/tests/use_cases/test_show_prd_account_details.py
+++ b/tests/use_cases/test_show_prd_account_details.py
@@ -16,7 +16,7 @@ class UseCaseTester(BaseTestCase):
         self.use_case = self.injector.get(
             show_prd_account_details.ShowPRDAccountDetailsUseCase
         )
-        self.control_thresholds.set_allowed_overdraw_of_member_account(10000)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
 
     def test_no_transfers_returned_when_no_transfers_took_place(self) -> None:
         company = self.company_generator.create_company()


### PR DESCRIPTION
After this change, by setting the variable ALLOWED_OVERDRAW_MEMBER to `-1`, the allowed overdraw of member accounts can be configured to be unlimited.

This is useful for tests and theoretical scenarios, but also for very permissive productive scenarios.

Note that this decision practically prevents us to allow negative overdraw values other than `-1`, which the author of this commits finds acceptable, because such a feature would mean to prohibit the spending of existing labour time tokens.