### PR TITLE
Make colors customizable

### DIFF
--- a/arbeitszeit_flask/dependency_injection/__init__.py
+++ b/arbeitszeit_flask/dependency_injection/__init__.py
@@ -41,7 +41,7 @@ from arbeitszeit_flask.url_index import GeneralUrlIndex
 from arbeitszeit_flask.views.accountant_invitation_email_view import (
     AccountantInvitationEmailViewImpl,
 )
-from arbeitszeit_web.colors import Colors
+from arbeitszeit_web.colors import HexColors
 from arbeitszeit_web.email import EmailConfiguration, MailService
 from arbeitszeit_web.email.accountant_invitation_presenter import (
     AccountantInvitationEmailView,
@@ -92,7 +92,7 @@ class FlaskModule(Module):
         binder[MailService] = CallableProvider(get_mail_service)
         binder[Translator] = AliasProvider(FlaskTranslator)
         binder[Plotter] = AliasProvider(FlaskPlotter)
-        binder[Colors] = AliasProvider(FlaskColors)
+        binder[HexColors] = AliasProvider(FlaskColors)
         binder[ControlThresholds] = AliasProvider(ControlThresholdsFlask)
         binder[DatetimeFormatter] = AliasProvider(FlaskDatetimeFormatter)
         binder[TimezoneConfiguration] = AliasProvider(FlaskTimezoneConfiguration)

--- a/arbeitszeit_flask/flask_colors.py
+++ b/arbeitszeit_flask/flask_colors.py
@@ -1,36 +1,45 @@
-from typing import Dict
+import colorsys
+
+
+def hsl_to_hex(hue: float, saturation: float, lightness: float) -> str:
+    """
+    Parameters:
+        h (float): Hue angle in degrees (0–360)
+        s (float): Saturation (0–100)
+        l (float): Lightness (0–100)
+
+    Returns:
+        str: Hex color string (e.g. '#ff5733')
+    """
+    # convert to 0–1 range
+    hue /= 360
+    saturation /= 100
+    lightness /= 100
+
+    r, g, b = colorsys.hls_to_rgb(hue, lightness, saturation)
+
+    # Convert to 0–255 and then to hex
+    return "#{:02x}{:02x}{:02x}".format(int(r * 255), int(g * 255), int(b * 255))
 
 
 class FlaskColors:
-    def __init__(self) -> None:
-        # hex values should be same as bulma values
-        self.all_colors = {
-            "primary": "#00d1b2",
-            "info": "#3e8ed0",
-            "warning": "#ffe08a",
-            "danger": "#f14668",
-            "success": "#48c78e",
-        }
+    # hsl values must be in sync with colors.css
+    @property
+    def primary(self):
+        return hsl_to_hex(171, 100, 41)
 
     @property
-    def primary(self) -> str:
-        return self.all_colors["primary"]
+    def info(self):
+        return hsl_to_hex(207, 61, 53)
 
     @property
-    def info(self) -> str:
-        return self.all_colors["info"]
+    def warning(self):
+        return hsl_to_hex(44, 100, 77)
 
     @property
-    def warning(self) -> str:
-        return self.all_colors["warning"]
+    def danger(self):
+        return hsl_to_hex(348, 86, 61)
 
     @property
-    def danger(self) -> str:
-        return self.all_colors["danger"]
-
-    @property
-    def success(self) -> str:
-        return self.all_colors["success"]
-
-    def get_all_defined_colors(self) -> Dict[str, str]:
-        return self.all_colors
+    def success(self):
+        return hsl_to_hex(153, 53, 53)

--- a/arbeitszeit_flask/plots/routes.py
+++ b/arbeitszeit_flask/plots/routes.py
@@ -10,7 +10,7 @@ from arbeitszeit.interactors.show_prd_account_details import (
     ShowPRDAccountDetailsInteractor,
 )
 from arbeitszeit_flask.dependency_injection import with_injection
-from arbeitszeit_web.colors import Colors
+from arbeitszeit_web.colors import HexColors
 from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.www.controllers.show_a_account_details_controller import (
@@ -27,7 +27,7 @@ plots = Blueprint("plots", __name__)
 @with_injection()
 @login_required
 def global_barplot_for_certificates(
-    plotter: Plotter, translator: Translator, colors: Colors
+    plotter: Plotter, translator: Translator, colors: HexColors
 ):
     certificates_count = Decimal(request.args["certificates_count"])
     available_product = Decimal(request.args["available_product"])
@@ -51,7 +51,7 @@ def global_barplot_for_certificates(
 @with_injection()
 @login_required
 def global_barplot_for_means_of_production(
-    plotter: Plotter, translator: Translator, colors: Colors
+    plotter: Plotter, translator: Translator, colors: HexColors
 ):
     planned_means = Decimal(request.args["planned_means"])
     planned_resources = Decimal(request.args["planned_resources"])
@@ -81,7 +81,9 @@ def global_barplot_for_means_of_production(
 @plots.route("/plots/global_barplot_for_plans")
 @with_injection()
 @login_required
-def global_barplot_for_plans(plotter: Plotter, translator: Translator, colors: Colors):
+def global_barplot_for_plans(
+    plotter: Plotter, translator: Translator, colors: HexColors
+):
     productive_plans = Decimal(request.args["productive_plans"])
     public_plans = Decimal(request.args["public_plans"])
     png = plotter.create_bar_plot(
@@ -90,7 +92,7 @@ def global_barplot_for_plans(plotter: Plotter, translator: Translator, colors: C
             translator.gettext("Public plans"),
         ],
         height_of_bars=[productive_plans, public_plans],
-        colors_of_bars=list(colors.get_all_defined_colors().values()),
+        colors_of_bars=[colors.primary, colors.info],
         fig_size=(5, 4),
         y_label=translator.gettext("Amount"),
     )

--- a/arbeitszeit_flask/static/colors.css
+++ b/arbeitszeit_flask/static/colors.css
@@ -1,0 +1,22 @@
+/* must be in sync with color definitions in code */
+:root {
+    --bulma-primary-h: 171deg;
+    --bulma-primary-s: 100%;
+    --bulma-primary-l: 41%;
+
+    --bulma-info-h: 198deg;
+    --bulma-info-s: 100%;
+    --bulma-info-l: 70%;
+
+    --bulma-warning-h: 42deg;
+    --bulma-warning-s: 100%;
+    --bulma-warning-l: 53%;
+
+    --bulma-danger-h: 348deg;
+    --bulma-danger-s: 100%;
+    --bulma-danger-l: 70%;
+
+    --bulma-success-h: 153deg;
+    --bulma-success-s: 53%;
+    --bulma-success-l: 53%;
+}

--- a/arbeitszeit_flask/templates/base.html
+++ b/arbeitszeit_flask/templates/base.html
@@ -16,6 +16,7 @@
   <link rel="shortcut icon" href="{{ url_for('static', filename='favicon.ico') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='bulma.css') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='main.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='colors.css') }}">
   {% block style %}
   {% endblock %}
   <script src="{{ url_for('static', filename='main.js') }}"></script>

--- a/arbeitszeit_web/colors.py
+++ b/arbeitszeit_web/colors.py
@@ -1,7 +1,7 @@
-from typing import Dict, Protocol
+from typing import Protocol
 
 
-class Colors(Protocol):
+class HexColors(Protocol):
     @property
     def primary(self) -> str: ...
 
@@ -16,5 +16,3 @@ class Colors(Protocol):
 
     @property
     def success(self) -> str: ...
-
-    def get_all_defined_colors(self) -> Dict[str, str]: ...

--- a/arbeitszeit_web/www/presenters/get_statistics_presenter.py
+++ b/arbeitszeit_web/www/presenters/get_statistics_presenter.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.interactors.get_statistics import StatisticsResponse
-from arbeitszeit_web.colors import Colors
+from arbeitszeit_web.colors import HexColors
 from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.translator import Translator
 from arbeitszeit_web.url_index import UrlIndex
@@ -34,7 +34,7 @@ class GetStatisticsViewModel:
 class GetStatisticsPresenter:
     translator: Translator
     plotter: Plotter
-    colors: Colors
+    colors: HexColors
     url_index: UrlIndex
     datetime_service: DatetimeService
 

--- a/tests/dependency_injection.py
+++ b/tests/dependency_injection.py
@@ -3,7 +3,7 @@ from arbeitszeit.datetime_service import DatetimeService
 from arbeitszeit.email_notifications import EmailSender
 from arbeitszeit.injector import AliasProvider, Binder, CallableProvider, Module
 from arbeitszeit.password_hasher import PasswordHasher
-from arbeitszeit_web.colors import Colors
+from arbeitszeit_web.colors import HexColors
 from arbeitszeit_web.plotter import Plotter
 from arbeitszeit_web.request import Request
 from arbeitszeit_web.text_renderer import TextRenderer
@@ -24,7 +24,7 @@ class TestingModule(Module):
         super().configure(binder)
         binder[EmailSender] = AliasProvider(EmailSenderTestImpl)
         binder[TextRenderer] = AliasProvider(TextRendererImpl)
-        binder[Colors] = AliasProvider(ColorsTestImpl)
+        binder[HexColors] = AliasProvider(ColorsTestImpl)
         binder[Plotter] = AliasProvider(FakePlotter)
         binder[ControlThresholds] = AliasProvider(ControlThresholdsTestImpl)
         binder[Translator] = AliasProvider(FakeTranslator)

--- a/tests/www/presenters/test_colors.py
+++ b/tests/www/presenters/test_colors.py
@@ -1,6 +1,3 @@
-from typing import Dict
-
-
 class ColorsTestImpl:
     def __init__(self) -> None:
         self.all_colors = {
@@ -30,6 +27,3 @@ class ColorsTestImpl:
     @property
     def success(self) -> str:
         return self.all_colors["success"]
-
-    def get_all_defined_colors(self) -> Dict[str, str]:
-        return self.all_colors


### PR DESCRIPTION
After this commit, we can change the main colors of the flask app via CSS variables defined in a CSS file and in "arbeitszeit_flask/flask_colors.py". In the adapters layer nothing has changed, we can still access the main colors through the interface in arbeitszeit_web/colors.py.

The actual colors of the app have not changed.