### PR TITLE
Add verification of doc generation to run-checks script

### DIFF
--- a/run-checks
+++ b/run-checks
@@ -14,6 +14,10 @@ def main():
     run_check_command(["flake8"])
     run_check_command(["mypy"])
     run_check_command(["isort", "--check"] + autoformatted_paths)
+    run_check_command(["python", "docs/generate_docs.py"])
+    run_check_command(
+        ["git", "diff", "--exit-code", "--", "docs/config_options_GENERATED.rst"]
+    )
     if configuration.is_unittests_requested:
         run_check_command(["pytest"])
 


### PR DESCRIPTION
After this change checks fail when flask options have been changed but docs have not been generated by developer.