### PR TITLE
Run alembic as a flask subcommand

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -41,16 +41,12 @@ jobs:
       with:
         name: arbeitszeit-2
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN_2 }}'
-    - run: nix develop --command alembic upgrade head
+    - run: nix develop --command alembic -x db_url=postgresql://postgres:postgres@localhost:5432/postgres upgrade head
       env:
-        ALEMBIC_SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/postgres
         ALEMBIC_CONFIG: tests/flask_integration/alembic.ini
-        FLASK_APP: workers_control.flask
-    - run: nix develop --command alembic check
+    - run: nix develop --command alembic -x db_url=postgresql://postgres:postgres@localhost:5432/postgres check
       env:
-        ALEMBIC_SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:5432/postgres
         ALEMBIC_CONFIG: tests/flask_integration/alembic.ini
-        FLASK_APP: workers_control.flask
     services:
       postgres:
         image: postgres

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,5 @@ recursive-include src/workers_control/flask/templates *.html
 recursive-include src/workers_control/flask/static *.js *.css favicon.ico
 recursive-include src/workers_control/flask/translations *.po *.mo *.pot
 include src/workers_control/flask/logging_config.json
-recursive-include src/workers_control/db/migrations *.mako *.py
+recursive-include src/workers_control/db/migrations *.mako *.py *.ini
 recursive-include build_support *.py *.cfg

--- a/dev/development_server.py
+++ b/dev/development_server.py
@@ -62,7 +62,7 @@ class FlaskDevConfiguration:
 
     SQLALCHEMY_DATABASE_URI = os.environ["WOCO_DEV_DB"]
     SQLALCHEMY_TRACK_MODIFICATIONS = False
-    ALEMBIC_CONFIG = os.getenv("ALEMBIC_CONFIG")
+    ALEMBIC_CONFIG = "dev/alembic.ini"
     AUTO_MIGRATE = os.getenv("AUTO_MIGRATE", False)
 
 

--- a/dev/nix/pythonPackages/workers-control.nix
+++ b/dev/nix/pythonPackages/workers-control.nix
@@ -31,6 +31,7 @@ buildPythonPackage {
   postPhases = [ "buildDocsPhase" ];
   pyproject = true;
   nativeCheckInputs = [
+    alembic
     pytest
     postgresql
     psycopg2

--- a/docs/config_options_GENERATED.rst
+++ b/docs/config_options_GENERATED.rst
@@ -12,7 +12,7 @@
 .. py:data:: AUTO_MIGRATE
    :no-index:
 
-   Upgrade the database schema if changes are detected on startup. If auto migration is not activated, you need to run database migrations manually via the ``alembic`` command line tool.
+   Upgrade the database schema if changes are detected on startup. If auto migration is not activated, you need to run database migrations manually.
 
    Example: ``AUTO_MIGRATE = True``
 
@@ -103,7 +103,9 @@
    :no-index:
 
    This integer defines the "relative deviation" from the ideal account balance of zero that is still deemed acceptable, expressed in percent and calculated relative to the expected transfer value of this account.
+
    Example: Company XY has an absolute deviation of minus 1000 hours on its account for means of production (PRD account). Because it has filed plans with total costs for means of production of 10000 hours (=the sum of expected transfer value), its relative deviation is 10%.
+
    Unacceptable high deviations might get labeled as such or highlighted by the application.
 
    Default: ``33``
@@ -112,6 +114,18 @@
    :no-index:
 
    A time window in days, over which the payout factor is calculated.
+
    Must be an integer larger than zero.
 
    Default: ``180``
+
+.. py:data:: ALEMBIC_CONFIG
+   :no-index:
+
+   Path to a custom alembic configuration file. Alembic is used to manage database migrations. See the Alembic documentation for details.
+
+   If not set, the bundled ``alembic.ini`` from the installed package is used.
+
+   Example: ``ALEMBIC_CONFIG = "/some/path/to/alembic.ini"``
+
+   Default: ``<path to bundled alembic.ini>``

--- a/docs/generate_docs.py
+++ b/docs/generate_docs.py
@@ -24,7 +24,7 @@ def create_options_section() -> str:
         for paragraph in option.description_paragraphs:
             description_lines.append(f"   {paragraph}")
 
-        description = "\n".join(description_lines)
+        description = "\n\n".join(description_lines)
 
         example = f"\n\n   Example: ``{option.example}``" if option.example else ""
         default = f"\n\n   Default: ``{option.default}``" if option.default else ""

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -18,10 +18,8 @@ document.
   export FLASK_APP=dev.development_server
   export WOCO_SERVER_NAME=127.0.0.1:5000
   export DEV_SECRET_KEY="my_secret_key"
-  export ALEMBIC_CONFIG=${PWD}/dev/alembic.ini
   export WOCO_TEST_DB=sqlite:///${PWD}/workers_control_test.db
   export WOCO_DEV_DB=sqlite:///${PWD}/workers_control_dev.db
-  export ALEMBIC_SQLALCHEMY_DATABASE_URI=${WOCO_DEV_DB}
 
 - Run ``pytest`` to run the testsuite.
 - Run ``python -m build_support.translations compile`` (only if you need translations in the development app)
@@ -120,10 +118,8 @@ Commented out variables are optional.
   export FLASK_APP=dev.development_server
   export WOCO_SERVER_NAME=127.0.0.1:5000
   export DEV_SECRET_KEY="my_secret_key"
-  export ALEMBIC_CONFIG=${PWD}/dev/alembic.ini
   export WOCO_TEST_DB=sqlite:///${PWD}/workers_control_test.db
   export WOCO_DEV_DB=sqlite:///${PWD}/workers_control_dev.db
-  export ALEMBIC_SQLALCHEMY_DATABASE_URI=${WOCO_DEV_DB}
   # export ALLOWED_OVERDRAW_MEMBER=1000
   # export DEFAULT_USER_TIMEZONE="Europe/Berlin"
   # export AUTO_MIGRATE=true
@@ -150,11 +146,9 @@ Note the following features of the development app:
   printed to ``stdout`` (your terminal). Click the confirmation
   links shown there.
 
-- The app uses the configured development database. You can
-  manually upgrade or downgrade the development database using the
-  ``alembic`` command-line tool. Run ``alembic --help`` to see the
-  options. If the environment variable ``AUTO_MIGRATE`` is set
-  to ``true``, the database will automatically
+- The app uses the configured development database. You can manually upgrade or
+  downgrade the development database. Run ``flask db --help`` to see the options. If the 
+  environment variable ``AUTO_MIGRATE`` is set to ``true``, the database will automatically
   be upgraded when the development server starts.
 
 

--- a/docs/hosting.rst
+++ b/docs/hosting.rst
@@ -51,17 +51,6 @@ Environment variables
     instead of the default locations.
 
 
-.. py:data:: ALEMBIC_CONFIG
-   :no-index:
-
-    (required)
-   
-    Path to the alembic configuration. Alembic is used to manage database migrations.
-    This file contains settings like the location of the migration scripts or the
-    database connection string. See the `alembic documentation <https://alembic.sqlalchemy.org/>`_
-    for details.
-
-
 Configuration file
 ...................
 

--- a/src/workers_control/db/migrations/alembic.ini
+++ b/src/workers_control/db/migrations/alembic.ini
@@ -1,0 +1,37 @@
+[alembic]
+script_location = workers_control.db:migrations
+path_separator=os
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/src/workers_control/db/migrations/env.py
+++ b/src/workers_control/db/migrations/env.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from logging.config import fileConfig
 
 from alembic import context
@@ -8,6 +7,12 @@ from alembic.script import ScriptDirectory
 from sqlalchemy import URL, Connection, create_engine, inspect, make_url
 
 from workers_control.db.models import Base
+
+x_args = context.get_x_argument(as_dictionary=True)
+db_url = x_args.get("db_url")
+
+if db_url:
+    context.config.set_main_option("sqlalchemy.url", db_url)
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
@@ -48,14 +53,9 @@ def upgrade_to_head_if_database_is_fresh(connection: Connection) -> None:
 
 
 def get_db_uri() -> URL:
-    if db_uri := os.getenv("ALEMBIC_SQLALCHEMY_DATABASE_URI"):
-        return make_url(db_uri)
     if db_uri := config.get_main_option("sqlalchemy.url"):
         return make_url(db_uri)
-    raise ValueError(
-        "No database URI configured. Set ALEMBIC_SQLALCHEMY_DATABASE_URI "
-        "or sqlalchemy.url in alembic.ini"
-    )
+    raise ValueError("No database URI configured. Set sqlalchemy.url in alembic.ini.")
 
 
 def run_migrations(connection: Connection) -> None:

--- a/src/workers_control/flask/__init__.py
+++ b/src/workers_control/flask/__init__.py
@@ -62,9 +62,18 @@ def create_app(
     app.template_filter("icon")(icon_filter)
 
     with app.app_context():
-        from workers_control.flask.commands import invite_accountant
+        from workers_control.flask.commands import invite_accountant, run_alembic
 
         app.cli.command("invite-accountant")(invite_accountant)
+        app.cli.command(
+            "db",
+            context_settings=dict(
+                ignore_unknown_options=True,
+                allow_extra_args=True,
+                allow_interspersed_args=False,
+            ),
+            add_help_option=False,
+        )(run_alembic)
 
         from workers_control.db.models import Accountant, Company, Member
 

--- a/src/workers_control/flask/commands.py
+++ b/src/workers_control/flask/commands.py
@@ -1,4 +1,7 @@
+import subprocess
+
 import click
+from flask import current_app
 from flask_babel import force_locale
 
 from workers_control.core.interactors.send_accountant_registration_token import (
@@ -19,3 +22,11 @@ def invite_accountant(
         interactor.send_accountant_registration_token(
             SendAccountantRegistrationTokenInteractor.Request(email=email_address)
         )
+
+
+@click.argument("args", nargs=-1)
+def run_alembic(args: tuple[str, ...]) -> None:
+    """Run the database migration tool alembic."""
+    db_url = current_app.config["SQLALCHEMY_DATABASE_URI"]
+    config = current_app.config["ALEMBIC_CONFIG"]
+    subprocess.run(["alembic", "-x", f"db_url={db_url}", "-c", config, *args])

--- a/src/workers_control/flask/config/options.py
+++ b/src/workers_control/flask/config/options.py
@@ -27,7 +27,7 @@ CONFIG_OPTIONS = [
         name="AUTO_MIGRATE",
         converts_to_types=(bool,),
         description_paragraphs=[
-            "Upgrade the database schema if changes are detected on startup. If auto migration is not activated, you need to run database migrations manually via the ``alembic`` command line tool."
+            "Upgrade the database schema if changes are detected on startup. If auto migration is not activated, you need to run database migrations manually."
         ],
         example="AUTO_MIGRATE = True",
         default="False",
@@ -155,5 +155,15 @@ CONFIG_OPTIONS = [
             "Must be an integer larger than zero.",
         ],
         default="180",
+    ),
+    ConfigOption(
+        name="ALEMBIC_CONFIG",
+        converts_to_types=(str,),
+        description_paragraphs=[
+            "Path to a custom alembic configuration file. Alembic is used to manage database migrations. See the Alembic documentation for details.",
+            "If not set, the bundled ``alembic.ini`` from the installed package is used.",
+        ],
+        example='ALEMBIC_CONFIG = "/some/path/to/alembic.ini"',
+        default="<path to bundled alembic.ini>",
     ),
 ]

--- a/src/workers_control/flask/config/production_defaults.py
+++ b/src/workers_control/flask/config/production_defaults.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 WOCO_PASSWORD_HASHER = "workers_control.flask.password_hasher:PasswordHasherImpl"
 
@@ -18,7 +19,9 @@ FLASK_PROFILER = {
     "enabled": False,
 }
 
-ALEMBIC_CONFIG = os.environ["ALEMBIC_CONFIG"]
+ALEMBIC_CONFIG = str(
+    Path(__file__).resolve().parent.parent.parent / "db" / "migrations" / "alembic.ini"
+)
 
 DEFAULT_USER_TIMEZONE = "UTC"
 ALLOWED_OVERDRAW_MEMBER = "0"

--- a/src/workers_control/flask/database.py
+++ b/src/workers_control/flask/database.py
@@ -8,13 +8,10 @@ from workers_control.db.db import Database
 
 
 def _get_alembic_config(flask_config: FlaskConfig) -> AlembicConfig:
-    path_str = flask_config.get("ALEMBIC_CONFIG")
-    if path_str is None:
-        raise ValueError("ALEMBIC_CONFIG not set in Flask config")
-    path = Path(path_str)
-    if not path.is_file():
-        raise FileNotFoundError(f"Alembic config file not found: {path}")
-    return AlembicConfig(path)
+    alembic_config = Path(flask_config["ALEMBIC_CONFIG"])
+    if not alembic_config.is_file():
+        raise FileNotFoundError(f"Alembic config file not found: {alembic_config}")
+    return AlembicConfig(alembic_config)
 
 
 def _upgrade_to_head(alembic_config: AlembicConfig) -> None:

--- a/tests/flask_integration/test_flask_db_command.py
+++ b/tests/flask_integration/test_flask_db_command.py
@@ -1,0 +1,12 @@
+from workers_control.flask.commands import run_alembic
+
+from .base_test_case import FlaskTestCase
+
+
+class FlaskDbTests(FlaskTestCase):
+    def test_can_query_migration_history_without_crashing(self) -> None:
+        run_alembic(
+            tuple(
+                "history",
+            )
+        )


### PR DESCRIPTION
In production and development environments, instead of invoking the "alembic" command for database migrations directly, developers and admins have to use the command "flask db", which is a wrapper around the "alembic" command.

This change has the benefit of simplifying the overall app configuration, as we can now access the flask configuration object when running alembic. This means that in production, the formerly obligatory environment variable ALEMBIC_CONFIG is now an optional configuration option, and a default alembic configuration file for production has been added. In development, environment variables ALEMBIC_CONFIG and ALEMBIC_SQLALCHEMY_DATABASE_URI are not needed anymore.