### PR TITLE
Remove "private consumption" button from member dashboard

### DIFF
--- a/src/workers_control/flask/templates/member/dashboard.html
+++ b/src/workers_control/flask/templates/member/dashboard.html
@@ -55,13 +55,6 @@
     <div class="fixed-grid has-3-cols has-1-cols-mobile">
       <ul class="grid">
         <li class="cell box has-background-primary-light mb-0">
-          <a href="{{ url_for('main_member.register_private_consumption') }}">
-            <h1 class="title is-5"><span class="icon">{{ "file-circle-plus"|icon }}</span> {{
-              gettext("Private consumption") }}</h1>
-            <div class="subtitle"></div>
-          </a>
-        </li>
-        <li class="cell box has-background-primary-light mb-0">
           <a href="{{ url_for('main_member.my_account') }}">
             <h1 class="title is-5"><span class="icon">{{ "industry"|icon }}</span> {{
               gettext("My account") }}

--- a/src/workers_control/flask/templates/member/register_private_consumption.html
+++ b/src/workers_control/flask/templates/member/register_private_consumption.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
+{% from 'macros/navbar.html' import navbar %}
 
 {% block navbar_start %}
-<div class="navbar-item">{{ gettext("Register consumption") }}</div>
+{{ navbar(navbar_items) }}
 {% endblock %}
 
 {% block content %}
@@ -83,7 +84,7 @@
                         <div class="control">
                             <button class="button is-primary" type="submit">{{ gettext("Register") }}</button>
                             {% if view_model and view_model.valid_plan_selected %}
-                            <a class="button is-light" href="{{ url_for('main_member.register_private_consumption') }}">{{ gettext("Cancel") }}</a>
+                            <a class="button is-light" href="{{ url_for('main_user.query_plans') }}">{{ gettext("Cancel") }}</a>
                             {% endif %}
                         </div>
                     </div>

--- a/src/workers_control/flask/url_index.py
+++ b/src/workers_control/flask/url_index.py
@@ -75,6 +75,9 @@ class GeneralUrlIndex:
             plan_id=plan_id,
         )
 
+    def get_my_private_consumptions_url(self) -> str:
+        return url_for(endpoint="main_member.consumptions")
+
     def get_global_barplot_for_means_of_production_url(
         self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
     ) -> str:

--- a/src/workers_control/flask/views/register_private_consumption.py
+++ b/src/workers_control/flask/views/register_private_consumption.py
@@ -108,4 +108,5 @@ class RegisterPrivateConsumptionView:
             "member/register_private_consumption.html",
             form=form,
             view_model=view_model,
+            navbar_items=self.presenter.create_navbar_items(),
         )

--- a/src/workers_control/web/url_index.py
+++ b/src/workers_control/web/url_index.py
@@ -65,6 +65,8 @@ class UrlIndex(Protocol):
         self, amount: Optional[int] = None, plan_id: Optional[UUID] = None
     ) -> str: ...
 
+    def get_my_private_consumptions_url(self) -> str: ...
+
     def get_register_productive_consumption_url(
         self,
         plan_id: Optional[UUID] = None,

--- a/src/workers_control/web/www/presenters/register_private_consumption_presenter.py
+++ b/src/workers_control/web/www/presenters/register_private_consumption_presenter.py
@@ -9,6 +9,7 @@ from workers_control.web.notification import Notifier
 from workers_control.web.request import Request
 from workers_control.web.translator import Translator
 from workers_control.web.url_index import UrlIndex
+from workers_control.web.www.navbar import NavbarItem
 from workers_control.web.www.response import Redirect
 
 
@@ -36,7 +37,7 @@ class RegisterPrivateConsumptionPresenter:
             self.user_notifier.display_info(
                 self.translator.gettext("Consumption successfully registered.")
             )
-            return Redirect(url=self.url_index.get_register_private_consumption_url())
+            return Redirect(url=self.url_index.get_my_private_consumptions_url())
         form = self._create_form(request)
         status_code = 400
         if interactor_response.rejection_reason == RejectionReason.plan_inactive:
@@ -71,6 +72,18 @@ class RegisterPrivateConsumptionPresenter:
             )
             status_code = 404
         return RenderForm(status_code=status_code, form=form)
+
+    def create_navbar_items(self) -> list[NavbarItem]:
+        return [
+            NavbarItem(
+                text=self.translator.gettext("All plans"),
+                url=self.url_index.get_query_plans_url(),
+            ),
+            NavbarItem(
+                text=self.translator.gettext("Register consumption"),
+                url=None,
+            ),
+        ]
 
     def _create_form(self, request: Request) -> RegisterPrivateConsumptionForm:
         return RegisterPrivateConsumptionForm(

--- a/tests/flask_integration/test_url_index.py
+++ b/tests/flask_integration/test_url_index.py
@@ -248,6 +248,12 @@ class GeneralUrlIndexTests(ViewTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
 
+    def test_url_for_my_private_consumptions_leads_to_functional_url(self) -> None:
+        self.login_member()
+        url = self.url_index.get_my_private_consumptions_url()
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
     def test_url_for_registration_of_productive_consumption_leads_to_functional_url_without_params_provided(
         self,
     ) -> None:

--- a/tests/web/www/presenters/test_register_private_consumption_presenter.py
+++ b/tests/web/www/presenters/test_register_private_consumption_presenter.py
@@ -94,7 +94,7 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         )
         assert isinstance(view_model, Redirect)
 
-    def test_that_user_is_redirected_to_register_private_consumption_view_on_successful_registration(
+    def test_that_user_is_redirected_to_my_private_consumptions_view_on_successful_registration(
         self,
     ) -> None:
         view_model = self.presenter.present(
@@ -102,7 +102,7 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
             request=FakeRequest(),
         )
         assert isinstance(view_model, Redirect)
-        assert view_model.url == self.url_index.get_register_private_consumption_url()
+        assert view_model.url == self.url_index.get_my_private_consumptions_url()
 
     @parameterized.expand([(reason,) for reason in RejectionReason])
     def test_that_error_response_results_in_form_being_rerendered(
@@ -164,3 +164,31 @@ class RegisterPrivateConsumptionPresenterTests(BaseTestCase):
         )
         assert isinstance(view_model, RenderForm)
         self.assertEqual(view_model.status_code, 404)
+
+
+class NavbarItemsTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(RegisterPrivateConsumptionPresenter)
+
+    def test_two_navbar_items_are_shown(self) -> None:
+        navbar_items = self.presenter.create_navbar_items()
+        self.assertEqual(len(navbar_items), 2)
+
+    def test_first_navbar_item_has_text_all_plans(self) -> None:
+        navbar_items = self.presenter.create_navbar_items()
+        self.assertEqual(navbar_items[0].text, self.translator.gettext("All plans"))
+
+    def test_first_navbar_item_links_to_query_plans(self) -> None:
+        navbar_items = self.presenter.create_navbar_items()
+        self.assertEqual(navbar_items[0].url, self.url_index.get_query_plans_url())
+
+    def test_second_navbar_item_has_text_register_consumption(self) -> None:
+        navbar_items = self.presenter.create_navbar_items()
+        self.assertEqual(
+            navbar_items[1].text, self.translator.gettext("Register consumption")
+        )
+
+    def test_second_navbar_item_has_no_link(self) -> None:
+        navbar_items = self.presenter.create_navbar_items()
+        self.assertIsNone(navbar_items[1].url)

--- a/tests/web/www/presenters/url_index.py
+++ b/tests/web/www/presenters/url_index.py
@@ -76,6 +76,7 @@ class UrlIndexTestImpl:
     get_plan_details_url = UrlIndexMethod()
     get_query_companies_url = UrlIndexMethod()
     get_query_plans_url = UrlIndexMethod()
+    get_my_private_consumptions_url = UrlIndexMethod()
     get_register_private_consumption_url = UrlIndexMethod()
     get_register_productive_consumption_url = UrlIndexMethod()
     get_reject_plan_url = UrlIndexMethod()


### PR DESCRIPTION
The main consumption entry point for members is the "all plans" list.