### PR TITLE
Split GET/POST for mail-triggering routes

### DIFF
--- a/src/workers_control/flask/routes/auth/routes.py
+++ b/src/workers_control/flask/routes/auth/routes.py
@@ -17,9 +17,6 @@ from workers_control.core.interactors.confirm_member import ConfirmMemberInterac
 from workers_control.core.interactors.log_in_accountant import LogInAccountantInteractor
 from workers_control.core.interactors.log_in_company import LogInCompanyInteractor
 from workers_control.core.interactors.log_in_member import LogInMemberInteractor
-from workers_control.core.interactors.resend_confirmation_mail import (
-    ResendConfirmationMailInteractor,
-)
 from workers_control.db import commit_changes
 from workers_control.flask.class_based_view import as_flask_view
 from workers_control.flask.dependency_injection import with_injection
@@ -28,6 +25,10 @@ from workers_control.flask.forms import LoginForm
 from workers_control.flask.types import Response
 from workers_control.flask.views.request_password_reset_view import (
     RequestPasswordResetView,
+)
+from workers_control.flask.views.resend_confirmation_view import (
+    ResendConfirmationCompanyView,
+    ResendConfirmationMemberView,
 )
 from workers_control.flask.views.reset_password_view import ResetPasswordView
 from workers_control.flask.views.signup_accountant_view import SignupAccountantView
@@ -141,23 +142,10 @@ def login_member(
     return render_template("auth/login_member.html", form=login_form)
 
 
-@auth.route("/member/resend")
-@with_injection()
-@commit_changes
+@auth.route("/member/resend", methods=["POST"])
 @login_required
-def resend_confirmation_member(
-    interactor: ResendConfirmationMailInteractor,
-    session: FlaskSession,
-):
-    current_user = session.get_current_user()
-    assert current_user
-    request = interactor.Request(user=current_user)
-    response = interactor.resend_confirmation_mail(request)
-    if response.is_token_sent:
-        flash("Eine neue Bestätigungsmail wurde gesendet.")
-    else:
-        flash("Bestätigungsmail konnte nicht gesendet werden!")
-    return redirect(url_for("auth.unconfirmed_member"))
+@as_flask_view()
+class resend_confirmation_member(ResendConfirmationMemberView): ...
 
 
 @auth.route("/company/unconfirmed")
@@ -234,22 +222,10 @@ def confirm_email_company(
     return redirect(url_for("auth.unconfirmed_company"))
 
 
-@auth.route("/company/resend")
-@with_injection()
-@commit_changes
+@auth.route("/company/resend", methods=["POST"])
 @login_required
-def resend_confirmation_company(
-    interactor: ResendConfirmationMailInteractor, flask_session: FlaskSession
-):
-    current_user = flask_session.get_current_user()
-    assert current_user
-    request = interactor.Request(user=current_user)
-    response = interactor.resend_confirmation_mail(request)
-    if response.is_token_sent:
-        flash("Eine neue Bestätigungsmail wurde gesendet.")
-    else:
-        flash("Bestätigungsmail konnte nicht gesendet werden!")
-    return redirect(url_for("auth.unconfirmed_company"))
+@as_flask_view()
+class resend_confirmation_company(ResendConfirmationCompanyView): ...
 
 
 @auth.route("/accountant/signup/<token>", methods=["GET", "POST"])

--- a/src/workers_control/flask/routes/user/routes.py
+++ b/src/workers_control/flask/routes/user/routes.py
@@ -1,7 +1,6 @@
 from uuid import UUID
 
-from flask import Response as FlaskResponse
-from flask import redirect, render_template, request
+from flask import render_template
 
 from workers_control.core.interactors.get_company_summary import (
     GetCompanySummaryInteractor,
@@ -10,12 +9,7 @@ from workers_control.core.interactors.get_company_summary import (
 from workers_control.core.interactors.get_user_account_details import (
     GetUserAccountDetailsInteractor,
 )
-from workers_control.core.interactors.request_email_address_change import (
-    RequestEmailAddressChangeInteractor,
-)
-from workers_control.db import commit_changes
 from workers_control.flask.class_based_view import as_flask_view
-from workers_control.flask.forms import RequestEmailAddressChangeForm
 from workers_control.flask.types import Response
 from workers_control.flask.views import QueryCompaniesView, QueryOffersView
 from workers_control.flask.views.change_email_address_view import ChangeEmailAddressView
@@ -29,6 +23,9 @@ from workers_control.flask.views.list_coordinators_of_cooperation_view import (
     ListCoordinationsOfCooperationView,
 )
 from workers_control.flask.views.list_transfers import ListTransfersView
+from workers_control.flask.views.request_email_address_change_view import (
+    RequestEmailAddressChangeView,
+)
 from workers_control.flask.views.show_a_account_details_view import (
     ShowAAccountDetailsView,
 )
@@ -51,17 +48,11 @@ from workers_control.flask.views.show_psf_account_details_view import (
 from workers_control.flask.views.show_r_account_details_view import (
     ShowRAccountDetailsView,
 )
-from workers_control.web.www.controllers.request_email_address_change_controller import (
-    RequestEmailAddressChangeController,
-)
 from workers_control.web.www.controllers.user_account_details_controller import (
     UserAccountDetailsController,
 )
 from workers_control.web.www.presenters.get_company_summary_presenter import (
     GetCompanySummarySuccessPresenter,
-)
-from workers_control.web.www.presenters.request_email_address_change_presenter import (
-    RequestEmailAddressChangePresenter,
 )
 from workers_control.web.www.presenters.user_account_details_presenter import (
     UserAccountDetailsPresenter,
@@ -100,31 +91,8 @@ def company_summary(
 
 
 @AuthenticatedUserRoute("/request-email-change", methods=["GET", "POST"])
-@commit_changes
-def request_email_change(
-    controller: RequestEmailAddressChangeController,
-    presenter: RequestEmailAddressChangePresenter,
-    interactor: RequestEmailAddressChangeInteractor,
-) -> Response:
-    template_name = "user/request_email_address_change.html"
-    form = RequestEmailAddressChangeForm(request.form)
-    match request.method:
-        case "POST":
-            if not form.validate():
-                return FlaskResponse(
-                    render_template(template_name, form=form), status=400
-                )
-            uc_request = controller.process_email_address_change_request(form)
-            uc_response = interactor.request_email_address_change(uc_request)
-            view_model = presenter.render_response(uc_response, form)
-            if view_model.redirect_url:
-                return redirect(view_model.redirect_url)
-            else:
-                return FlaskResponse(
-                    render_template(template_name, form=form), status=400
-                )
-        case _:
-            return FlaskResponse(render_template(template_name, form=form), status=200)
+@as_flask_view()
+class request_email_change(RequestEmailAddressChangeView): ...
 
 
 @AuthenticatedUserRoute("/change-email/<token>", methods=["GET", "POST"])

--- a/src/workers_control/flask/templates/auth/unconfirmed_company.html
+++ b/src/workers_control/flask/templates/auth/unconfirmed_company.html
@@ -15,8 +15,11 @@
         <br>
         <p>{{ gettext("Please confirm your account.") }}<br>
             {{ gettext("Check your mailbox (and your spam folder) - you should have received an email with a confirmation link.") }}</p>
-        <p>{{ gettext("You did not get an email?") }} <a href="{{ url_for('auth.resend_confirmation_company') }}">{{
-                gettext("Resend mail") }}</a>.
+        <p>{{ gettext("You did not get an email?") }}
+            <form action="{{ url_for('auth.resend_confirmation_company') }}" method="POST" style="display:inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="button is-text">{{ gettext("Resend mail") }}</button>
+            </form>.
         </p>
     </div>
 </div>

--- a/src/workers_control/flask/templates/auth/unconfirmed_member.html
+++ b/src/workers_control/flask/templates/auth/unconfirmed_member.html
@@ -13,8 +13,11 @@
         <h1>{{ gettext("Welcome!") }}</h1>
         <br>
         <p>{{ gettext("Please confirm your account.") }}<br>{{ gettext("Check your mailbox (and your spam folder) - you should have received an email with a confirmation link.") }}</p>
-        <p>{{ gettext("You did not get an email?") }} <a href="{{ url_for('auth.resend_confirmation_member') }}">{{
-                gettext("Resend mail") }}</a>.
+        <p>{{ gettext("You did not get an email?") }}
+            <form action="{{ url_for('auth.resend_confirmation_member') }}" method="POST" style="display:inline">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <button type="submit" class="button is-text">{{ gettext("Resend mail") }}</button>
+            </form>.
         </p>
     </div>
 </div>

--- a/src/workers_control/flask/views/request_email_address_change_view.py
+++ b/src/workers_control/flask/views/request_email_address_change_view.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+
+from flask import Response as FlaskResponse
+from flask import redirect, render_template, request
+
+from workers_control.core.interactors.request_email_address_change import (
+    RequestEmailAddressChangeInteractor,
+)
+from workers_control.db import commit_changes
+from workers_control.flask.forms import RequestEmailAddressChangeForm
+from workers_control.flask.types import Response
+from workers_control.web.www.controllers.request_email_address_change_controller import (
+    RequestEmailAddressChangeController,
+)
+from workers_control.web.www.presenters.request_email_address_change_presenter import (
+    RequestEmailAddressChangePresenter,
+)
+
+TEMPLATE_NAME = "user/request_email_address_change.html"
+
+
+@dataclass
+class RequestEmailAddressChangeView:
+    controller: RequestEmailAddressChangeController
+    presenter: RequestEmailAddressChangePresenter
+    interactor: RequestEmailAddressChangeInteractor
+
+    def GET(self) -> Response:
+        form = RequestEmailAddressChangeForm(request.form)
+        return FlaskResponse(render_template(TEMPLATE_NAME, form=form), status=200)
+
+    @commit_changes
+    def POST(self) -> Response:
+        form = RequestEmailAddressChangeForm(request.form)
+        if not form.validate():
+            return FlaskResponse(render_template(TEMPLATE_NAME, form=form), status=400)
+        uc_request = self.controller.process_email_address_change_request(form)
+        uc_response = self.interactor.request_email_address_change(uc_request)
+        view_model = self.presenter.render_response(uc_response, form)
+        if view_model.redirect_url:
+            return redirect(view_model.redirect_url)
+        return FlaskResponse(render_template(TEMPLATE_NAME, form=form), status=400)

--- a/src/workers_control/flask/views/resend_confirmation_view.py
+++ b/src/workers_control/flask/views/resend_confirmation_view.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import ClassVar
+
+from flask import flash, redirect, url_for
+
+from workers_control.core.interactors.resend_confirmation_mail import (
+    ResendConfirmationMailInteractor,
+)
+from workers_control.db import commit_changes
+from workers_control.flask.flask_session import FlaskSession
+from workers_control.flask.types import Response
+
+
+@dataclass
+class _ResendConfirmationView:
+    interactor: ResendConfirmationMailInteractor
+    session: FlaskSession
+
+    redirect_endpoint: ClassVar[str]
+
+    @commit_changes
+    def POST(self) -> Response:
+        current_user = self.session.get_current_user()
+        assert current_user
+        response = self.interactor.resend_confirmation_mail(
+            self.interactor.Request(user=current_user)
+        )
+        if response.is_token_sent:
+            flash("Eine neue Bestätigungsmail wurde gesendet.")
+        else:
+            flash("Bestätigungsmail konnte nicht gesendet werden!")
+        return redirect(url_for(self.redirect_endpoint))
+
+
+class ResendConfirmationMemberView(_ResendConfirmationView):
+    redirect_endpoint = "auth.unconfirmed_member"
+
+
+class ResendConfirmationCompanyView(_ResendConfirmationView):
+    redirect_endpoint = "auth.unconfirmed_company"

--- a/tests/flask_integration/test_resend_confirmation_view.py
+++ b/tests/flask_integration/test_resend_confirmation_view.py
@@ -18,15 +18,20 @@ class AuthTests(ViewTestCase):
             (LogInUser.member, 302),
         ]
     )
-    def test_correct_status_codes_on_get_requests(
+    def test_correct_status_codes_on_post_requests(
         self, login: Optional[LogInUser], expected_code: int
     ) -> None:
         self.assert_response_has_expected_code(
             url=self.url,
-            method="get",
+            method="post",
             login=login,
             expected_code=expected_code,
         )
+
+    def test_get_returns_405_because_route_only_accepts_post(self) -> None:
+        self.login_member(confirm_member=False)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, 405)
 
 
 class AuthenticatedButUnconfirmedMemberTests(ViewTestCase):
@@ -38,11 +43,8 @@ class AuthenticatedButUnconfirmedMemberTests(ViewTestCase):
     def test_authenticated_and_unconfirmed_users_get_redirected_and_mail_gets_send(
         self,
     ) -> None:
-        response = self.client.get(self.url)
         with self.email_service.record_messages() as outbox:
-            response = self.client.get(
-                self.url,
-            )
+            response = self.client.post(self.url)
             self.assertEqual(response.status_code, 302)
             assert len(outbox) == 1
 
@@ -56,11 +58,8 @@ class ConfirmedMemberTests(ViewTestCase):
     def test_already_confirmed_member_gets_redirected_and_no_mail_gets_sent(
         self,
     ) -> None:
-        response = self.client.get(self.url)
         with self.email_service.record_messages() as outbox:
-            response = self.client.get(
-                self.url,
-            )
+            response = self.client.post(self.url)
             self.assertEqual(response.status_code, 302)
             assert len(outbox) == 0
 
@@ -68,7 +67,7 @@ class ConfirmedMemberTests(ViewTestCase):
 class OutboxPersistenceTests(ViewTestCase):
     def test_member_resend_commits_email_row_to_outbox(self) -> None:
         self.login_member(confirm_member=False)
-        self.client.get("/member/resend")
+        self.client.post("/member/resend")
         # Discard uncommitted state so we only see rows the request actually
         # committed.
         self.db.session.rollback()
@@ -76,6 +75,6 @@ class OutboxPersistenceTests(ViewTestCase):
 
     def test_company_resend_commits_email_row_to_outbox(self) -> None:
         self.login_company(confirm_company=False)
-        self.client.get("/company/resend")
+        self.client.post("/company/resend")
         self.db.session.rollback()
         assert self.database_gateway.get_emails().first() is not None


### PR DESCRIPTION
Refactor /request-email-change and the /member,company/resend routes into class-based views so @commit_changes wraps only the POST method. The resend routes become POST-only; their templates use a small form instead of an <a href> link.