### PR TITLE
Change PSF balance calculation

### DIFF
--- a/src/workers_control/core/services/psf_balance.py
+++ b/src/workers_control/core/services/psf_balance.py
@@ -1,9 +1,8 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Iterable
 
 from workers_control.core.decimal import decimal_sum
-from workers_control.core.records import Plan, SocialAccounting, Transfer
+from workers_control.core.records import SocialAccounting
 from workers_control.core.repositories import DatabaseGateway
 
 
@@ -13,27 +12,16 @@ class PublicSectorFundService:
     social_accounting: SocialAccounting
 
     def calculate_psf_balance(self) -> Decimal:
-        public_plans = (
-            self.database_gateway.get_plans().that_are_public().that_are_approved()
-        )
         taxes_transfers = (
             self.database_gateway.get_transfers().where_account_is_creditor(
                 self.social_accounting.account_psf
             )
         )
-        public_plans_costs = self._calculate_public_plans_costs(
-            public_plans=public_plans
+        public_credit_transfers = (
+            self.database_gateway.get_transfers().where_account_is_debtor(
+                self.social_accounting.account_psf
+            )
         )
-        taxes = self._calculate_sum_of_taxes(taxes_transfers=taxes_transfers)
+        taxes = decimal_sum(t.value for t in taxes_transfers)
+        public_plans_costs = decimal_sum(t.value for t in public_credit_transfers)
         return taxes - public_plans_costs
-
-    def _calculate_public_plans_costs(self, public_plans: Iterable[Plan]) -> Decimal:
-        return decimal_sum(
-            plan.production_costs.resource_cost
-            + plan.production_costs.means_cost
-            + plan.production_costs.labour_cost
-            for plan in public_plans
-        )
-
-    def _calculate_sum_of_taxes(self, taxes_transfers: Iterable[Transfer]) -> Decimal:
-        return decimal_sum(transfer.value for transfer in taxes_transfers)


### PR DESCRIPTION
Calculate PSF balance using recorded transfers instead of planned values. The get_statistics benchmark shows a 25% faster execution.

see #1345