### PR TITLE
Implement user timezone detection

### DIFF
--- a/docs/coding_guidelines.rst
+++ b/docs/coding_guidelines.rst
@@ -577,8 +577,9 @@ We work internally with the UTC timezone. To this end we use timezone-aware pyth
 datetime objects wherever possible. We convert datetime to the required timezone 
 only in the presenter layer.
 
-Currently the user timezone can only set application-wide by the server admin.
-Per-user timezones are not implemented yet.  
+The user's timezone is detected from the browser via JavaScript and stored in a
+cookie. If the cookie is not available (e.g. JavaScript is disabled), the
+``DEFAULT_USER_TIMEZONE`` configuration option is used as a fallback.
 
 
 Icons

--- a/src/workers_control/flask/datetime.py
+++ b/src/workers_control/flask/datetime.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime, tzinfo
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from flask import current_app
+from flask import current_app, request
 
 from workers_control.core.datetime_service import DatetimeService
 from workers_control.web.formatters.datetime_formatter import TimezoneConfiguration
@@ -31,9 +31,15 @@ class FlaskDatetimeFormatter:
 
 class FlaskTimezoneConfiguration:
     def get_timezone_of_current_user(self) -> tzinfo:
-        timezone = current_app.config.get("DEFAULT_USER_TIMEZONE", "UTC")
+        user_timezone = request.cookies.get("user_timezone")
+        if user_timezone:
+            try:
+                return ZoneInfo(user_timezone)
+            except (ZoneInfoNotFoundError, TypeError, KeyError):
+                pass
+        default_timezone = current_app.config.get("DEFAULT_USER_TIMEZONE", "UTC")
         try:
-            zone_info = ZoneInfo(timezone)
+            zone_info = ZoneInfo(default_timezone)
         except (ZoneInfoNotFoundError, TypeError):
             return UTC
         return zone_info

--- a/src/workers_control/flask/static/main.js
+++ b/src/workers_control/flask/static/main.js
@@ -3,6 +3,14 @@ function expandMenu() {
   element.classList.toggle("is-active");
 }
 
+// Detect browser timezone and store in cookie for server-side use
+(function() {
+  var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (tz && document.cookie.indexOf("user_timezone=" + tz) === -1) {
+    document.cookie = "user_timezone=" + tz + ";path=/;max-age=31536000;SameSite=Lax";
+  }
+})();
+
 function togglePasswordVisibility(clickedElement) {
   let input = clickedElement.parentElement.firstElementChild
   let eye = input.nextElementSibling.nextElementSibling

--- a/tests/flask_integration/test_user_account_details_view.py
+++ b/tests/flask_integration/test_user_account_details_view.py
@@ -52,6 +52,10 @@ class UserAccountDetailsViewTests(ViewTestCase):
 
 
 class DateAndTimezoneTestsBase(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = "/user/account"
+
     @property
     def configured_timezone(self) -> str | None:
         raise NotImplementedError()
@@ -76,6 +80,11 @@ class DateAndTimezoneTestsBase(ViewTestCase):
         modules.append(_Module())
         return modules
 
+    def set_cookie_for_timezone(self, timezone: str) -> None:
+        self.client.set_cookie(
+            "user_timezone", timezone, domain=self.app.config["SERVER_NAME"]
+        )
+
 
 class DateAndTimezoneTestsForTokyo(DateAndTimezoneTestsBase):
     @property
@@ -84,8 +93,8 @@ class DateAndTimezoneTestsForTokyo(DateAndTimezoneTestsBase):
 
     def test_that_current_time_is_shown_with_configured_timezone_info(self) -> None:
         self.login_user(LogInUser.member)
-        response = self.client.get("/user/account")
-        "(JST)" in response.text
+        response = self.client.get(self.url)
+        assert "(JST)" in response.text
 
 
 class DateAndTimezoneTestsForNonexistentTimezone(DateAndTimezoneTestsBase):
@@ -97,5 +106,40 @@ class DateAndTimezoneTestsForNonexistentTimezone(DateAndTimezoneTestsBase):
         self,
     ) -> None:
         self.login_user(LogInUser.member)
-        response = self.client.get("/user/account")
-        "(UTC)" in response.text
+        response = self.client.get(self.url)
+        assert "(UTC)" in response.text
+
+
+class TimezoneFromBrowserCookieTests(DateAndTimezoneTestsBase):
+    @property
+    def configured_timezone(self) -> str:
+        return "UTC"
+
+    def test_that_timezone_from_cookie_is_used_when_set(self) -> None:
+        self.login_user(LogInUser.member)
+        self.set_cookie_for_timezone("Asia/Tokyo")
+        response = self.client.get(self.url)
+        assert "(JST)" in response.text
+
+    def test_that_server_default_is_used_when_cookie_has_invalid_timezone(self) -> None:
+        self.login_user(LogInUser.member)
+        self.set_cookie_for_timezone("Invalid/Timezone")
+        response = self.client.get(self.url)
+        assert "(UTC)" in response.text
+
+    def test_that_server_default_is_used_when_no_cookie_is_set(self) -> None:
+        self.login_user(LogInUser.member)
+        response = self.client.get(self.url)
+        assert "(UTC)" in response.text
+
+
+class TimezoneFromBrowserCookieOverridesServerDefaultTests(DateAndTimezoneTestsBase):
+    @property
+    def configured_timezone(self) -> str:
+        return "Europe/Berlin"
+
+    def test_that_cookie_timezone_overrides_server_default(self) -> None:
+        self.login_user(LogInUser.member)
+        self.set_cookie_for_timezone("America/New_York")
+        response = self.client.get(self.url)
+        assert "(EST)" in response.text or "(EDT)" in response.text


### PR DESCRIPTION
- Detect user's timezone from the browser and store it in a cookie.
- Update timezone retrieval logic to use the cookie value or fallback to server default.

fixes #1286 