### PR TITLE
Change calculation of payout factor (FIC)

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -101,7 +101,7 @@ where :math:`L` is the sum of all working hours in productive plans,
 :math:`P_o` is the sum of all fixed means of production in public plans, and
 :math:`R_o` is the sum of all liquid means of production in public plans. 
 
-The FIC ranges from −∞ to 1, but in practice, it should never be negative. A negative FIC indicates that available labor is insufficient to cover the costs of public plans, leading to the issuance of negative work certificates upon work registration.
+The FIC ranges from 0 to 1.
 
 * If FIC = 0, all labor is allocated to public plans, making all goods and services freely available. When workers register hours worked, they do not receive any work certificates, since their work goes entirely to freely available public-sector goods and services and thus cannot be exchanged for private consumption.
 * If FIC = 1, all labor is dedicated to productive plans, meaning nothing is freely available. Work certificates are issued in full without deductions.

--- a/tests/interactors/test_register_hours_worked.py
+++ b/tests/interactors/test_register_hours_worked.py
@@ -212,14 +212,14 @@ class RegisterHoursWorkedTests(BaseTestCase):
             == -hours_worked
         )
 
-    def test_that_with_negative_fic_worker_receives_negative_certificates(self) -> None:
+    def test_that_with_fic_of_zero_worker_receives_zero_certificates(self) -> None:
         worker = self.member_generator.create_member()
         company = self.company_generator.create_company_record(workers=[worker])
-        self._make_fic_negative()
+        self._make_fic_zero()
         self.register_hours_worked.execute(
             RegisterHoursWorkedRequest(company.id, worker, hours_worked=Decimal(10))
         )
-        assert self.balance_checker.get_member_account_balance(worker) < Decimal("0")
+        assert self.balance_checker.get_member_account_balance(worker) == Decimal("0")
 
     @parameterized.expand(
         [
@@ -227,13 +227,13 @@ class RegisterHoursWorkedTests(BaseTestCase):
             (Decimal(20),),
         ]
     )
-    def test_that_with_negative_fic_company_gets_deducted_all_hours_worked(
+    def test_that_with_fic_of_zero_company_gets_deducted_all_hours_worked(
         self,
         hours_worked: Decimal,
     ) -> None:
         worker = self.member_generator.create_member()
         company = self.company_generator.create_company_record(workers=[worker])
-        self._make_fic_negative()
+        self._make_fic_zero()
         self.register_hours_worked.execute(
             RegisterHoursWorkedRequest(company.id, worker, hours_worked=hours_worked)
         )
@@ -242,7 +242,7 @@ class RegisterHoursWorkedTests(BaseTestCase):
             == -hours_worked
         )
 
-    def _make_fic_negative(self) -> None:
+    def _make_fic_zero(self) -> None:
         self.plan_generator.create_plan(
             is_public_service=True,
             costs=ProductionCosts(
@@ -251,4 +251,4 @@ class RegisterHoursWorkedTests(BaseTestCase):
                 resource_cost=Decimal(10),
             ),
         )
-        self.fic_service.get_current_payout_factor() < Decimal("0")
+        assert self.fic_service.get_current_payout_factor() == Decimal("0")

--- a/tests/services/test_payout_factor_service.py
+++ b/tests/services/test_payout_factor_service.py
@@ -1,6 +1,8 @@
 from datetime import timedelta
 from decimal import Decimal
 
+from parameterized import parameterized
+
 from arbeitszeit.records import ProductionCosts
 from arbeitszeit.services.payout_factor import PayoutFactorService
 from tests.datetime_service import datetime_utc
@@ -12,43 +14,57 @@ class PayoutFactorServiceCalculationTests(BaseTestCase):
         super().setUp()
         self.service = self.injector.get(PayoutFactorService)
 
-    def test_that_payout_factor_is_one_if_no_plans_exist(self) -> None:
+    def test_that_payout_factor_is_1_if_no_plans_exist(self) -> None:
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertEqual(pf, 1)
+        assert pf == 1
 
-    def test_that_payout_factor_is_negative_with_one_public_plan_that_includes_p_or_r(
+    def test_that_payout_factor_is_1_if_there_is_only_one_public_plan_without_costs(
         self,
     ) -> None:
         self.plan_generator.create_plan(
             is_public_service=True,
-            costs=ProductionCosts(Decimal(10), Decimal(10), Decimal(10)),
+            costs=ProductionCosts.zero(),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertTrue(pf < 0)
+        assert pf == 1
 
-    def test_that_payout_factor_is_zero_with_one_public_plan_that_does_not_includes_p_or_r(
+    @parameterized.expand(
+        [
+            (Decimal(1), Decimal(0), Decimal(1)),
+            (Decimal(1), Decimal(1), Decimal(0)),
+            (Decimal(1), Decimal(0), Decimal(0)),
+            (Decimal(1), Decimal(1), Decimal(1)),
+            (Decimal(0), Decimal(0), Decimal(1)),
+            (Decimal(0), Decimal(1), Decimal(0)),
+            (Decimal(0), Decimal(1), Decimal(1)),
+        ]
+    )
+    def test_that_payout_factor_is_0_if_there_is_only_one_public_plan_with_costs(
         self,
+        public_a: Decimal,
+        public_p: Decimal,
+        public_r: Decimal,
     ) -> None:
         self.plan_generator.create_plan(
             is_public_service=True,
-            costs=ProductionCosts(Decimal(10), Decimal(0), Decimal(0)),
+            costs=ProductionCosts(public_a, public_p, public_r),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertEqual(pf, 0)
+        assert pf == 0
 
-    def test_that_payout_factor_is_zero_when_productive_labour_equals_sum_of_public_p_and_r(
+    def test_that_payout_factor_is_0_when_productive_labour_equals_sum_of_public_p_and_r(
         self,
     ) -> None:
         self.plan_generator.create_plan(
             is_public_service=True,
-            costs=ProductionCosts(Decimal(10), Decimal(10), Decimal(10)),
+            costs=ProductionCosts(Decimal(0), Decimal(10), Decimal(10)),
         )
         self.plan_generator.create_plan(
             is_public_service=False,
             costs=ProductionCosts(Decimal(20), Decimal(0), Decimal(0)),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertEqual(pf, 0)
+        assert pf == 0
 
     def test_that_payout_factor_is_positive_when_productive_labour_surpasses_sum_of_public_p_and_r(
         self,
@@ -62,9 +78,9 @@ class PayoutFactorServiceCalculationTests(BaseTestCase):
             costs=ProductionCosts(Decimal(21), Decimal(0), Decimal(0)),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertTrue(pf > 0)
+        assert pf > 0
 
-    def test_that_payout_factor_is_negative_when_sum_of_public_p_and_r_surpasses_productive_labour(
+    def test_that_payout_factor_is_zero_when_sum_of_public_p_and_r_surpasses_productive_labour(
         self,
     ) -> None:
         self.plan_generator.create_plan(
@@ -76,24 +92,33 @@ class PayoutFactorServiceCalculationTests(BaseTestCase):
             costs=ProductionCosts(Decimal(19), Decimal(0), Decimal(0)),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        self.assertTrue(pf < 0)
+        assert pf == 0
 
-    def test_that_correct_payout_factor_gets_calculated(self) -> None:
-        A = 10
-        Po = 10
-        Ro = 10
-        Ao = 10
-
+    @parameterized.expand(
+        [
+            (Decimal(10), Decimal(10), Decimal(10), Decimal(10), Decimal(0)),
+            (Decimal(20), Decimal(10), Decimal(10), Decimal(10), Decimal(0)),
+            (Decimal(30), Decimal(10), Decimal(10), Decimal(10), Decimal(0.25)),
+            (Decimal(30), Decimal(0), Decimal(0), Decimal(0), Decimal(1)),
+        ]
+    )
+    def test_that_expected_payout_factor_gets_calculated(
+        self,
+        productive_a: Decimal,
+        public_a: Decimal,
+        public_p: Decimal,
+        public_r: Decimal,
+        expected_payout_factor: Decimal,
+    ) -> None:
         self.plan_generator.create_plan(
             is_public_service=True,
-            costs=ProductionCosts(Decimal(Ao), Decimal(Ro), Decimal(Po)),
+            costs=ProductionCosts(public_a, public_r, public_p),
         )
         self.plan_generator.create_plan(
             is_public_service=False,
-            costs=ProductionCosts(Decimal(A), Decimal(10), Decimal(10)),
+            costs=ProductionCosts(productive_a, Decimal(10), Decimal(10)),
         )
         pf = self.service.calculate_payout_factor(self.datetime_service.now())
-        expected_payout_factor = Decimal((A - (Po + Ro)) / (A + Ao))
         self.assertAlmostEqual(pf, expected_payout_factor)
 
     def test_that_payout_factor_gets_calculated_based_on_supplied_timestamp(


### PR DESCRIPTION
Changes:
- assure that FIC ranges between 0 and 1. Convert negative values to zero.
- If no living labour is planned, return either zero if machinery or raw materials are planned in the public sector, or 1 otherwise.

fixes #1333