### PR TITLE
Commit when writing mails to outbox

### DIFF
--- a/src/workers_control/flask/routes/auth/routes.py
+++ b/src/workers_control/flask/routes/auth/routes.py
@@ -143,6 +143,7 @@ def login_member(
 
 @auth.route("/member/resend")
 @with_injection()
+@commit_changes
 @login_required
 def resend_confirmation_member(
     interactor: ResendConfirmationMailInteractor,
@@ -235,6 +236,7 @@ def confirm_email_company(
 
 @auth.route("/company/resend")
 @with_injection()
+@commit_changes
 @login_required
 def resend_confirmation_company(
     interactor: ResendConfirmationMailInteractor, flask_session: FlaskSession

--- a/src/workers_control/flask/routes/user/routes.py
+++ b/src/workers_control/flask/routes/user/routes.py
@@ -13,6 +13,7 @@ from workers_control.core.interactors.get_user_account_details import (
 from workers_control.core.interactors.request_email_address_change import (
     RequestEmailAddressChangeInteractor,
 )
+from workers_control.db import commit_changes
 from workers_control.flask.class_based_view import as_flask_view
 from workers_control.flask.forms import RequestEmailAddressChangeForm
 from workers_control.flask.types import Response
@@ -99,6 +100,7 @@ def company_summary(
 
 
 @AuthenticatedUserRoute("/request-email-change", methods=["GET", "POST"])
+@commit_changes
 def request_email_change(
     controller: RequestEmailAddressChangeController,
     presenter: RequestEmailAddressChangePresenter,

--- a/tests/flask_integration/test_request_email_change_view.py
+++ b/tests/flask_integration/test_request_email_change_view.py
@@ -168,6 +168,26 @@ class SentEmailTestsWithoutAdminMailInConfig(SentEmailTestCase):
             assert new_email in recipients
 
 
+class OutboxPersistenceTests(ViewTestCase):
+    def test_email_rows_are_committed_to_outbox(self) -> None:
+        password = "123_pw"
+        self.login_member(password=password)
+        emails_before = len(list(self.database_gateway.get_emails()))
+        response = self.client.post(
+            URL,
+            data={
+                "new_email": "new_email@test.test",
+                "current_password": password,
+            },
+        )
+        assert response.status_code == 302
+        # Discard uncommitted state so we only see rows the request actually
+        # committed.
+        self.db.session.rollback()
+        emails_after = len(list(self.database_gateway.get_emails()))
+        assert emails_after - emails_before == 2
+
+
 class SentEmailTestsWithAdminMailInConfig(SentEmailTestCase):
     @property
     def expected_admin_mail(self) -> str:

--- a/tests/flask_integration/test_resend_confirmation_view.py
+++ b/tests/flask_integration/test_resend_confirmation_view.py
@@ -63,3 +63,19 @@ class ConfirmedMemberTests(ViewTestCase):
             )
             self.assertEqual(response.status_code, 302)
             assert len(outbox) == 0
+
+
+class OutboxPersistenceTests(ViewTestCase):
+    def test_member_resend_commits_email_row_to_outbox(self) -> None:
+        self.login_member(confirm_member=False)
+        self.client.get("/member/resend")
+        # Discard uncommitted state so we only see rows the request actually
+        # committed.
+        self.db.session.rollback()
+        assert self.database_gateway.get_emails().first() is not None
+
+    def test_company_resend_commits_email_row_to_outbox(self) -> None:
+        self.login_company(confirm_company=False)
+        self.client.get("/company/resend")
+        self.db.session.rollback()
+        assert self.database_gateway.get_emails().first() is not None


### PR DESCRIPTION
Before this change some mails (request email change, resend company and member confirmation mail) where not actually commited to the database. This bug was introduced recently when replacing the SMTP mail service with the outbox mail service.