### PR TITLE
Add consumption link to plan list

### DIFF
--- a/src/workers_control/flask/templates/user/query_plans.html
+++ b/src/workers_control/flask/templates/user/query_plans.html
@@ -80,12 +80,24 @@
                         {% if column.is_expired %}
                         <span class="tag is-danger">{{ gettext("Expired") }}</span>
                         {% endif %}
+                        {% if column.is_own_plan %}
+                        <span class="tag is-info">{{ gettext("Our plan") }}</span>
+                        {% endif %}
                     </div>
                 </div>
                 <div class="media-right">
                     <p class="is-size-5">
                         {{ column.price_per_unit }}
                     </p>
+                </div>
+                <div class="media-right">
+                    {% if column.show_consumption_icon %}
+                        {% if column.is_consumption_disabled %}
+                        <span class="has-text-grey-light">{{ "basket-shopping"|icon }}</span>
+                        {% else %}
+                        <a href="{{ column.consumption_url }}">{{ "basket-shopping"|icon }}</a>
+                        {% endif %}
+                    {% endif %}
                 </div>
             </article>
             {% endfor %}

--- a/src/workers_control/web/www/presenters/query_plans_presenter.py
+++ b/src/workers_control/web/www/presenters/query_plans_presenter.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
 
-from workers_control.core.interactors.query_plans import PlanQueryResponse
+from workers_control.core.interactors.query_plans import PlanQueryResponse, QueriedPlan
 from workers_control.web.notification import Notifier
 from workers_control.web.pagination import Pagination, Paginator
 from workers_control.web.request import Request
+from workers_control.web.session import Session, UserRole
 from workers_control.web.translator import Translator
 from workers_control.web.url_index import UrlIndex, UserUrlIndex
 
@@ -19,6 +22,10 @@ class ResultTableRow:
     is_public_service: bool
     is_cooperating: bool
     is_expired: bool
+    is_own_plan: bool
+    show_consumption_icon: bool
+    is_consumption_disabled: bool
+    consumption_url: str
 
 
 @dataclass
@@ -41,30 +48,19 @@ class QueryPlansPresenter:
     user_notifier: Notifier
     translator: Translator
     request: Request
+    session: Session
 
     def present(self, response: PlanQueryResponse) -> QueryPlansViewModel:
         if not response.results:
             self.user_notifier.display_warning(self.translator.gettext("No results."))
+        user_role = self.session.get_user_role()
+        current_user = self.session.get_current_user()
         return QueryPlansViewModel(
             total_results=response.total_results,
             show_results=bool(response.results),
             results=ResultsTable(
                 rows=[
-                    ResultTableRow(
-                        plan_details_url=self.user_url_index.get_plan_details_url(
-                            result.plan_id
-                        ),
-                        company_summary_url=self.url_index.get_company_summary_url(
-                            company_id=result.company_id,
-                        ),
-                        company_name=result.company_name,
-                        product_name=result.product_name,
-                        description="".join(result.description.splitlines())[:150],
-                        price_per_unit=str(round(result.price_per_unit, 2)),
-                        is_public_service=result.is_public_service,
-                        is_cooperating=result.is_cooperating,
-                        is_expired=result.is_expired,
-                    )
+                    self._build_row(result, user_role, current_user)
                     for result in response.results
                 ],
             ),
@@ -77,6 +73,44 @@ class QueryPlansPresenter:
             results=ResultsTable(rows=[]),
             show_results=False,
             pagination=Pagination(is_visible=False, pages=[]),
+        )
+
+    def _build_row(
+        self,
+        result: QueriedPlan,
+        user_role: Optional[UserRole],
+        current_user: Optional[UUID],
+    ) -> ResultTableRow:
+        is_own_plan = (
+            user_role == UserRole.company and current_user == result.company_id
+        )
+        show_consumption_icon = user_role in (UserRole.member, UserRole.company)
+        if user_role == UserRole.member:
+            consumption_url = self.url_index.get_register_private_consumption_url(
+                plan_id=result.plan_id
+            )
+        elif user_role == UserRole.company:
+            consumption_url = self.url_index.get_register_productive_consumption_url(
+                plan_id=result.plan_id
+            )
+        else:
+            consumption_url = ""
+        return ResultTableRow(
+            plan_details_url=self.user_url_index.get_plan_details_url(result.plan_id),
+            company_summary_url=self.url_index.get_company_summary_url(
+                company_id=result.company_id,
+            ),
+            company_name=result.company_name,
+            product_name=result.product_name,
+            description="".join(result.description.splitlines())[:150],
+            price_per_unit=str(round(result.price_per_unit, 2)),
+            is_public_service=result.is_public_service,
+            is_cooperating=result.is_cooperating,
+            is_expired=result.is_expired,
+            is_own_plan=is_own_plan,
+            show_consumption_icon=show_consumption_icon,
+            is_consumption_disabled=result.is_expired or is_own_plan,
+            consumption_url=consumption_url,
         )
 
     def _create_pagination(self, response: PlanQueryResponse) -> Pagination:

--- a/tests/web/www/presenters/test_query_plans_presenter.py
+++ b/tests/web/www/presenters/test_query_plans_presenter.py
@@ -287,3 +287,145 @@ class QueryPlansPresenterTests(BaseTestCase):
         first_domain = urlparse(first).netloc
         second_domain = urlparse(second).netloc
         assert first_domain == second_domain
+
+
+class MyPlanFlagTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(QueryPlansPresenter)
+        self.queried_plan_generator = QueriedPlanGenerator()
+
+    def test_is_own_plan_true_when_logged_in_company_matches_planner(self) -> None:
+        company_id = uuid4()
+        self.session.login_company(company_id)
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(company_id=company_id)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertTrue(presentation.results.rows[0].is_own_plan)
+
+    def test_is_own_plan_false_when_logged_in_company_is_not_the_planner(self) -> None:
+        self.session.login_company(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(company_id=uuid4())]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].is_own_plan)
+
+    def test_is_own_plan_false_when_user_is_a_member(self) -> None:
+        member_id = uuid4()
+        self.session.login_member(member_id)
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(company_id=member_id)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].is_own_plan)
+
+    def test_is_own_plan_false_when_user_is_an_accountant(self) -> None:
+        accountant_id = uuid4()
+        self.session.login_accountant(accountant_id)
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(company_id=accountant_id)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].is_own_plan)
+
+
+class ConsumptionIconTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(QueryPlansPresenter)
+        self.queried_plan_generator = QueriedPlanGenerator()
+
+    def test_icon_is_shown_to_members(self) -> None:
+        self.session.login_member(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan()]
+        )
+        presentation = self.presenter.present(response)
+        self.assertTrue(presentation.results.rows[0].show_consumption_icon)
+
+    def test_icon_is_shown_to_companies(self) -> None:
+        self.session.login_company(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan()]
+        )
+        presentation = self.presenter.present(response)
+        self.assertTrue(presentation.results.rows[0].show_consumption_icon)
+
+    def test_icon_is_hidden_from_accountants(self) -> None:
+        self.session.login_accountant(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan()]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].show_consumption_icon)
+
+    def test_member_consumption_url_is_private_consumption_url(self) -> None:
+        self.session.login_member(uuid4())
+        plan_id = uuid4()
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(plan_id=plan_id)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertEqual(
+            presentation.results.rows[0].consumption_url,
+            self.url_index.get_register_private_consumption_url(plan_id=plan_id),
+        )
+
+    def test_company_consumption_url_is_productive_consumption_url(self) -> None:
+        self.session.login_company(uuid4())
+        plan_id = uuid4()
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(plan_id=plan_id)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertEqual(
+            presentation.results.rows[0].consumption_url,
+            self.url_index.get_register_productive_consumption_url(plan_id=plan_id),
+        )
+
+    def test_accountant_has_empty_consumption_url(self) -> None:
+        self.session.login_accountant(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan()]
+        )
+        presentation = self.presenter.present(response)
+        self.assertEqual(presentation.results.rows[0].consumption_url, "")
+
+    def test_consumption_is_disabled_for_members_on_expired_plans(self) -> None:
+        self.session.login_member(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(is_expired=True)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertTrue(presentation.results.rows[0].is_consumption_disabled)
+
+    def test_consumption_is_enabled_for_members_on_active_plans(self) -> None:
+        self.session.login_member(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(is_expired=False)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].is_consumption_disabled)
+
+    def test_consumption_is_disabled_for_own_plan_even_when_active(self) -> None:
+        company_id = uuid4()
+        self.session.login_company(company_id)
+        response = self.queried_plan_generator.get_response(
+            [
+                self.queried_plan_generator.get_plan(
+                    company_id=company_id, is_expired=False
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        self.assertTrue(presentation.results.rows[0].is_consumption_disabled)
+
+    def test_consumption_is_enabled_for_company_on_foreign_active_plan(self) -> None:
+        self.session.login_company(uuid4())
+        response = self.queried_plan_generator.get_response(
+            [self.queried_plan_generator.get_plan(company_id=uuid4(), is_expired=False)]
+        )
+        presentation = self.presenter.present(response)
+        self.assertFalse(presentation.results.rows[0].is_consumption_disabled)


### PR DESCRIPTION
After this change members and companies can consume products directly from the "all plans" list. An shopping cart icon has been added for that purpose.

A new colored tag signals to companies that a plan is their own.