### PR TITLE
Add plan preview to member private consumption form

### DIFF
--- a/src/workers_control/core/interactors/select_private_consumption.py
+++ b/src/workers_control/core/interactors/select_private_consumption.py
@@ -1,0 +1,57 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from workers_control.core.datetime_service import DatetimeService
+from workers_control.core.repositories import DatabaseGateway
+
+
+@dataclass
+class Request:
+    plan_id: UUID | None
+    amount: int | None
+
+
+@dataclass
+class NoPlanResponse:
+    amount: int | None
+
+
+@dataclass
+class InvalidPlanResponse:
+    amount: int | None
+
+
+@dataclass
+class ValidPlanResponse:
+    plan_id: UUID
+    amount: int | None
+    plan_name: str
+    plan_description: str
+
+
+@dataclass
+class SelectPrivateConsumptionInteractor:
+    database: DatabaseGateway
+    datetime_service: DatetimeService
+
+    def select_private_consumption(
+        self, request: Request
+    ) -> NoPlanResponse | InvalidPlanResponse | ValidPlanResponse:
+        amount = request.amount
+        if not request.plan_id:
+            return NoPlanResponse(amount=amount)
+        plan_result = (
+            self.database.get_plans()
+            .with_id(request.plan_id)
+            .that_will_expire_after(self.datetime_service.now())
+        )
+        if not plan_result:
+            return InvalidPlanResponse(amount=amount)
+        plan = plan_result.first()
+        assert plan
+        return ValidPlanResponse(
+            plan_id=request.plan_id,
+            amount=amount,
+            plan_name=plan.prd_name,
+            plan_description=plan.description,
+        )

--- a/src/workers_control/flask/templates/member/register_private_consumption.html
+++ b/src/workers_control/flask/templates/member/register_private_consumption.html
@@ -33,6 +33,7 @@
                             placeholder="{{ gettext('Plan ID') }}"
                             type="text"
                             value="{{ form.plan_id_value }}"
+                            {% if view_model and view_model.valid_plan_selected %}readonly{% endif %}
                             required
                             >
                         </div>
@@ -44,6 +45,19 @@
                         </ul>
                         {% endif %}
                     </div>
+                    {% if view_model and view_model.valid_plan_selected %}
+                    <div class="notification is-info">
+                        <p>
+                            {{ gettext("Plan ID") }}: {{ view_model.plan_id }}
+                        </p>
+                        <p>
+                            {{ gettext("Plan name") }}: {{ view_model.plan_name }}
+                        </p>
+                        <p>
+                            {{ gettext("Plan description") }}: {{ view_model.plan_description }}
+                        </p>
+                    </div>
+                    {% endif %}
                     <div class="field">
                         <label class="label">{{ gettext("Amount") }}</label>
                         <div class="control">
@@ -68,6 +82,9 @@
                     <div class="field">
                         <div class="control">
                             <button class="button is-primary" type="submit">{{ gettext("Register") }}</button>
+                            {% if view_model and view_model.valid_plan_selected %}
+                            <a class="button is-light" href="{{ url_for('main_member.register_private_consumption') }}">{{ gettext("Cancel") }}</a>
+                            {% endif %}
                         </div>
                     </div>
                 </form>

--- a/src/workers_control/flask/views/register_private_consumption.py
+++ b/src/workers_control/flask/views/register_private_consumption.py
@@ -1,11 +1,14 @@
 from dataclasses import dataclass
 
 from flask import Response as FlaskResponse
-from flask import redirect, render_template, request
+from flask import redirect, render_template
 
 from workers_control.core.interactors.register_private_consumption import (
     RegisterPrivateConsumption,
     RegisterPrivateConsumptionRequest,
+)
+from workers_control.core.interactors.select_private_consumption import (
+    SelectPrivateConsumptionInteractor,
 )
 from workers_control.db import commit_changes
 from workers_control.flask.flask_request import FlaskRequest
@@ -16,9 +19,15 @@ from workers_control.web.www.controllers.register_private_consumption_controller
     FormError,
     RegisterPrivateConsumptionController,
 )
+from workers_control.web.www.controllers.select_private_consumption_controller import (
+    SelectPrivateConsumptionController,
+)
 from workers_control.web.www.presenters.register_private_consumption_presenter import (
     RegisterPrivateConsumptionPresenter,
     RenderForm,
+)
+from workers_control.web.www.presenters.select_private_consumption_presenter import (
+    SelectPrivateConsumptionPresenter,
 )
 from workers_control.web.www.response import Redirect
 
@@ -29,13 +38,44 @@ class RegisterPrivateConsumptionView:
     register_private_consumption: RegisterPrivateConsumption
     controller: RegisterPrivateConsumptionController
     presenter: RegisterPrivateConsumptionPresenter
+    select_private_consumption_controller: SelectPrivateConsumptionController
+    select_private_consumption_interactor: SelectPrivateConsumptionInteractor
+    select_private_consumption_presenter: SelectPrivateConsumptionPresenter
 
     def GET(self) -> Response:
-        form = RegisterPrivateConsumptionForm(
-            amount_value=request.args.get("amount") or "",
-            plan_id_value=request.args.get("plan_id") or "",
+        try:
+            interactor_request = (
+                self.select_private_consumption_controller.process_input_data(
+                    FlaskRequest()
+                )
+            )
+        except self.select_private_consumption_controller.InputDataError:
+            return FlaskResponse(
+                self._render_template(
+                    form=RegisterPrivateConsumptionForm(
+                        plan_id_value="", amount_value=""
+                    )
+                ),
+                status=400,
+            )
+        interactor_response = (
+            self.select_private_consumption_interactor.select_private_consumption(
+                interactor_request
+            )
         )
-        return FlaskResponse(self._render_template(form=form))
+        view_model = self.select_private_consumption_presenter.render_response(
+            interactor_response
+        )
+        form = RegisterPrivateConsumptionForm(
+            plan_id_value=view_model.plan_id or "",
+            amount_value=(
+                str(view_model.amount) if view_model.amount is not None else ""
+            ),
+        )
+        return FlaskResponse(
+            self._render_template(form=form, view_model=view_model),
+            status=view_model.status_code,
+        )
 
     @commit_changes
     def POST(self) -> Response:
@@ -55,11 +95,17 @@ class RegisterPrivateConsumptionView:
                 return redirect(url)
             case RenderForm(status_code=status_code, form=form):
                 return FlaskResponse(
-                    render_template(
-                        "member/register_private_consumption.html", form=form
-                    ),
+                    self._render_template(form=form),
                     status=status_code,
                 )
 
-    def _render_template(self, form: RegisterPrivateConsumptionForm) -> str:
-        return render_template("member/register_private_consumption.html", form=form)
+    def _render_template(
+        self,
+        form: RegisterPrivateConsumptionForm,
+        view_model: SelectPrivateConsumptionPresenter.ViewModel | None = None,
+    ) -> str:
+        return render_template(
+            "member/register_private_consumption.html",
+            form=form,
+            view_model=view_model,
+        )

--- a/src/workers_control/web/www/controllers/select_private_consumption_controller.py
+++ b/src/workers_control/web/www/controllers/select_private_consumption_controller.py
@@ -1,0 +1,63 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from workers_control.core.interactors.select_private_consumption import (
+    Request as InteractorRequest,
+)
+from workers_control.web.notification import Notifier
+from workers_control.web.request import Request
+from workers_control.web.translator import Translator
+
+
+@dataclass
+class SelectPrivateConsumptionController:
+    class InputDataError(Exception):
+        pass
+
+    notifier: Notifier
+    translator: Translator
+
+    def process_input_data(self, request: Request) -> InteractorRequest:
+        plan_id = self._process_plan_id(request)
+        amount = self._process_amount(request)
+        return InteractorRequest(plan_id=plan_id, amount=amount)
+
+    def _process_plan_id(self, request: Request) -> UUID | None:
+        plan_id_from_query_string = request.query_string().get_last_value("plan_id")
+        plan_id_from_form = request.get_form("plan_id")
+        if not plan_id_from_query_string and not plan_id_from_form:
+            return None
+        elif plan_id_from_query_string:
+            return self._convert_string_to_uuid(plan_id_from_query_string)
+        else:
+            assert plan_id_from_form
+            return self._convert_string_to_uuid(plan_id_from_form)
+
+    def _convert_string_to_uuid(self, input_string: str) -> UUID:
+        try:
+            return UUID(input_string)
+        except ValueError:
+            self.notifier.display_warning(
+                self.translator.gettext("The provided plan ID is not a valid UUID.")
+            )
+            raise self.InputDataError()
+
+    def _process_amount(self, request: Request) -> int | None:
+        amount_from_query_string = request.query_string().get_last_value("amount")
+        amount_from_form = request.get_form("amount")
+        if not amount_from_query_string and not amount_from_form:
+            return None
+        elif amount_from_query_string:
+            return self._convert_string_to_int(amount_from_query_string)
+        else:
+            assert amount_from_form
+            return self._convert_string_to_int(amount_from_form)
+
+    def _convert_string_to_int(self, input_string: str) -> int:
+        try:
+            return int(input_string)
+        except ValueError:
+            self.notifier.display_warning(
+                self.translator.gettext("The provided amount is not a valid integer.")
+            )
+            raise self.InputDataError()

--- a/src/workers_control/web/www/presenters/select_private_consumption_presenter.py
+++ b/src/workers_control/web/www/presenters/select_private_consumption_presenter.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+from workers_control.core.interactors.select_private_consumption import (
+    InvalidPlanResponse,
+    NoPlanResponse,
+    ValidPlanResponse,
+)
+from workers_control.web.notification import Notifier
+from workers_control.web.translator import Translator
+
+
+@dataclass
+class SelectPrivateConsumptionPresenter:
+    notifier: Notifier
+    translator: Translator
+
+    @dataclass
+    class ViewModel:
+        valid_plan_selected: bool
+        plan_id: str | None
+        plan_name: str | None
+        plan_description: str | None
+        amount: int | None
+        status_code: int
+
+    def render_response(
+        self, response: NoPlanResponse | InvalidPlanResponse | ValidPlanResponse
+    ) -> ViewModel:
+        if isinstance(response, NoPlanResponse):
+            return self.ViewModel(
+                valid_plan_selected=False,
+                plan_id=None,
+                plan_name=None,
+                plan_description=None,
+                amount=response.amount,
+                status_code=200,
+            )
+        if isinstance(response, InvalidPlanResponse):
+            self.notifier.display_warning(
+                self.translator.gettext(
+                    "The selected plan does not exist or is not active anymore."
+                )
+            )
+            return self.ViewModel(
+                valid_plan_selected=False,
+                plan_id=None,
+                plan_name=None,
+                plan_description=None,
+                amount=response.amount,
+                status_code=404,
+            )
+        assert isinstance(response, ValidPlanResponse)
+        return self.ViewModel(
+            valid_plan_selected=True,
+            plan_id=str(response.plan_id),
+            plan_name=response.plan_name,
+            plan_description=response.plan_description,
+            amount=response.amount,
+            status_code=200,
+        )

--- a/tests/flask_integration/test_register_private_consumption_view.py
+++ b/tests/flask_integration/test_register_private_consumption_view.py
@@ -14,6 +14,41 @@ class AuthenticatedMemberTests(ViewTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
+    def test_get_with_invalid_plan_id_returns_error_status(self) -> None:
+        response = self.client.get(f"{self.url}?plan_id=not_a_valid_uuid")
+        assert response.status_code >= 400
+
+    def test_get_with_unknown_plan_id_returns_404(self) -> None:
+        response = self.client.get(f"{self.url}?plan_id={uuid4()}")
+        self.assertEqual(response.status_code, 404)
+
+    def test_get_without_plan_id_does_not_render_readonly_plan_id_field(self) -> None:
+        response = self.client.get(self.url)
+        assert "readonly" not in response.text
+
+    def test_get_with_valid_plan_id_renders_plan_summary_in_html(self) -> None:
+        expected_plan_name = "Plan name 1234"
+        expected_plan_description = "Plan description 1234"
+        plan = self.plan_generator.create_plan(
+            product_name=expected_plan_name,
+            description=expected_plan_description,
+        )
+        response = self.client.get(f"{self.url}?plan_id={plan}")
+        self.assertEqual(response.status_code, 200)
+        assert str(plan) in response.text
+        assert expected_plan_name in response.text
+        assert expected_plan_description in response.text
+
+    def test_get_with_valid_plan_id_renders_readonly_plan_id_field(self) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.get(f"{self.url}?plan_id={plan}")
+        assert "readonly" in response.text
+
+    def test_get_with_valid_plan_id_renders_cancel_button(self) -> None:
+        plan = self.plan_generator.create_plan()
+        response = self.client.get(f"{self.url}?plan_id={plan}")
+        assert ">Cancel</a>" in response.text
+
     def test_posting_without_data_results_in_400(self) -> None:
         response = self.client.post(self.url)
         self.assertEqual(response.status_code, 400)

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -241,8 +241,9 @@ class GeneralUrlIndexTests(ViewTestCase):
         self,
     ) -> None:
         self.login_member()
+        plan = self.plan_generator.create_plan()
         url = self.url_index.get_register_private_consumption_url(
-            amount=1, plan_id=uuid4()
+            amount=1, plan_id=plan
         )
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/tests/interactors/test_select_private_consumption.py
+++ b/tests/interactors/test_select_private_consumption.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from tests.interactors.base_test_case import BaseTestCase
+from workers_control.core.interactors import select_private_consumption
+
+
+class InteractorTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.interactor = self.injector.get(
+            select_private_consumption.SelectPrivateConsumptionInteractor
+        )
+
+    def test_that_no_plan_response_is_returned_when_no_plan_id_is_provided(self):
+        request = self.create_request()
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.NoPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_does_not_exist(
+        self,
+    ):
+        request = self.create_request(plan_id=uuid4())
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.InvalidPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_is_not_approved(
+        self,
+    ):
+        plan = self.plan_generator.create_plan(approved=False)
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.InvalidPlanResponse)
+
+    def test_that_invalid_plan_response_is_returned_when_plan_id_is_provided_but_plan_is_expired(
+        self,
+    ):
+        self.datetime_service.freeze_time()
+        plan = self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.advance_time(timedelta(days=2))
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.InvalidPlanResponse)
+
+    def test_that_valid_plan_response_is_returned_when_plan_id_is_provided_and_plan_exists(
+        self,
+    ):
+        plan = self.plan_generator.create_plan()
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.ValidPlanResponse)
+
+    @parameterized.expand([(None,), (0,), (1,), (2,)])
+    def test_that_amount_from_request_is_passed_to_response(self, amount: int | None):
+        request = self.create_request(amount=amount)
+        response = self.interactor.select_private_consumption(request)
+        assert response.amount == amount
+
+    def test_that_plan_id_of_valid_plan_response_is_the_same_as_the_provided_plan_id(
+        self,
+    ):
+        plan = self.plan_generator.create_plan()
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert response.plan_id == plan
+
+    @parameterized.expand([("Plan Name 1",), ("Plan Name 2",)])
+    def test_that_plan_name_of_valid_plan_response_is_the_same_as_the_provided_plan_name(
+        self, plan_name: str
+    ):
+        plan = self.plan_generator.create_plan(product_name=plan_name)
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.ValidPlanResponse)
+        assert response.plan_name == plan_name
+
+    @parameterized.expand([("Plan Description 1",), ("Plan Description 2",)])
+    def test_that_plan_description_of_valid_plan_response_is_the_same_as_the_provided_plan_description(
+        self, plan_description: str
+    ):
+        plan = self.plan_generator.create_plan(description=plan_description)
+        request = self.create_request(plan_id=plan)
+        response = self.interactor.select_private_consumption(request)
+        assert isinstance(response, select_private_consumption.ValidPlanResponse)
+        assert response.plan_description == plan_description
+
+    def create_request(
+        self,
+        plan_id: UUID | None = None,
+        amount: int | None = None,
+    ) -> select_private_consumption.Request:
+        return select_private_consumption.Request(plan_id=plan_id, amount=amount)

--- a/tests/web/www/controllers/test_select_private_consumption_controller.py
+++ b/tests/web/www/controllers/test_select_private_consumption_controller.py
@@ -1,0 +1,81 @@
+from uuid import uuid4
+
+from tests.web.base_test_case import BaseTestCase
+from tests.web.www.request import FakeRequest
+from workers_control.web.www.controllers.select_private_consumption_controller import (
+    SelectPrivateConsumptionController,
+)
+
+
+class SelectPrivateConsumptionControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(SelectPrivateConsumptionController)
+
+    def test_that_none_is_returned_when_no_plan_id_is_provided(self) -> None:
+        request = FakeRequest()
+        response = self.controller.process_input_data(request=request)
+        assert response.plan_id is None
+
+    def test_that_input_error_is_raised_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        request = FakeRequest()
+        request.set_arg("plan_id", "not_a_valid_uuid")
+        with self.assertRaises(SelectPrivateConsumptionController.InputDataError):
+            self.controller.process_input_data(request=request)
+
+    def test_that_a_warning_is_displayed_when_plan_id_is_not_a_valid_uuid(self) -> None:
+        request = FakeRequest()
+        assert not self.notifier.warnings
+        request.set_arg("plan_id", "not_a_valid_uuid")
+        with self.assertRaises(SelectPrivateConsumptionController.InputDataError):
+            self.controller.process_input_data(request=request)
+        assert self.notifier.warnings
+
+    def test_that_plan_id_from_url_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
+        plan_id = uuid4()
+        request.set_arg("plan_id", str(plan_id))
+        response = self.controller.process_input_data(request=request)
+        assert response.plan_id == plan_id
+
+    def test_that_plan_id_from_form_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
+        plan_id = uuid4()
+        request.set_form("plan_id", str(plan_id))
+        response = self.controller.process_input_data(request=request)
+        assert response.plan_id == plan_id
+
+    def test_that_none_is_returned_when_no_amount_is_provided(self) -> None:
+        request = FakeRequest()
+        response = self.controller.process_input_data(request=request)
+        assert response.amount is None
+
+    def test_that_input_error_is_raised_when_amount_is_not_a_valid_number(self) -> None:
+        request = FakeRequest()
+        request.set_arg("amount", "not_a_valid_number")
+        with self.assertRaises(SelectPrivateConsumptionController.InputDataError):
+            self.controller.process_input_data(request=request)
+
+    def test_that_a_warning_is_displayed_when_amount_is_not_a_valid_number(
+        self,
+    ) -> None:
+        request = FakeRequest()
+        assert not self.notifier.warnings
+        request.set_arg("amount", "not_a_valid_number")
+        with self.assertRaises(SelectPrivateConsumptionController.InputDataError):
+            self.controller.process_input_data(request=request)
+        assert self.notifier.warnings
+
+    def test_that_amount_from_url_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
+        amount = 10
+        request.set_arg("amount", str(amount))
+        response = self.controller.process_input_data(request=request)
+        assert response.amount == amount
+
+    def test_that_amount_from_form_gets_passed_to_response_object(self) -> None:
+        request = FakeRequest()
+        amount = 10
+        request.set_form("amount", str(amount))
+        response = self.controller.process_input_data(request=request)
+        assert response.amount == amount

--- a/tests/web/www/presenters/test_select_private_consumption_presenter.py
+++ b/tests/web/www/presenters/test_select_private_consumption_presenter.py
@@ -1,0 +1,75 @@
+from uuid import UUID, uuid4
+
+from parameterized import parameterized
+
+from tests.web.base_test_case import BaseTestCase
+from workers_control.core.interactors import select_private_consumption
+from workers_control.web.www.presenters.select_private_consumption_presenter import (
+    SelectPrivateConsumptionPresenter,
+)
+
+
+class PresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(SelectPrivateConsumptionPresenter)
+
+    @parameterized.expand([(None,), (5,), (10,)])
+    def test_that_no_plan_response_gets_rendered_correctly(
+        self, amount: int | None
+    ) -> None:
+        response = select_private_consumption.NoPlanResponse(amount=amount)
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is False
+        assert view_model.plan_id is None
+        assert view_model.plan_name is None
+        assert view_model.plan_description is None
+        assert view_model.amount == amount
+        assert view_model.status_code == 200
+
+    def test_that_warning_is_displayed_when_plan_is_invalid(self) -> None:
+        assert not self.notifier.warnings
+        response = select_private_consumption.InvalidPlanResponse(amount=5)
+        self.presenter.render_response(response)
+        assert self.notifier.warnings
+
+    @parameterized.expand([(None,), (5,), (10,)])
+    def test_that_invalid_plan_response_gets_rendered_correctly(
+        self, amount: int | None
+    ) -> None:
+        response = select_private_consumption.InvalidPlanResponse(amount=amount)
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is False
+        assert view_model.plan_id is None
+        assert view_model.plan_name is None
+        assert view_model.plan_description is None
+        assert view_model.amount == amount
+        assert view_model.status_code == 404
+
+    @parameterized.expand(
+        [
+            (uuid4(), 5, "Plan Name", "Plan Description"),
+            (uuid4(), 10, "Plan Name", "Plan Description"),
+            (uuid4(), None, "Plan Name", "Plan Description"),
+        ]
+    )
+    def test_that_valid_plan_response_gets_rendered_correctly(
+        self,
+        plan_id: UUID,
+        amount: int | None,
+        plan_name: str,
+        plan_description: str,
+    ) -> None:
+        response = select_private_consumption.ValidPlanResponse(
+            plan_id=plan_id,
+            amount=amount,
+            plan_name=plan_name,
+            plan_description=plan_description,
+        )
+        view_model = self.presenter.render_response(response)
+        assert view_model.valid_plan_selected is True
+        assert view_model.plan_id == str(plan_id)
+        assert view_model.plan_name == plan_name
+        assert view_model.plan_description == plan_description
+        assert view_model.amount == amount
+        assert view_model.status_code == 200


### PR DESCRIPTION
When navigating to the consumption registration form from a plan details page, members now see a read-only plan ID and a summary of the selected plan, mirroring the existing company flow.