### PR TITLE
Fix bug in psf balance calculation

### DIFF
--- a/src/workers_control/core/services/psf_balance.py
+++ b/src/workers_control/core/services/psf_balance.py
@@ -29,7 +29,9 @@ class PublicSectorFundService:
 
     def _calculate_public_plans_costs(self, public_plans: Iterable[Plan]) -> Decimal:
         return decimal_sum(
-            plan.production_costs.resource_cost + plan.production_costs.means_cost
+            plan.production_costs.resource_cost
+            + plan.production_costs.means_cost
+            + plan.production_costs.labour_cost
             for plan in public_plans
         )
 


### PR DESCRIPTION
This commit fixes a bug. The planned "living labour" was not considered in the sum of the public plan costs. A test that would have catched that bug was missing, it has been added now.