### PR TITLE
Use a trap in nix checkPhase to kill PostgreSQL on exit

### DIFF
--- a/dev/nix/pythonPackages/workers-control.nix
+++ b/dev/nix/pythonPackages/workers-control.nix
@@ -74,11 +74,10 @@ buildPythonPackage {
     initdb -D $POSTGRES_DIR
     postgres -h "" -k $POSTGRES_DIR -D $POSTGRES_DIR &
     POSTGRES_PID=$!
+    trap "kill $POSTGRES_PID" EXIT
     until createdb -h $POSTGRES_DIR; do echo "Retry createdb"; done
 
     WOCO_TEST_DB="postgresql:///?host=$POSTGRES_DIR" pytest -x
-
-    kill $POSTGRES_PID
 
     runHook postCheck
   '';


### PR DESCRIPTION
Before this change nix flake checks would sometimes hang on failure.