### PR TITLE
Rename nix package to "workers-control"

### DIFF
--- a/dev/nix/devShell.nix
+++ b/dev/nix/devShell.nix
@@ -29,8 +29,8 @@ mkShell (
         sqlite
         git
       ]
-      ++ python3.pkgs.arbeitszeitapp.optional-dependencies.profiling;
-    inputsFrom = [ python3.pkgs.arbeitszeitapp ];
+      ++ python3.pkgs.workers-control.optional-dependencies.profiling;
+    inputsFrom = [ python3.pkgs.workers-control ];
     shellHook = ''
       export PYTHONPATH="$PWD/src:$PYTHONPATH"
     '';

--- a/dev/nix/pythonPackages.nix
+++ b/dev/nix/pythonPackages.nix
@@ -1,5 +1,5 @@
 self: super: {
-  arbeitszeitapp = self.callPackage pythonPackages/arbeitszeitapp.nix { };
+  workers-control = self.callPackage pythonPackages/workers-control.nix { };
   flask-babel = self.callPackage pythonPackages/flask-babel.nix { };
   flask-login = self.callPackage pythonPackages/flask-login.nix { };
 }

--- a/dev/nix/pythonPackages/workers-control.nix
+++ b/dev/nix/pythonPackages/workers-control.nix
@@ -22,7 +22,7 @@
   sphinx-rtd-theme,
 }:
 buildPythonPackage {
-  pname = "arbeitszeitapp";
+  pname = "workers-control";
   version = "0.1.1";
   src = ../../..;
   outputs = [
@@ -55,8 +55,8 @@ buildPythonPackage {
     matplotlib
   ];
   buildDocsPhase = ''
-    mkdir -p $doc/share/doc/arbeitszeitapp
-    python -m sphinx -a $src/docs $doc/share/doc/arbeitszeitapp
+    mkdir -p $doc/share/doc/workers-control
+    python -m sphinx -a $src/docs $doc/share/doc/workers-control
   '';
   passthru.optional-dependencies = {
     profiling = [ flask-profiler ];

--- a/docs/config_options_GENERATED.rst
+++ b/docs/config_options_GENERATED.rst
@@ -102,7 +102,7 @@
 
    This variable tells the application how it is addressed. This is important to generate links in emails it sends out.
 
-   Example: ``SERVER_NAME = "arbeitszeitapp.cp.org"``
+   Example: ``SERVER_NAME = "workers-control.cp.org"``
 
 .. py:data:: SQLALCHEMY_DATABASE_URI
    :no-index:

--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
             };
           };
           packages = {
-            default = pkgs.python3.pkgs.arbeitszeitapp;
+            default = pkgs.python3.pkgs.workers-control;
             inherit (pkgs) python3;
           };
           checks = {
@@ -56,10 +56,10 @@
             # artifacts. This is why we can test for the system
             # python3 interpreter and also explicitly list all
             # versions we want to support.
-            arbeitszeit-python3-nixpkgs-unstable = pkgs.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python312-nixpkgs-unstable = pkgs.python312.pkgs.arbeitszeitapp;
-            arbeitszeit-python3-nixpkgs-stable = pkgs-25-11.python3.pkgs.arbeitszeitapp;
-            arbeitszeit-python312-nixpkgs-stable = pkgs-25-11.python312.pkgs.arbeitszeitapp;
+            woco-python3-nixpkgs-unstable = pkgs.python3.pkgs.workers-control;
+            woco-python312-nixpkgs-unstable = pkgs.python312.pkgs.workers-control;
+            woco-python3-nixpkgs-stable = pkgs-25-11.python3.pkgs.workers-control;
+            woco-python312-nixpkgs-stable = pkgs-25-11.python312.pkgs.workers-control;
           };
         }
       );

--- a/src/workers_control/flask/config/options.py
+++ b/src/workers_control/flask/config/options.py
@@ -141,7 +141,7 @@ CONFIG_OPTIONS = [
         description_paragraphs=[
             "This variable tells the application how it is addressed. This is important to generate links in emails it sends out."
         ],
-        example='SERVER_NAME = "arbeitszeitapp.cp.org"',
+        example='SERVER_NAME = "workers-control.cp.org"',
         default=None,
     ),
     ConfigOption(


### PR DESCRIPTION
Requires downstream production users to update their reference.

see #1314 