### PR TITLE
List basic services in member consumptions

### DIFF
--- a/src/workers_control/core/interactors/get_private_consumption_details.py
+++ b/src/workers_control/core/interactors/get_private_consumption_details.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+from uuid import UUID
+
+from workers_control.core.repositories import DatabaseGateway
+
+
+@dataclass
+class GetPrivateConsumptionDetailsInteractor:
+    @dataclass
+    class Request:
+        consumption_id: UUID
+        member: UUID
+
+    @dataclass
+    class Response:
+        consumption_date: datetime
+        plan_id: UUID
+        plan_name: str
+        plan_description: str
+        amount: int
+        paid_price_per_unit: Decimal
+        paid_price_total: Decimal
+
+    database_gateway: DatabaseGateway
+
+    def get_details(self, request: Request) -> Optional[Response]:
+        row = (
+            self.database_gateway.get_private_consumptions()
+            .with_id(request.consumption_id)
+            .where_consumer_is_member(member=request.member)
+            .joined_with_transfer_and_plan()
+            .first()
+        )
+        if not row:
+            return None
+        consumption, transfer, plan = row
+        return self.Response(
+            consumption_date=transfer.date,
+            plan_id=plan.id,
+            plan_name=plan.prd_name,
+            plan_description=plan.description,
+            amount=consumption.amount,
+            paid_price_per_unit=transfer.value / consumption.amount,
+            paid_price_total=transfer.value,
+        )

--- a/src/workers_control/core/interactors/query_private_consumptions.py
+++ b/src/workers_control/core/interactors/query_private_consumptions.py
@@ -1,20 +1,31 @@
 from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
+from enum import Enum, auto
 from uuid import UUID
 
-from workers_control.core.records import Plan, PrivateConsumption, Transfer
+from workers_control.core.records import (
+    BasicService,
+    Plan,
+    PrivateConsumption,
+    PrivateConsumptionOfBasicService,
+    Transfer,
+)
 from workers_control.core.repositories import DatabaseGateway
+
+
+class ConsumptionType(Enum):
+    plan = auto()
+    basic_service = auto()
 
 
 @dataclass
 class Consumption:
+    id: UUID
+    consumption_type: ConsumptionType
     consumption_date: datetime
-    plan_id: UUID
-    product_name: str
-    product_description: str
-    paid_price_per_unit: Decimal
-    amount: int
+    name: str
+    description: str
     paid_price_total: Decimal
 
 
@@ -33,27 +44,50 @@ class QueryPrivateConsumptions:
     database_gateway: DatabaseGateway
 
     def query_private_consumptions(self, request: Request) -> Response:
-        records = (
-            self.database_gateway.get_private_consumptions()
-            .where_consumer_is_member(member=request.member)
-            .ordered_by_creation_date(ascending=False)
-            .joined_with_transfer_and_plan()
-        )
         consumptions = [
-            self._consumption_to_response_model(consumption, transfer, plan)
-            for consumption, transfer, plan in records
+            self._plan_consumption_to_response_model(consumption, transfer, plan)
+            for consumption, transfer, plan in (
+                self.database_gateway.get_private_consumptions()
+                .where_consumer_is_member(member=request.member)
+                .joined_with_transfer_and_plan()
+            )
         ]
+        consumptions.extend(
+            self._basic_service_consumption_to_response_model(
+                consumption, transfer, basic_service
+            )
+            for consumption, transfer, basic_service in (
+                self.database_gateway.get_private_consumptions_of_basic_service()
+                .where_consumer_is_member(member=request.member)
+                .joined_with_transfer_and_basic_service()
+            )
+        )
+        consumptions.sort(key=lambda c: c.consumption_date, reverse=True)
         return Response(consumptions=consumptions)
 
-    def _consumption_to_response_model(
+    def _plan_consumption_to_response_model(
         self, consumption: PrivateConsumption, transfer: Transfer, plan: Plan
     ) -> Consumption:
         return Consumption(
+            id=consumption.id,
+            consumption_type=ConsumptionType.plan,
             consumption_date=transfer.date,
-            plan_id=plan.id,
-            product_name=plan.prd_name,
-            product_description=plan.description,
-            paid_price_per_unit=transfer.value / consumption.amount,
-            amount=consumption.amount,
+            name=plan.prd_name,
+            description=plan.description,
+            paid_price_total=transfer.value,
+        )
+
+    def _basic_service_consumption_to_response_model(
+        self,
+        consumption: PrivateConsumptionOfBasicService,
+        transfer: Transfer,
+        basic_service: BasicService,
+    ) -> Consumption:
+        return Consumption(
+            id=consumption.id,
+            consumption_type=ConsumptionType.basic_service,
+            consumption_date=transfer.date,
+            name=basic_service.name,
+            description=basic_service.description,
             paid_price_total=transfer.value,
         )

--- a/src/workers_control/core/interactors/register_private_consumption_of_basic_service.py
+++ b/src/workers_control/core/interactors/register_private_consumption_of_basic_service.py
@@ -72,12 +72,16 @@ class RegisterPrivateConsumptionOfBasicServiceInteractor:
         assert provider
         if not self._is_account_balance_sufficient(request.amount, consumer.account):
             raise RejectionReason.insufficient_balance
-        self.database_gateway.create_transfer(
+        transfer = self.database_gateway.create_transfer(
             date=self.datetime_service.now(),
             debit_account=consumer.account,
             credit_account=provider.account,
             value=request.amount,
             type=TransferType.private_consumption_of_basic_service,
+        )
+        self.database_gateway.create_private_consumption_of_basic_service(
+            basic_service=basic_service.id,
+            transfer=transfer.id,
         )
         return RegisterPrivateConsumptionOfBasicServiceResponse(rejection_reason=None)
 

--- a/src/workers_control/core/records.py
+++ b/src/workers_control/core/records.py
@@ -297,6 +297,13 @@ class PrivateConsumption:
 
 
 @dataclass(frozen=True)
+class PrivateConsumptionOfBasicService:
+    id: UUID
+    basic_service: UUID
+    transfer: UUID
+
+
+@dataclass(frozen=True)
 class ProductiveConsumption:
     id: UUID
     plan_id: UUID

--- a/src/workers_control/core/repositories.py
+++ b/src/workers_control/core/repositories.py
@@ -248,6 +248,8 @@ class MemberResult(QueryResult[records.Member], Protocol):
 class PrivateConsumptionResult(QueryResult[records.PrivateConsumption], Protocol):
     def ordered_by_creation_date(self, *, ascending: bool = ...) -> Self: ...
 
+    def with_id(self, id_: UUID) -> Self: ...
+
     def where_consumer_is_member(self, member: UUID) -> Self: ...
 
     def where_provider_is_company(self, company: UUID) -> Self: ...
@@ -266,6 +268,22 @@ class PrivateConsumptionResult(QueryResult[records.PrivateConsumption], Protocol
             records.Transfer,
             records.Plan,
             records.Member,
+        ]
+    ]: ...
+
+
+class PrivateConsumptionOfBasicServiceResult(
+    QueryResult[records.PrivateConsumptionOfBasicService], Protocol
+):
+    def where_consumer_is_member(self, member: UUID) -> Self: ...
+
+    def joined_with_transfer_and_basic_service(
+        self,
+    ) -> QueryResult[
+        Tuple[
+            records.PrivateConsumptionOfBasicService,
+            records.Transfer,
+            records.BasicService,
         ]
     ]: ...
 
@@ -531,6 +549,16 @@ class DatabaseGateway(Protocol):
     ) -> records.PrivateConsumption: ...
 
     def get_private_consumptions(self) -> PrivateConsumptionResult: ...
+
+    def create_private_consumption_of_basic_service(
+        self,
+        basic_service: UUID,
+        transfer: UUID,
+    ) -> records.PrivateConsumptionOfBasicService: ...
+
+    def get_private_consumptions_of_basic_service(
+        self,
+    ) -> PrivateConsumptionOfBasicServiceResult: ...
 
     def create_productive_consumption(
         self,

--- a/src/workers_control/db/migrations/versions/399a221ebea4_add_private_consumption_of_basic_.py
+++ b/src/workers_control/db/migrations/versions/399a221ebea4_add_private_consumption_of_basic_.py
@@ -1,0 +1,40 @@
+"""add private consumption of basic service table
+
+Revision ID: 399a221ebea4
+Revises: 686f2af1cbfe
+Create Date: 2026-04-27 21:06:39.948825
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '399a221ebea4'
+down_revision: Union[str, None] = '686f2af1cbfe'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "private_consumption_of_basic_service",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("basic_service", sa.Uuid(), nullable=False),
+        sa.Column("transfer", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["basic_service"],
+            ["basic_service.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["transfer"],
+            ["transfer.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("private_consumption_of_basic_service")

--- a/src/workers_control/db/models.py
+++ b/src/workers_control/db/models.py
@@ -283,6 +283,14 @@ class PrivateConsumption(Base):
     amount: Mapped[int]
 
 
+class PrivateConsumptionOfBasicService(Base):
+    __tablename__ = "private_consumption_of_basic_service"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    basic_service: Mapped[UUID] = mapped_column(Uuid, ForeignKey("basic_service.id"))
+    transfer: Mapped[UUID] = mapped_column(Uuid, ForeignKey("transfer.id"))
+
+
 class ProductiveConsumption(Base):
     __tablename__ = "productive_consumption"
 

--- a/src/workers_control/db/repositories.py
+++ b/src/workers_control/db/repositories.py
@@ -1379,6 +1379,11 @@ class ProductiveConsumptionResult(SqlQueryResult[records.ProductiveConsumption])
 
 
 class PrivateConsumptionResult(SqlQueryResult[records.PrivateConsumption]):
+    def with_id(self, id_: UUID) -> Self:
+        return self._with_modified_query(
+            lambda query: query.filter(models.PrivateConsumption.id == id_)
+        )
+
     def where_consumer_is_member(self, member: UUID) -> Self:
         transfer = aliased(models.Transfer)
         account = aliased(models.Account)
@@ -1500,6 +1505,71 @@ class PrivateConsumptionResult(SqlQueryResult[records.PrivateConsumption]):
             )
             .join(plan, models.PrivateConsumption.plan_id == plan.id)
             .with_entities(models.PrivateConsumption, transfer, plan, member),
+        )
+
+
+class PrivateConsumptionOfBasicServiceResult(
+    SqlQueryResult[records.PrivateConsumptionOfBasicService]
+):
+    def where_consumer_is_member(self, member: UUID) -> Self:
+        transfer = aliased(models.Transfer)
+        account = aliased(models.Account)
+        consuming_member = aliased(models.Member)
+        return self._with_modified_query(
+            lambda query: query.join(
+                transfer,
+                models.PrivateConsumptionOfBasicService.transfer == transfer.id,
+            )
+            .join(account, transfer.debit_account == account.id)
+            .join(
+                consuming_member,
+                account.id == consuming_member.account,
+            )
+            .filter(consuming_member.id == member)
+        )
+
+    def joined_with_transfer_and_basic_service(
+        self,
+    ) -> SqlQueryResult[
+        Tuple[
+            records.PrivateConsumptionOfBasicService,
+            records.Transfer,
+            records.BasicService,
+        ]
+    ]:
+        def mapper(
+            orm,
+        ) -> Tuple[
+            records.PrivateConsumptionOfBasicService,
+            records.Transfer,
+            records.BasicService,
+        ]:
+            consumption_orm, transfer_orm, basic_service_orm = orm
+            return (
+                DatabaseGatewayImpl.private_consumption_of_basic_service_from_orm(
+                    consumption_orm
+                ),
+                DatabaseGatewayImpl.transfer_from_orm(transfer_orm),
+                DatabaseGatewayImpl.basic_service_from_orm(basic_service_orm),
+            )
+
+        transfer = aliased(models.Transfer)
+        basic_service = aliased(models.BasicService)
+        return SqlQueryResult(
+            db=self.db,
+            mapper=mapper,
+            query=self.query.join(
+                transfer,
+                models.PrivateConsumptionOfBasicService.transfer == transfer.id,
+            )
+            .join(
+                basic_service,
+                models.PrivateConsumptionOfBasicService.basic_service
+                == basic_service.id,
+            )
+            .with_entities(
+                models.PrivateConsumptionOfBasicService, transfer, basic_service
+            ),
         )
 
 
@@ -2281,6 +2351,39 @@ class DatabaseGatewayImpl:
             db=self.db,
             query=self.db.session.query(models.PrivateConsumption),
             mapper=self.private_consumption_from_orm,
+        )
+
+    def create_private_consumption_of_basic_service(
+        self,
+        basic_service: UUID,
+        transfer: UUID,
+    ) -> records.PrivateConsumptionOfBasicService:
+        orm = models.PrivateConsumptionOfBasicService(
+            id=uuid4(),
+            basic_service=basic_service,
+            transfer=transfer,
+        )
+        self.db.session.add(orm)
+        self.db.session.flush()
+        return self.private_consumption_of_basic_service_from_orm(orm)
+
+    def get_private_consumptions_of_basic_service(
+        self,
+    ) -> PrivateConsumptionOfBasicServiceResult:
+        return PrivateConsumptionOfBasicServiceResult(
+            db=self.db,
+            query=self.db.session.query(models.PrivateConsumptionOfBasicService),
+            mapper=self.private_consumption_of_basic_service_from_orm,
+        )
+
+    @classmethod
+    def private_consumption_of_basic_service_from_orm(
+        cls, orm: models.PrivateConsumptionOfBasicService
+    ) -> records.PrivateConsumptionOfBasicService:
+        return records.PrivateConsumptionOfBasicService(
+            id=orm.id,
+            basic_service=orm.basic_service,
+            transfer=orm.transfer,
         )
 
     @classmethod

--- a/src/workers_control/flask/routes/member/routes.py
+++ b/src/workers_control/flask/routes/member/routes.py
@@ -20,6 +20,9 @@ from workers_control.flask.views import (
 from workers_control.flask.views.create_basic_service_view import (
     CreateBasicServiceView,
 )
+from workers_control.flask.views.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsView,
+)
 from workers_control.flask.views.http_error_view import http_404
 from workers_control.flask.views.list_basic_services_of_worker_view import (
     ListBasicServicesOfWorkerView,
@@ -43,6 +46,11 @@ from .blueprint import MemberRoute
 @MemberRoute("/consumptions")
 @as_flask_view()
 class consumptions(QueryPrivateConsumptionsView): ...
+
+
+@MemberRoute("/consumptions/<uuid:consumption_id>")
+@as_flask_view()
+class consumption_details(GetPrivateConsumptionDetailsView): ...
 
 
 @MemberRoute("/basic_services")

--- a/src/workers_control/flask/templates/member/consumption_details.html
+++ b/src/workers_control/flask/templates/member/consumption_details.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block navbar_start %}
+<div class="navbar-item">{{ gettext("Consumption details") }}</div>
+{% endblock %}
+
+{% block content %}
+
+<div class="section">
+  <div class="container">
+    <h1 class="title has-text-centered">
+      {{ view_model.plan_name }}
+    </h1>
+
+    <div class="columns is-centered">
+      <div class="column is-three-fifths">
+        <div class="box">
+          <table class="table is-fullwidth">
+            <tbody>
+              <tr>
+                <th>{{ gettext("Date") }}</th>
+                <td>{{ view_model.consumption_date }}</td>
+              </tr>
+              <tr>
+                <th>{{ gettext("Description") }}</th>
+                <td>{{ view_model.plan_description }}</td>
+              </tr>
+              <tr>
+                <th>{{ gettext("Amount") }}</th>
+                <td>{{ view_model.amount }}</td>
+              </tr>
+              <tr>
+                <th>{{ gettext("Price per unit") }}</th>
+                <td>{{ view_model.price_per_unit }}</td>
+              </tr>
+              <tr>
+                <th>{{ gettext("Hours paid") }}</th>
+                <td>{{ view_model.price_total }}</td>
+              </tr>
+            </tbody>
+          </table>
+
+          <div class="has-text-centered">
+            <a class="button is-primary is-light" href="{{ view_model.plan_details_url }}">
+              {{ gettext("View plan") }}
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/src/workers_control/flask/templates/member/consumptions.html
+++ b/src/workers_control/flask/templates/member/consumptions.html
@@ -24,11 +24,10 @@
       <thead>
         <tr>
           <th>{{ gettext("Date") }}</th>
-          <th>{{ gettext("Name") }}</th>
-          <th>{{ gettext("Description") }}</th>
-          <th>{{ gettext("Price per unit") }}</th>
-          <th>{{ gettext("Amount") }}</th>
-          <th>{{ gettext("Total price") }}</th>
+          <th>{{ gettext("Offer type") }}</th>
+          <th>{{ gettext("Offer name") }}</th>
+          <th>{{ gettext("Offer description") }}</th>
+          <th>{{ gettext("Hours paid") }}</th>
         </tr>
       </thead>
       <tbody>
@@ -36,11 +35,16 @@
         {% for consumption in view_model.consumptions %}
         <tr>
           <td>{{ consumption.consumption_date }}</td>
-          <td>{{ consumption.product_name }}</td>
-          <td>{{ consumption.product_description }}</td>
-          <td>{{ consumption.price_per_unit }}</td>
-          <th>{{ consumption.consumption_amount }}</th>
-          <th>{{ consumption.price_total }} </th>
+          <td>{{ consumption.consumption_type }}</td>
+          <td>
+            {% if consumption.details_url %}
+            <a href="{{ consumption.details_url }}">{{ consumption.name }}</a>
+            {% else %}
+            {{ consumption.name }}
+            {% endif %}
+          </td>
+          <td>{{ consumption.description }}</td>
+          <th>{{ consumption.hours_paid }}</th>
         </tr>
         {% endfor %}
         {% else %}

--- a/src/workers_control/flask/url_index.py
+++ b/src/workers_control/flask/url_index.py
@@ -89,6 +89,12 @@ class GeneralUrlIndex:
     def get_my_private_consumptions_url(self) -> str:
         return url_for(endpoint="main_member.consumptions")
 
+    def get_my_private_consumption_details_url(self, consumption_id: UUID) -> str:
+        return url_for(
+            endpoint="main_member.consumption_details",
+            consumption_id=consumption_id,
+        )
+
     def get_global_barplot_for_means_of_production_url(
         self, planned_means: Decimal, planned_resources: Decimal, planned_work: Decimal
     ) -> str:

--- a/src/workers_control/flask/views/get_private_consumption_details.py
+++ b/src/workers_control/flask/views/get_private_consumption_details.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from flask import render_template
+
+from workers_control.core.interactors.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsInteractor,
+)
+from workers_control.flask.types import Response
+from workers_control.flask.views.http_error_view import http_404
+from workers_control.web.www.controllers.get_private_consumption_details_controller import (
+    GetPrivateConsumptionDetailsController,
+)
+from workers_control.web.www.presenters.private_consumption_details_presenter import (
+    PrivateConsumptionDetailsPresenter,
+)
+
+
+@dataclass
+class GetPrivateConsumptionDetailsView:
+    controller: GetPrivateConsumptionDetailsController
+    interactor: GetPrivateConsumptionDetailsInteractor
+    presenter: PrivateConsumptionDetailsPresenter
+
+    def GET(self, consumption_id: UUID) -> Response:
+        interactor_request = self.controller.create_request(
+            consumption_id=consumption_id
+        )
+        interactor_response = self.interactor.get_details(interactor_request)
+        if interactor_response is None:
+            return http_404()
+        view_model = self.presenter.present(interactor_response)
+        return render_template("member/consumption_details.html", view_model=view_model)

--- a/src/workers_control/web/url_index.py
+++ b/src/workers_control/web/url_index.py
@@ -73,6 +73,8 @@ class UrlIndex(Protocol):
 
     def get_my_private_consumptions_url(self) -> str: ...
 
+    def get_my_private_consumption_details_url(self, consumption_id: UUID) -> str: ...
+
     def get_register_productive_consumption_url(
         self,
         plan_id: Optional[UUID] = None,

--- a/src/workers_control/web/www/controllers/get_private_consumption_details_controller.py
+++ b/src/workers_control/web/www/controllers/get_private_consumption_details_controller.py
@@ -1,0 +1,22 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from workers_control.core.interactors.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsInteractor,
+)
+from workers_control.web.session import Session
+
+
+@dataclass
+class GetPrivateConsumptionDetailsController:
+    session: Session
+
+    def create_request(
+        self, consumption_id: UUID
+    ) -> GetPrivateConsumptionDetailsInteractor.Request:
+        member = self.session.get_current_user()
+        assert member
+        return GetPrivateConsumptionDetailsInteractor.Request(
+            consumption_id=consumption_id,
+            member=member,
+        )

--- a/src/workers_control/web/www/presenters/private_consumption_details_presenter.py
+++ b/src/workers_control/web/www/presenters/private_consumption_details_presenter.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+from workers_control.core.interactors.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsInteractor,
+)
+from workers_control.web.formatters.datetime_formatter import DatetimeFormatter
+from workers_control.web.session import UserRole
+from workers_control.web.url_index import UrlIndex
+
+
+@dataclass
+class PrivateConsumptionDetailsPresenter:
+    @dataclass
+    class ViewModel:
+        consumption_date: str
+        plan_name: str
+        plan_description: str
+        amount: str
+        price_per_unit: str
+        price_total: str
+        plan_details_url: str
+
+    datetime_formatter: DatetimeFormatter
+    url_index: UrlIndex
+
+    def present(
+        self, response: GetPrivateConsumptionDetailsInteractor.Response
+    ) -> ViewModel:
+        return self.ViewModel(
+            consumption_date=self.datetime_formatter.format_datetime(
+                date=response.consumption_date,
+                fmt="%d.%m.%Y",
+            ),
+            plan_name=response.plan_name,
+            plan_description=response.plan_description,
+            amount=str(response.amount),
+            price_per_unit=str(round(response.paid_price_per_unit, 2)),
+            price_total=str(round(response.paid_price_total, 2)),
+            plan_details_url=self.url_index.get_plan_details_url(
+                user_role=UserRole.member, plan_id=response.plan_id
+            ),
+        )

--- a/src/workers_control/web/www/presenters/private_consumptions_presenter.py
+++ b/src/workers_control/web/www/presenters/private_consumptions_presenter.py
@@ -1,8 +1,14 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
-from workers_control.core.interactors.query_private_consumptions import Response
+from workers_control.core.interactors.query_private_consumptions import (
+    Consumption,
+    ConsumptionType,
+    Response,
+)
 from workers_control.web.formatters.datetime_formatter import DatetimeFormatter
+from workers_control.web.translator import Translator
+from workers_control.web.url_index import UrlIndex
 
 
 @dataclass
@@ -11,33 +17,51 @@ class PrivateConsumptionsPresenter:
     class ViewModel:
         @dataclass
         class Consumption:
+            consumption_type: str
             consumption_date: str
-            product_name: str
-            product_description: str
-            price_per_unit: str
-            consumption_amount: str
-            price_total: str
+            name: str
+            description: str
+            hours_paid: str
+            details_url: Optional[str]
 
         is_consumptions_visible: bool
         consumptions: List[Consumption]
 
     datetime_formatter: DatetimeFormatter
+    translator: Translator
+    url_index: UrlIndex
 
     def present_private_consumptions(self, response: Response) -> ViewModel:
         return self.ViewModel(
             is_consumptions_visible=bool(response.consumptions),
             consumptions=[
-                self.ViewModel.Consumption(
-                    consumption_date=self.datetime_formatter.format_datetime(
-                        date=consumption.consumption_date,
-                        fmt="%d.%m.%Y",
-                    ),
-                    product_name=consumption.product_name,
-                    product_description=consumption.product_description,
-                    price_per_unit=str(consumption.paid_price_per_unit),
-                    consumption_amount=str(consumption.amount),
-                    price_total=str(consumption.paid_price_total),
-                )
+                self._present_consumption(consumption)
                 for consumption in response.consumptions
             ],
         )
+
+    def _present_consumption(self, consumption: Consumption) -> ViewModel.Consumption:
+        return self.ViewModel.Consumption(
+            consumption_type=self._format_type(consumption.consumption_type),
+            consumption_date=self.datetime_formatter.format_datetime(
+                date=consumption.consumption_date,
+                fmt="%d.%m.%Y",
+            ),
+            name=consumption.name,
+            description=consumption.description,
+            hours_paid=str(round(consumption.paid_price_total, 2)),
+            details_url=(
+                self.url_index.get_my_private_consumption_details_url(
+                    consumption_id=consumption.id
+                )
+                if consumption.consumption_type == ConsumptionType.plan
+                else None
+            ),
+        )
+
+    def _format_type(self, consumption_type: ConsumptionType) -> str:
+        match consumption_type:
+            case ConsumptionType.plan:
+                return self.translator.gettext("Plan")
+            case ConsumptionType.basic_service:
+                return self.translator.gettext("Basic service")

--- a/src/workers_control/web/www/presenters/register_private_consumption_of_basic_service_presenter.py
+++ b/src/workers_control/web/www/presenters/register_private_consumption_of_basic_service_presenter.py
@@ -37,7 +37,7 @@ class RegisterPrivateConsumptionOfBasicServicePresenter:
             self.user_notifier.display_info(
                 self.translator.gettext("Consumption successfully registered.")
             )
-            return Redirect(url=self.url_index.get_query_offers_url())
+            return Redirect(url=self.url_index.get_my_private_consumptions_url())
         form = self._create_form(request)
         status_code = 400
         if (

--- a/tests/db/test_private_consumption_of_basic_service_result.py
+++ b/tests/db/test_private_consumption_of_basic_service_result.py
@@ -1,0 +1,101 @@
+from decimal import Decimal
+
+from tests.control_thresholds import ControlThresholdsTestImpl
+from tests.db.base_test_case import DatabaseTestCase
+
+
+class PrivateConsumptionOfBasicServiceTests(DatabaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.control_thresholds = self.injector.get(ControlThresholdsTestImpl)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
+
+    def test_that_by_default_no_consumptions_of_basic_service_are_in_db(self) -> None:
+        assert not self.database_gateway.get_private_consumptions_of_basic_service()
+
+    def test_that_a_consumption_is_in_db_after_one_was_created(self) -> None:
+        self.consumption_generator.create_private_consumption_of_basic_service()
+        assert self.database_gateway.get_private_consumptions_of_basic_service()
+
+    def test_that_retrieved_consumption_references_the_specified_basic_service(
+        self,
+    ) -> None:
+        basic_service = self.basic_service_generator.create_basic_service()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            basic_service=basic_service
+        )
+        consumption = (
+            self.database_gateway.get_private_consumptions_of_basic_service().first()
+        )
+        assert consumption
+        assert consumption.basic_service == basic_service
+
+    def test_that_retrieved_consumption_references_an_existing_transfer(self) -> None:
+        self.consumption_generator.create_private_consumption_of_basic_service()
+        consumption = (
+            self.database_gateway.get_private_consumptions_of_basic_service().first()
+        )
+        assert consumption
+        transfer_ids = {t.id for t in self.database_gateway.get_transfers()}
+        assert consumption.transfer in transfer_ids
+
+    def test_that_two_different_consumptions_reference_different_transfers(
+        self,
+    ) -> None:
+        self.consumption_generator.create_private_consumption_of_basic_service()
+        self.consumption_generator.create_private_consumption_of_basic_service()
+        consumption_1, consumption_2 = list(
+            self.database_gateway.get_private_consumptions_of_basic_service()
+        )
+        assert consumption_1.transfer != consumption_2.transfer
+
+    def test_can_filter_consumptions_by_consumer(self) -> None:
+        member = self.member_generator.create_member()
+        other_member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        consumptions = self.database_gateway.get_private_consumptions_of_basic_service()
+        assert consumptions.where_consumer_is_member(member)
+        assert not consumptions.where_consumer_is_member(other_member)
+
+    def test_can_retrieve_basic_service_and_transfer_with_consumption(self) -> None:
+        self.consumption_generator.create_private_consumption_of_basic_service()
+        result = (
+            self.database_gateway.get_private_consumptions_of_basic_service()
+            .joined_with_transfer_and_basic_service()
+            .first()
+        )
+        assert result
+        consumption, transfer, basic_service = result
+        assert consumption.transfer == transfer.id
+        assert consumption.basic_service == basic_service.id
+
+    def test_that_amount_of_transfer_equals_amount_specified_when_creating_the_consumption(
+        self,
+    ) -> None:
+        expected_amount = Decimal("5")
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            amount=expected_amount
+        )
+        result = (
+            self.database_gateway.get_private_consumptions_of_basic_service()
+            .joined_with_transfer_and_basic_service()
+            .first()
+        )
+        assert result
+        _, transfer, _ = result
+        assert transfer.value == expected_amount
+
+    def test_can_combine_filtering_and_joining_of_consumptions_with_transfer_and_basic_service(
+        self,
+    ) -> None:
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        assert (
+            self.database_gateway.get_private_consumptions_of_basic_service()
+            .where_consumer_is_member(member)
+            .joined_with_transfer_and_basic_service()
+        )

--- a/tests/flask_integration/test_private_consumption_details_view.py
+++ b/tests/flask_integration/test_private_consumption_details_view.py
@@ -1,0 +1,76 @@
+from typing import Optional
+from uuid import uuid4
+
+from parameterized import parameterized
+
+from tests.flask_integration.base_test_case import LogInUser, ViewTestCase
+
+
+class UserAccessTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.url = f"/member/consumptions/{uuid4()}"
+
+    @parameterized.expand(
+        [
+            (LogInUser.accountant, 302),
+            (None, 302),
+            (LogInUser.company, 302),
+        ]
+    )
+    def test_correct_status_codes_for_non_members(
+        self, login: Optional[LogInUser], expected_code: int
+    ) -> None:
+        self.assert_response_has_expected_code(
+            url=self.url,
+            method="get",
+            login=login,
+            expected_code=expected_code,
+        )
+
+
+class MemberAccessTests(ViewTestCase):
+    def test_logged_in_member_gets_404_for_unknown_consumption(self) -> None:
+        self.login_member()
+        response = self.client.get(f"/member/consumptions/{uuid4()}")
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_member_gets_200_for_own_plan_consumption(self) -> None:
+        member = self.login_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        response = self.client.get(f"/member/consumptions/{consumption.id}")
+        self.assertEqual(response.status_code, 200)
+
+    def test_logged_in_member_gets_404_for_another_members_consumption(self) -> None:
+        owner = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=owner)
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        self.login_member()
+        response = self.client.get(f"/member/consumptions/{consumption.id}")
+        self.assertEqual(response.status_code, 404)
+
+    def test_logged_in_member_gets_404_for_a_basic_service_consumption_id(self) -> None:
+        member = self.login_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        bs_consumption = (
+            self.database_gateway.get_private_consumptions_of_basic_service().first()
+        )
+        assert bs_consumption
+        response = self.client.get(f"/member/consumptions/{bs_consumption.id}")
+        self.assertEqual(response.status_code, 404)
+
+
+class UnconfirmedMemberTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.member = self.login_member(confirm_member=False)
+        self.url = f"/member/consumptions/{uuid4()}"
+
+    def test_unconfirmed_member_gets_302(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 302)

--- a/tests/flask_integration/test_private_consumptions_view.py
+++ b/tests/flask_integration/test_private_consumptions_view.py
@@ -34,6 +34,14 @@ class UserAccessTests(ViewTestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
 
+    def test_logged_in_member_gets_200_after_consuming_a_basic_service(self) -> None:
+        member = self.login_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
 
 class AnonymousUserTest(ViewTestCase):
     def setUp(self) -> None:

--- a/tests/interactors/repositories.py
+++ b/tests/interactors/repositories.py
@@ -978,6 +978,9 @@ class TransferResult(QueryResultImpl[records.Transfer]):
 
 
 class PrivateConsumptionResult(QueryResultImpl[records.PrivateConsumption]):
+    def with_id(self, id_: UUID) -> Self:
+        return self._filter_elements(lambda consumption: consumption.id == id_)
+
     def ordered_by_creation_date(self, *, ascending: bool = True) -> Self:
         def consumption_sorting_key(
             consumption: records.PrivateConsumption,
@@ -1061,6 +1064,46 @@ class PrivateConsumptionResult(QueryResultImpl[records.PrivateConsumption]):
                 (member_id,) = members
                 member = self.database.members[member_id]
                 yield consumption, transfer, plan, member
+
+        return QueryResultImpl(
+            items=joined_items,
+            database=self.database,
+        )
+
+
+class PrivateConsumptionOfBasicServiceResult(
+    QueryResultImpl[records.PrivateConsumptionOfBasicService]
+):
+    def where_consumer_is_member(self, member: UUID) -> Self:
+        def filtered_items() -> Iterator[records.PrivateConsumptionOfBasicService]:
+            member_account = self.database.members[member].account
+            for consumption in self.items():
+                transfer = self.database.transfers[consumption.transfer]
+                if transfer.debit_account == member_account:
+                    yield consumption
+
+        return self.from_iterable(items=filtered_items)
+
+    def joined_with_transfer_and_basic_service(
+        self,
+    ) -> QueryResultImpl[
+        Tuple[
+            records.PrivateConsumptionOfBasicService,
+            records.Transfer,
+            records.BasicService,
+        ]
+    ]:
+        def joined_items() -> Iterator[
+            Tuple[
+                records.PrivateConsumptionOfBasicService,
+                records.Transfer,
+                records.BasicService,
+            ]
+        ]:
+            for consumption in self.items():
+                transfer = self.database.transfers[consumption.transfer]
+                basic_service = self.database.basic_services[consumption.basic_service]
+                yield consumption, transfer, basic_service
 
         return QueryResultImpl(
             items=joined_items,
@@ -1748,6 +1791,9 @@ class MockDatabase:
             UUID, records.CoordinationTransferRequest
         ] = dict()
         self.private_consumptions: Dict[UUID, records.PrivateConsumption] = dict()
+        self.private_consumptions_of_basic_service: Dict[
+            UUID, records.PrivateConsumptionOfBasicService
+        ] = dict()
         self.productive_consumptions: Dict[UUID, records.ProductiveConsumption] = dict()
         self.company_work_invites: List[CompanyWorkInvite] = list()
         self.email_addresses: Dict[str, records.EmailAddress] = dict()
@@ -1798,6 +1844,27 @@ class MockDatabase:
         return PrivateConsumptionResult(
             database=self,
             items=self.private_consumptions.values,
+        )
+
+    def create_private_consumption_of_basic_service(
+        self,
+        basic_service: UUID,
+        transfer: UUID,
+    ) -> records.PrivateConsumptionOfBasicService:
+        consumption = records.PrivateConsumptionOfBasicService(
+            id=uuid4(),
+            basic_service=basic_service,
+            transfer=transfer,
+        )
+        self.private_consumptions_of_basic_service[consumption.id] = consumption
+        return consumption
+
+    def get_private_consumptions_of_basic_service(
+        self,
+    ) -> PrivateConsumptionOfBasicServiceResult:
+        return PrivateConsumptionOfBasicServiceResult(
+            database=self,
+            items=self.private_consumptions_of_basic_service.values,
         )
 
     def create_productive_consumption(

--- a/tests/interactors/test_get_private_consumption_details.py
+++ b/tests/interactors/test_get_private_consumption_details.py
@@ -1,0 +1,99 @@
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from tests.interactors.base_test_case import BaseTestCase
+from workers_control.core.interactors.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsInteractor,
+)
+
+
+class TestGetPrivateConsumptionDetails(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.interactor = self.injector.get(GetPrivateConsumptionDetailsInteractor)
+        self.control_thresholds.set_allowed_overdraw_of_member_account(None)
+
+    def test_that_none_is_returned_for_unknown_consumption_id(self) -> None:
+        member = self.member_generator.create_member()
+        response = self.interactor.get_details(
+            GetPrivateConsumptionDetailsInteractor.Request(
+                consumption_id=uuid4(),
+                member=member,
+            )
+        )
+        assert response is None
+
+    def test_that_response_is_returned_for_own_plan_consumption(self) -> None:
+        member = self.member_generator.create_member()
+        plan = self.plan_generator.create_plan(
+            product_name="My Product",
+            description="A description",
+        )
+        self.consumption_generator.create_private_consumption(
+            consumer=member, plan=plan, amount=2
+        )
+        consumption_id = self._get_only_private_consumption_id()
+        response = self.interactor.get_details(
+            GetPrivateConsumptionDetailsInteractor.Request(
+                consumption_id=consumption_id,
+                member=member,
+            )
+        )
+        assert response is not None
+        assert response.plan_id == plan
+        assert response.plan_name == "My Product"
+        assert response.plan_description == "A description"
+        assert response.amount == 2
+
+    def test_that_paid_price_per_unit_is_total_divided_by_amount(self) -> None:
+        member = self.member_generator.create_member()
+        plan = self.plan_generator.create_plan()
+        self.consumption_generator.create_private_consumption(
+            consumer=member, plan=plan, amount=4
+        )
+        consumption_id = self._get_only_private_consumption_id()
+        response = self.interactor.get_details(
+            GetPrivateConsumptionDetailsInteractor.Request(
+                consumption_id=consumption_id,
+                member=member,
+            )
+        )
+        assert response is not None
+        assert response.paid_price_per_unit == response.paid_price_total / Decimal(4)
+
+    def test_that_none_is_returned_when_a_different_member_requests_the_consumption(
+        self,
+    ) -> None:
+        owner = self.member_generator.create_member()
+        other = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=owner)
+        consumption_id = self._get_only_private_consumption_id()
+        response = self.interactor.get_details(
+            GetPrivateConsumptionDetailsInteractor.Request(
+                consumption_id=consumption_id,
+                member=other,
+            )
+        )
+        assert response is None
+
+    def test_that_none_is_returned_for_a_basic_service_consumption_id(self) -> None:
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        bs_consumption = (
+            self.database_gateway.get_private_consumptions_of_basic_service().first()
+        )
+        assert bs_consumption
+        response = self.interactor.get_details(
+            GetPrivateConsumptionDetailsInteractor.Request(
+                consumption_id=bs_consumption.id,
+                member=member,
+            )
+        )
+        assert response is None
+
+    def _get_only_private_consumption_id(self) -> UUID:
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        return consumption.id

--- a/tests/interactors/test_query_private_consumptions.py
+++ b/tests/interactors/test_query_private_consumptions.py
@@ -1,8 +1,10 @@
 from datetime import timedelta
+from decimal import Decimal
 
 from tests.datetime_service import datetime_utc
 from tests.interactors.base_test_case import BaseTestCase
 from workers_control.core.interactors.query_private_consumptions import (
+    ConsumptionType,
     QueryPrivateConsumptions,
     Request,
 )
@@ -22,7 +24,7 @@ class TestQueryPrivateConsumptions(BaseTestCase):
         assert not response.consumptions
 
     def test_that_correct_consumptions_are_returned(self) -> None:
-        expected_plan = self.plan_generator.create_plan()
+        expected_plan = self.plan_generator.create_plan(product_name="my product")
         member = self.member_generator.create_member()
         self.consumption_generator.create_private_consumption(
             consumer=member, plan=expected_plan
@@ -31,12 +33,65 @@ class TestQueryPrivateConsumptions(BaseTestCase):
             Request(member=member)
         )
         assert len(response.consumptions) == 1
-        assert response.consumptions[0].plan_id == expected_plan
+        assert response.consumptions[0].name == "my product"
+
+    def test_that_plan_consumption_has_consumption_type_plan(self) -> None:
+        plan = self.plan_generator.create_plan()
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(
+            consumer=member, plan=plan
+        )
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert response.consumptions[0].consumption_type == ConsumptionType.plan
+
+    def test_that_basic_service_consumption_is_returned(self) -> None:
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member, amount=Decimal("3")
+        )
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert len(response.consumptions) == 1
+        consumption = response.consumptions[0]
+        assert consumption.consumption_type == ConsumptionType.basic_service
+        assert consumption.paid_price_total == Decimal("3")
+
+    def test_that_basic_service_consumption_includes_name_and_description_of_basic_service(
+        self,
+    ) -> None:
+        bs = self.basic_service_generator.create_basic_service(
+            name="My Service", description="My service description"
+        )
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member, basic_service=bs
+        )
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert response.consumptions[0].name == "My Service"
+        assert response.consumptions[0].description == "My service description"
+
+    def test_that_plan_and_basic_service_consumptions_are_both_returned(self) -> None:
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert len(response.consumptions) == 2
+        types = {c.consumption_type for c in response.consumptions}
+        assert types == {ConsumptionType.plan, ConsumptionType.basic_service}
 
     def test_that_consumptions_are_returned_in_correct_order(self) -> None:
         self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
-        first_plan = self.plan_generator.create_plan()
-        second_plan = self.plan_generator.create_plan()
+        first_plan = self.plan_generator.create_plan(product_name="first")
+        second_plan = self.plan_generator.create_plan(product_name="second")
         member = self.member_generator.create_member()
         self.consumption_generator.create_private_consumption(
             consumer=member, plan=first_plan
@@ -48,5 +103,21 @@ class TestQueryPrivateConsumptions(BaseTestCase):
         response = self.query_consumptions.query_private_consumptions(
             Request(member=member)
         )
-        assert response.consumptions[0].plan_id == second_plan
-        assert response.consumptions[1].plan_id == first_plan
+        assert response.consumptions[0].name == "second"
+        assert response.consumptions[1].name == "first"
+
+    def test_that_mixed_consumptions_are_ordered_by_date_descending(self) -> None:
+        self.datetime_service.freeze_time(datetime_utc(2000, 1, 1))
+        member = self.member_generator.create_member()
+        self.consumption_generator.create_private_consumption(consumer=member)
+        self.datetime_service.advance_time(timedelta(days=1))
+        self.consumption_generator.create_private_consumption_of_basic_service(
+            consumer=member
+        )
+        response = self.query_consumptions.query_private_consumptions(
+            Request(member=member)
+        )
+        assert (
+            response.consumptions[0].consumption_type == ConsumptionType.basic_service
+        )
+        assert response.consumptions[1].consumption_type == ConsumptionType.plan

--- a/tests/interactors/test_register_private_consumption.py
+++ b/tests/interactors/test_register_private_consumption.py
@@ -248,17 +248,15 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         self.register_private_consumption.register_private_consumption(
             self.make_request(plan, pieces)
         )
-        response = self.query_private_consumptions.query_private_consumptions(
-            query_private_consumptions.Request(member=self.consumer)
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        assert consumption.plan_id == plan
+        assert consumption.amount == pieces
+        transfers = self.get_private_consumption_transfers()
+        assert len(transfers) == 1
+        assert transfers[0].value / pieces == self.price_checker.get_price_per_unit(
+            plan
         )
-        assert len(response.consumptions) == 1
-        latest_consumption = response.consumptions[0]
-        assert (
-            latest_consumption.paid_price_per_unit
-            == self.price_checker.get_price_per_unit(plan)
-        )
-        assert latest_consumption.amount == pieces
-        assert latest_consumption.plan_id == plan
 
     def test_correct_consumption_is_added_when_plan_is_public_service(self) -> None:
         plan = self.plan_generator.create_plan(is_public_service=True)
@@ -266,13 +264,12 @@ class RegisterPrivateConsumptionTests(RegisterPrivateConsumptionBase):
         self.register_private_consumption.register_private_consumption(
             self.make_request(plan, pieces)
         )
-        response = self.query_private_consumptions.query_private_consumptions(
-            query_private_consumptions.Request(member=self.consumer)
-        )
-        assert len(response.consumptions) == 1
-        latest_consumption = response.consumptions[0]
-        assert latest_consumption.paid_price_per_unit == Decimal(0)
-        assert latest_consumption.plan_id == plan
+        consumption = self.database_gateway.get_private_consumptions().first()
+        assert consumption
+        assert consumption.plan_id == plan
+        transfers = self.get_private_consumption_transfers()
+        assert len(transfers) == 1
+        assert transfers[0].value == Decimal(0)
 
     def make_request(
         self, plan: UUID, amount: int, consumer: Optional[UUID] = None

--- a/tests/web/www/controllers/test_get_private_consumption_details_controller.py
+++ b/tests/web/www/controllers/test_get_private_consumption_details_controller.py
@@ -1,0 +1,29 @@
+from uuid import uuid4
+
+from tests.web.base_test_case import BaseTestCase
+from workers_control.web.www.controllers.get_private_consumption_details_controller import (
+    GetPrivateConsumptionDetailsController,
+)
+
+
+class ControllerTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.controller = self.injector.get(GetPrivateConsumptionDetailsController)
+
+    def test_request_contains_consumption_id_passed_in(self) -> None:
+        self.session.login_member(uuid4())
+        expected_consumption_id = uuid4()
+        request = self.controller.create_request(consumption_id=expected_consumption_id)
+        assert request.consumption_id == expected_consumption_id
+
+    def test_request_contains_logged_in_member_id(self) -> None:
+        expected_member_id = uuid4()
+        self.session.login_member(expected_member_id)
+        request = self.controller.create_request(consumption_id=uuid4())
+        assert request.member == expected_member_id
+
+    def test_assertion_error_is_raised_when_no_user_is_logged_in(self) -> None:
+        self.session.logout()
+        with self.assertRaises(AssertionError):
+            self.controller.create_request(consumption_id=uuid4())

--- a/tests/web/www/presenters/test_private_consumption_details_presenter.py
+++ b/tests/web/www/presenters/test_private_consumption_details_presenter.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+from tests.datetime_service import datetime_utc
+from tests.web.base_test_case import BaseTestCase
+from workers_control.core.interactors.get_private_consumption_details import (
+    GetPrivateConsumptionDetailsInteractor,
+)
+from workers_control.web.session import UserRole
+from workers_control.web.www.presenters.private_consumption_details_presenter import (
+    PrivateConsumptionDetailsPresenter,
+)
+
+
+class PresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(PrivateConsumptionDetailsPresenter)
+
+    def test_that_date_is_formatted_properly(self) -> None:
+        response = self._response(consumption_date=datetime_utc(2000, 1, 1))
+        view_model = self.presenter.present(response)
+        self.assertEqual(
+            view_model.consumption_date,
+            self.datetime_formatter.format_datetime(
+                datetime_utc(2000, 1, 1),
+                fmt="%d.%m.%Y",
+            ),
+        )
+
+    def test_that_plan_name_and_description_are_passed_through(self) -> None:
+        response = self._response(plan_name="Bread", plan_description="Tasty")
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.plan_name, "Bread")
+        self.assertEqual(view_model.plan_description, "Tasty")
+
+    def test_that_amount_is_formatted_as_string(self) -> None:
+        response = self._response(amount=5)
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.amount, "5")
+
+    def test_that_price_per_unit_is_formatted_as_rounded_string(self) -> None:
+        response = self._response(paid_price_per_unit=Decimal("2.5"))
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.price_per_unit, "2.50")
+
+    def test_that_price_total_is_formatted_as_rounded_string(self) -> None:
+        response = self._response(paid_price_total=Decimal("12"))
+        view_model = self.presenter.present(response)
+        self.assertEqual(view_model.price_total, "12.00")
+
+    def test_that_plan_details_url_points_to_member_plan_details_view(self) -> None:
+        plan_id = uuid4()
+        response = self._response(plan_id=plan_id)
+        view_model = self.presenter.present(response)
+        self.assertEqual(
+            view_model.plan_details_url,
+            self.url_index.get_plan_details_url(
+                user_role=UserRole.member, plan_id=plan_id
+            ),
+        )
+
+    def _response(
+        self,
+        consumption_date: datetime = datetime_utc(2020, 1, 1),
+        plan_id: UUID = uuid4(),
+        plan_name: str = "Some product",
+        plan_description: str = "Some description",
+        amount: int = 1,
+        paid_price_per_unit: Decimal = Decimal("1"),
+        paid_price_total: Decimal = Decimal("1"),
+    ) -> GetPrivateConsumptionDetailsInteractor.Response:
+        return GetPrivateConsumptionDetailsInteractor.Response(
+            consumption_date=consumption_date,
+            plan_id=plan_id,
+            plan_name=plan_name,
+            plan_description=plan_description,
+            amount=amount,
+            paid_price_per_unit=paid_price_per_unit,
+            paid_price_total=paid_price_total,
+        )

--- a/tests/web/www/presenters/test_private_consumptions_presenter.py
+++ b/tests/web/www/presenters/test_private_consumptions_presenter.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from tests.datetime_service import datetime_utc
 from tests.web.base_test_case import BaseTestCase
@@ -16,7 +16,7 @@ class PresenterTests(BaseTestCase):
         self.presenter = self.injector.get(PrivateConsumptionsPresenter)
 
     def test_that_date_is_formatted_properly(self) -> None:
-        response = self.create_response_with_one_consumption(
+        response = self._response_with_plan_consumption(
             consumption_timestamp=datetime_utc(2000, 1, 1)
         )
         view_model = self.presenter.present_private_consumptions(response)
@@ -28,19 +28,92 @@ class PresenterTests(BaseTestCase):
             ),
         )
 
-    def create_response_with_one_consumption(
-        self, consumption_timestamp: datetime = datetime_utc(2020, 1, 1)
+    def test_that_plan_consumption_type_is_translated_as_plan(self) -> None:
+        response = self._response_with_plan_consumption()
+        view_model = self.presenter.present_private_consumptions(response)
+        self.assertEqual(
+            view_model.consumptions[0].consumption_type,
+            self.translator.gettext("Plan"),
+        )
+
+    def test_that_basic_service_consumption_type_is_translated(self) -> None:
+        response = self._response_with_basic_service_consumption()
+        view_model = self.presenter.present_private_consumptions(response)
+        self.assertEqual(
+            view_model.consumptions[0].consumption_type,
+            self.translator.gettext("Basic service"),
+        )
+
+    def test_that_basic_service_consumption_shows_paid_price_total_as_rounded_hours_paid(
+        self,
+    ) -> None:
+        response = self._response_with_basic_service_consumption(
+            price_total=Decimal("3")
+        )
+        view_model = self.presenter.present_private_consumptions(response)
+        self.assertEqual(view_model.consumptions[0].hours_paid, "3.00")
+
+    def test_that_basic_service_consumption_uses_basic_service_name_and_description(
+        self,
+    ) -> None:
+        response = self._response_with_basic_service_consumption(
+            name="My Service", description="A nice service"
+        )
+        view_model = self.presenter.present_private_consumptions(response)
+        consumption = view_model.consumptions[0]
+        self.assertEqual(consumption.name, "My Service")
+        self.assertEqual(consumption.description, "A nice service")
+
+    def test_that_plan_consumption_has_a_details_url(self) -> None:
+        consumption_id = uuid4()
+        response = self._response_with_plan_consumption(consumption_id=consumption_id)
+        view_model = self.presenter.present_private_consumptions(response)
+        self.assertEqual(
+            view_model.consumptions[0].details_url,
+            self.url_index.get_my_private_consumption_details_url(
+                consumption_id=consumption_id
+            ),
+        )
+
+    def test_that_basic_service_consumption_has_no_details_url(self) -> None:
+        response = self._response_with_basic_service_consumption()
+        view_model = self.presenter.present_private_consumptions(response)
+        self.assertIsNone(view_model.consumptions[0].details_url)
+
+    def _response_with_plan_consumption(
+        self,
+        consumption_timestamp: datetime = datetime_utc(2020, 1, 1),
+        consumption_id: UUID = uuid4(),
     ) -> interactor.Response:
         return interactor.Response(
             consumptions=[
                 interactor.Consumption(
+                    id=consumption_id,
+                    consumption_type=interactor.ConsumptionType.plan,
                     consumption_date=consumption_timestamp,
-                    plan_id=uuid4(),
-                    product_name="test product",
-                    product_description="test product description",
-                    paid_price_per_unit=Decimal("1"),
-                    amount=1,
+                    name="test product",
+                    description="test product description",
                     paid_price_total=Decimal("1"),
+                )
+            ]
+        )
+
+    def _response_with_basic_service_consumption(
+        self,
+        consumption_timestamp: datetime = datetime_utc(2020, 1, 1),
+        price_total: Decimal = Decimal("1"),
+        name: str = "Some Service",
+        description: str = "A description",
+    ) -> interactor.Response:
+        return interactor.Response(
+            consumptions=[
+                interactor.Consumption(
+                    id=uuid4(),
+                    consumption_type=interactor.ConsumptionType.basic_service,
+                    consumption_date=consumption_timestamp,
+                    name=name,
+                    description=description,
+                    paid_price_total=price_total,
                 )
             ]
         )

--- a/tests/web/www/presenters/test_register_private_consumption_of_basic_service_presenter.py
+++ b/tests/web/www/presenters/test_register_private_consumption_of_basic_service_presenter.py
@@ -43,7 +43,7 @@ class RegisterPrivateConsumptionOfBasicServicePresenterTests(BaseTestCase):
             request=FakeRequest(),
         )
         assert isinstance(view_model, Redirect)
-        assert view_model.url == self.url_index.get_query_offers_url()
+        assert view_model.url == self.url_index.get_my_private_consumptions_url()
 
     @parameterized.expand([(reason,) for reason in RejectionReason])
     def test_rejection_results_in_render_form(self, reason: RejectionReason) -> None:

--- a/tests/web/www/presenters/url_index.py
+++ b/tests/web/www/presenters/url_index.py
@@ -78,6 +78,7 @@ class UrlIndexTestImpl:
     get_query_companies_url = UrlIndexMethod()
     get_query_offers_url = UrlIndexMethod()
     get_my_private_consumptions_url = UrlIndexMethod()
+    get_my_private_consumption_details_url = UrlIndexMethod()
     get_register_hours_worked_url = UrlIndexMethod()
     get_registered_hours_worked_url = UrlIndexMethod()
     get_register_private_consumption_url = UrlIndexMethod()


### PR DESCRIPTION
In order to make the list of member consumptions clearer, a consumption details view has been created that provides information on plan consumptions.

A new db table has been added (PrivateConsumptionOfBasicService) to connect consumption transfers with its corresponding basic service.

fixes #1450 