### PR TITLE
Add bash to nix devShell

### DIFF
--- a/dev/nix/devShell.nix
+++ b/dev/nix/devShell.nix
@@ -7,6 +7,7 @@
   includeGlibcLocales,
   lib,
   git,
+  bash,
 }:
 mkShell (
   {
@@ -25,6 +26,7 @@ mkShell (
         types-setuptools
       ])
       ++ [
+        bash
         nixfmt
         sqlite
         git


### PR DESCRIPTION
This is a workaround due to a bug with github copilot CLI and the nix development shell which can be removed as soon as the bug gets solved. The problem is described in several issues in the copilot-cli repo, e.g.: https://github.com/github/copilot-cli/issues/1428