### PR TITLE
Implement flask layer of CreateBasicService workflow

### DIFF
--- a/src/workers_control/flask/forms.py
+++ b/src/workers_control/flask/forms.py
@@ -243,6 +243,23 @@ class CreateCooperationForm(Form):
         return self.data["definition"]
 
 
+class CreateBasicServiceForm(Form):
+    name = StringField(
+        render_kw={"placeholder": trans.lazy_gettext("Name")},
+        validators=[validators.InputRequired()],
+    )
+    description = TextAreaField(
+        render_kw={"placeholder": trans.lazy_gettext("Description")},
+        validators=[validators.InputRequired()],
+    )
+
+    def get_name_string(self) -> str:
+        return self.data["name"]
+
+    def get_description_string(self) -> str:
+        return self.data["description"]
+
+
 class RequestCooperationForm(Form):
     plan_id = StringField()
     cooperation_id = StringField()

--- a/src/workers_control/flask/routes/member/routes.py
+++ b/src/workers_control/flask/routes/member/routes.py
@@ -16,6 +16,9 @@ from workers_control.flask.views import (
     CompanyWorkInviteView,
     RegisterPrivateConsumptionView,
 )
+from workers_control.flask.views.create_basic_service_view import (
+    CreateBasicServiceView,
+)
 from workers_control.flask.views.http_error_view import http_404
 from workers_control.flask.views.list_basic_services_of_worker_view import (
     ListBasicServicesOfWorkerView,
@@ -44,6 +47,11 @@ class consumptions(QueryPrivateConsumptionsView): ...
 @MemberRoute("/basic_services")
 @as_flask_view()
 class basic_services(ListBasicServicesOfWorkerView): ...
+
+
+@MemberRoute("/create_basic_service", methods=["GET", "POST"])
+@as_flask_view()
+class create_basic_service(CreateBasicServiceView): ...
 
 
 @MemberRoute("/register_private_consumption", methods=["GET", "POST"])

--- a/src/workers_control/flask/templates/member/basic_services.html
+++ b/src/workers_control/flask/templates/member/basic_services.html
@@ -17,6 +17,9 @@
         {{ gettext("Your offered basic services are shown here.") }}<br>
       </p>
     </div>
+    <a class="button is-primary" href="{{ url_for('main_member.create_basic_service') }}">
+      {{ gettext("Create basic service") }}
+    </a>
   </div>
 
   <div class="table-container">

--- a/src/workers_control/flask/templates/member/create_basic_service.html
+++ b/src/workers_control/flask/templates/member/create_basic_service.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block navbar_start %}
+<a class="navbar-item" href="{{ url_for('main_member.basic_services') }}">{{ gettext("My basic services") }}</a>
+<div class="navbar-item">{{ gettext("Create basic service") }}</div>
+{% endblock %}
+
+{% block content %}
+<div class="section has-text-centered">
+  <h1 class="title">
+    {{ gettext("Create basic service") }}
+  </h1>
+  <div class="columns is-centered">
+    <div class="column is-three-fifths">
+      <div class="box has-background-warning-light has-text-warning-dark">
+        <div class="icon">{{ "exclamation-triangle"|icon }}</div>
+        <p>
+          {{ gettext("A note on data protection: If you create a basic service, your name and email address will be visible to other registered users of this app so they can contact you.") }}
+        </p>
+      </div>
+      <div class="content">
+        <form method="post">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <div class="field">
+            <label class="label">{{ gettext("Name") }}</label>
+            <div class="control">
+              {{ form.name(class_="input is-large") }}
+            </div>
+          </div>
+          <div class="block"></div>
+
+          <div class="field">
+            <label class="label">{{ gettext("Description") }}</label>
+            <div class="control">
+              {{ form.description(class_="textarea is-large") }}
+            </div>
+          </div>
+          <div class="block"></div>
+          <div class="field">
+            <div class="control">
+              <button class="button is-primary" type="submit">
+                {{ gettext("Create basic service") }}
+              </button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/src/workers_control/flask/views/create_basic_service_view.py
+++ b/src/workers_control/flask/views/create_basic_service_view.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+
+from flask import Response as FlaskResponse
+from flask import redirect, render_template, request, url_for
+
+from workers_control.core.interactors.create_basic_service import (
+    CreateBasicServiceInteractor,
+)
+from workers_control.db import commit_changes
+from workers_control.flask.forms import CreateBasicServiceForm
+from workers_control.flask.types import Response
+from workers_control.web.www.controllers.create_basic_service_controller import (
+    CreateBasicServiceController,
+    InvalidRequest,
+)
+from workers_control.web.www.presenters.create_basic_service_presenter import (
+    CreateBasicServicePresenter,
+)
+
+
+@dataclass
+class CreateBasicServiceView:
+    interactor: CreateBasicServiceInteractor
+    presenter: CreateBasicServicePresenter
+    controller: CreateBasicServiceController
+
+    def GET(self) -> Response:
+        return FlaskResponse(
+            self._render_template(CreateBasicServiceForm()), status=200
+        )
+
+    @commit_changes
+    def POST(self) -> Response:
+        form = CreateBasicServiceForm(request.form)
+        if not form.validate():
+            return FlaskResponse(self._render_template(form), status=400)
+        match self.controller.import_form_data(form):
+            case InvalidRequest(status_code=status_code):
+                return FlaskResponse(self._render_template(form), status=status_code)
+            case interactor_request:
+                pass
+        interactor_response = self.interactor.execute(interactor_request)
+        self.presenter.present(interactor_response)
+        if interactor_response.is_rejected:
+            return FlaskResponse(self._render_template(form), status=400)
+        return redirect(url_for("main_member.basic_services"))
+
+    def _render_template(self, form: CreateBasicServiceForm) -> str:
+        return render_template("member/create_basic_service.html", form=form)

--- a/src/workers_control/web/www/controllers/create_basic_service_controller.py
+++ b/src/workers_control/web/www/controllers/create_basic_service_controller.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+from workers_control.core.interactors.create_basic_service import (
+    CreateBasicServiceRequest,
+)
+from workers_control.web.session import Session
+
+
+class CreateBasicServiceForm(Protocol):
+    def get_name_string(self) -> str: ...
+
+    def get_description_string(self) -> str: ...
+
+
+@dataclass
+class InvalidRequest:
+    status_code: int
+
+
+@dataclass
+class CreateBasicServiceController:
+    session: Session
+
+    def import_form_data(
+        self, form: CreateBasicServiceForm
+    ) -> CreateBasicServiceRequest | InvalidRequest:
+        user_id = self.session.get_current_user()
+        if not user_id:
+            return InvalidRequest(status_code=401)
+        return CreateBasicServiceRequest(
+            member_id=user_id,
+            name=form.get_name_string(),
+            description=form.get_description_string(),
+        )

--- a/tests/flask_integration/test_create_basic_service_view.py
+++ b/tests/flask_integration/test_create_basic_service_view.py
@@ -1,0 +1,126 @@
+from typing import Optional
+
+from parameterized import parameterized
+
+from tests.flask_integration.base_test_case import LogInUser, ViewTestCase
+
+
+class UserAccessGetTests(ViewTestCase):
+    URL = "/member/create_basic_service"
+
+    @parameterized.expand(
+        [
+            (LogInUser.member, 200),
+        ]
+    )
+    def test_get_expected_code_for_logged_in_users(
+        self, login: Optional[LogInUser], expected_code: int
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=self.URL,
+            method="get",
+            login=login,
+            expected_code=expected_code,
+        )
+
+    @parameterized.expand(
+        [
+            (LogInUser.company,),
+            (LogInUser.accountant,),
+        ]
+    )
+    def test_non_member_users_get_redirected(self, login: LogInUser) -> None:
+        self.assert_response_has_expected_code(
+            url=self.URL,
+            method="get",
+            login=login,
+            expected_code=302,
+        )
+
+    def test_anonymous_user_gets_redirected(self) -> None:
+        self.assert_response_has_expected_code(
+            url=self.URL,
+            method="get",
+            login=None,
+            expected_code=302,
+        )
+
+
+class UserAccessPostTests(ViewTestCase):
+    URL = "/member/create_basic_service"
+
+    @parameterized.expand(
+        [
+            (LogInUser.company,),
+            (LogInUser.accountant,),
+        ]
+    )
+    def test_non_member_users_get_redirected(self, login: LogInUser) -> None:
+        self.assert_response_has_expected_code(
+            url=self.URL,
+            method="post",
+            login=login,
+            expected_code=302,
+        )
+
+    def test_anonymous_user_gets_redirected(self) -> None:
+        self.assert_response_has_expected_code(
+            url=self.URL,
+            method="post",
+            login=None,
+            expected_code=302,
+        )
+
+
+class AuthenticatedMemberGetTests(ViewTestCase):
+    URL = "/member/create_basic_service"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_member()
+
+    def test_get_returns_200(self) -> None:
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, 200)
+
+    def test_data_protection_warning_is_shown(self) -> None:
+        response = self.client.get(self.URL)
+        self.assertIn("data protection", response.text)
+
+
+class AuthenticatedMemberPostTests(ViewTestCase):
+    URL = "/member/create_basic_service"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_member()
+
+    def test_post_with_valid_data_redirects(self) -> None:
+        response = self.client.post(
+            self.URL,
+            data=dict(name="Test Service", description="A test description"),
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_post_with_valid_data_redirects_to_basic_services_list(self) -> None:
+        response = self.client.post(
+            self.URL,
+            data=dict(name="Test Service", description="A test description"),
+        )
+        assert response.location
+        self.assertIn("/member/basic_services", response.location)
+
+    def test_post_with_valid_data_creates_basic_service(self) -> None:
+        member_id = self.login_member()
+        self.client.post(
+            self.URL,
+            data=dict(name="My Service", description="My description"),
+        )
+        services = list(
+            self.database_gateway.get_basic_services().of_provider(member_id)
+        )
+        self.assertEqual(len(services), 1)
+
+    def test_post_with_empty_data_returns_400(self) -> None:
+        response = self.client.post(self.URL, data={})
+        self.assertEqual(response.status_code, 400)

--- a/tests/web/www/controllers/test_create_basic_service_controller.py
+++ b/tests/web/www/controllers/test_create_basic_service_controller.py
@@ -1,0 +1,61 @@
+from uuid import uuid4
+
+from tests.web.base_test_case import BaseTestCase
+from workers_control.core.interactors.create_basic_service import (
+    CreateBasicServiceRequest,
+)
+from workers_control.web.www.controllers.create_basic_service_controller import (
+    CreateBasicServiceController,
+    InvalidRequest,
+)
+
+
+class FakeForm:
+    def __init__(self, name: str = "test", description: str = "test desc") -> None:
+        self._name = name
+        self._description = description
+
+    def get_name_string(self) -> str:
+        return self._name
+
+    def get_description_string(self) -> str:
+        return self._description
+
+
+class ControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(CreateBasicServiceController)
+
+    def test_anonymous_user_receives_401(self) -> None:
+        self.session.logout()
+        result = self.controller.import_form_data(FakeForm())
+        assert isinstance(result, InvalidRequest)
+        assert result.status_code == 401
+
+    def test_logged_in_member_gets_interactor_request(self) -> None:
+        member_id = uuid4()
+        self.session.login_member(member_id)
+        result = self.controller.import_form_data(FakeForm())
+        assert isinstance(result, CreateBasicServiceRequest)
+
+    def test_interactor_request_contains_member_id(self) -> None:
+        member_id = uuid4()
+        self.session.login_member(member_id)
+        result = self.controller.import_form_data(FakeForm())
+        assert isinstance(result, CreateBasicServiceRequest)
+        assert result.member_id == member_id
+
+    def test_interactor_request_contains_form_name(self) -> None:
+        self.session.login_member(uuid4())
+        result = self.controller.import_form_data(FakeForm(name="My Service"))
+        assert isinstance(result, CreateBasicServiceRequest)
+        assert result.name == "My Service"
+
+    def test_interactor_request_contains_form_description(self) -> None:
+        self.session.login_member(uuid4())
+        result = self.controller.import_form_data(
+            FakeForm(description="Service description")
+        )
+        assert isinstance(result, CreateBasicServiceRequest)
+        assert result.description == "Service description"


### PR DESCRIPTION
Add the flask layer (view, form, template and route) for creating basic services. Members can now create basic services through a form that includes a data protection warning about name/email visibility. After creation, users are redirected to their basic services list.

Create missing controller in the web layer (CreateBasicServiceController).

fixes #1422 