### PR TITLE
Fix f-strings not being translated

### DIFF
--- a/docs/coding_guidelines.rst
+++ b/docs/coding_guidelines.rst
@@ -893,6 +893,8 @@ The workflow for updating the translations is as follows:
     translator.pgettext(comment: str, message: str)
     translator.ngettext(self, singular: str, plural: str, n: Number)
 
+   The `message` argument must not be an F-string.
+
    In Jinja templates use::
 
     gettext(message: str)

--- a/src/workers_control/flask/translations/messages.pot
+++ b/src/workers_control/flask/translations/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-01-17 12:29+0100\n"
+"POT-Creation-Date: 2026-01-22 20:24+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1827,8 +1827,15 @@ msgstr ""
 msgid "Invitation from a company on Workers Control app"
 msgstr ""
 
-#: src/workers_control/web/email/notify_about_worker_removal_from_company_presenter.py:18
+#: src/workers_control/web/email/notify_about_worker_removal_from_company_presenter.py:19
 msgid "Worker removed from company"
+msgstr ""
+
+#: src/workers_control/web/email/notify_about_worker_removal_from_company_presenter.py:22
+#, python-format
+msgid ""
+"Hello,<br><br>The worker %(worker_name)s (id: %(worker_id)s) has been "
+"removed from company %(company_name)s."
 msgstr ""
 
 #: src/workers_control/web/email/notify_accountant_about_new_plan_presenter.py:20
@@ -1925,18 +1932,38 @@ msgid "At least one of the costs fields must be a positive number of hours."
 msgstr ""
 
 #: src/workers_control/web/www/controllers/draft_form_validator.py:126
-#: src/workers_control/web/www/controllers/draft_form_validator.py:145
-#: src/workers_control/web/www/controllers/draft_form_validator.py:179
+#: src/workers_control/web/www/controllers/draft_form_validator.py:146
+#: src/workers_control/web/www/controllers/draft_form_validator.py:183
 #: src/workers_control/web/www/controllers/register_productive_consumption_controller.py:64
 msgid "This field is required."
 msgstr ""
 
-#: src/workers_control/web/www/controllers/draft_form_validator.py:150
+#: src/workers_control/web/www/controllers/draft_form_validator.py:131
+#, python-format
+msgid "This field must be at most %(max_length)s characters long."
+msgstr ""
+
+#: src/workers_control/web/www/controllers/draft_form_validator.py:151
 msgid "This field must be an integer."
 msgstr ""
 
-#: src/workers_control/web/www/controllers/draft_form_validator.py:185
+#: src/workers_control/web/www/controllers/draft_form_validator.py:158
+#, python-format
+msgid "This field must be an integer between %(min_value)s and %(max_value)s."
+msgstr ""
+
+#: src/workers_control/web/www/controllers/draft_form_validator.py:165
+#, python-format
+msgid "This field must be an integer greater than or equal to %(min_value)s."
+msgstr ""
+
+#: src/workers_control/web/www/controllers/draft_form_validator.py:172
+#, python-format
+msgid "This field must be an integer less than or equal to %(max_value)s."
+msgstr ""
+
 #: src/workers_control/web/www/controllers/draft_form_validator.py:189
+#: src/workers_control/web/www/controllers/draft_form_validator.py:193
 msgid "This field must be zero or a positive number."
 msgstr ""
 

--- a/src/workers_control/web/email/notify_about_worker_removal_from_company_presenter.py
+++ b/src/workers_control/web/email/notify_about_worker_removal_from_company_presenter.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from html import escape
 
 from workers_control.core.email_notifications import WorkerRemovalNotification
 from workers_control.web.email import EmailConfiguration, MailService
@@ -18,7 +19,12 @@ class NotifyAboutWorkerRemovalPresenter:
             subject=self.translator.gettext("Worker removed from company"),
             recipients=[message_data.worker_email, message_data.company_email],
             html=self.translator.gettext(
-                f"Hello,<br><br>The worker {message_data.worker_name} (id: {str(message_data.worker_id)}) has been removed from company {message_data.company_name}."
+                "Hello,<br><br>The worker %(worker_name)s (id: %(worker_id)s) has been removed from company %(company_name)s."
+                % dict(
+                    worker_name=escape(message_data.worker_name),
+                    worker_id=message_data.worker_id,
+                    company_name=escape(message_data.company_name),
+                )
             ),
             sender=self.email_configuration.get_sender_address(),
         )

--- a/src/workers_control/web/www/controllers/draft_form_validator.py
+++ b/src/workers_control/web/www/controllers/draft_form_validator.py
@@ -128,7 +128,8 @@ class DraftFormValidator:
         if max_length and len(text) > max_length:
             return [
                 self.translator.gettext(
-                    f"This field must be at most {max_length} characters long."
+                    "This field must be at most %(max_length)s characters long."
+                    % dict(max_length=max_length)
                 )
             ]
         return text.strip()
@@ -154,19 +155,22 @@ class DraftFormValidator:
             if min_value is not None and max_value is not None:
                 return [
                     self.translator.gettext(
-                        f"This field must be an integer between {min_value} and {max_value}."
+                        "This field must be an integer between %(min_value)s and %(max_value)s."
+                        % dict(min_value=min_value, max_value=max_value)
                     )
                 ]
             elif min_value is not None:
                 return [
                     self.translator.gettext(
-                        f"This field must be an integer greater than or equal to {min_value}."
+                        "This field must be an integer greater than or equal to %(min_value)s."
+                        % dict(min_value=min_value)
                     )
                 ]
             elif max_value is not None:
                 return [
                     self.translator.gettext(
-                        f"This field must be an integer less than or equal to {max_value}."
+                        "This field must be an integer less than or equal to %(max_value)s."
+                        % dict(max_value=max_value)
                     )
                 ]
         return integer


### PR DESCRIPTION
F-strings are not supported by python-babel. F-strings in a few places have been replaced by % substitution. Instructions have been added to the dev docs.

Moreover, html in one mail body has been safely escaped.