### PR TITLE
Automate publishing to PyPi

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,47 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Verify tag matches pyproject version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          version="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [ "$tag" != "$version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match pyproject version $version" >&2
+            exit 1
+          fi
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          twine check dist/*
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write          # required for Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/maintenance.rst
+++ b/docs/maintenance.rst
@@ -51,5 +51,19 @@ Maintainers regularly release new versions of the app. Procedure:
 #. Create a Pull Request with label "release". This will trigger integration tests against
    the `deployment repo <https://github.com/ida-arbeitszeit/workers-control-deployment>`_.
    On failure, fix current branch or deployment repo.
-#. After merging: tag the ``master`` branch (scheme: ``git tag v1.2.3 -m "Release version 1.2.3"``) and push the tag.
-#. Create sdist and wheel via ``python -m build`` and upload to PyPi with twine: ``twine upload dist/*``.
+#. After merging: create a new git tag (scheme: ``git tag v1.2.3 -m "Release version 1.2.3"``) and push the tag. 
+   Pushing the ``vX.Y.Z`` tag triggers the ``publish-pypi.yml`` GitHub Actions workflow,
+   which builds the sdist and wheel and uploads them to PyPi.
+
+
+One-time PyPI release setup
+...........................
+
+Automated publishing uses `PyPI Trusted Publishing
+<https://docs.pypi.org/trusted-publishers/>`_ (OIDC). Configure once by a maintainer:
+
+#. On PyPi, open the ``workers-control`` project and add a new
+   GitHub trusted publisher with: Owner ``ida-arbeitszeit``, Repository
+   ``workers-control``, Workflow ``publish-pypi.yml``.
+#. On Github, restrict who can create the triggering tag: add a repository ruleset 
+   targeting tags matching ``v*`` and a bypass list limited to maintainers/admins.


### PR DESCRIPTION
This commit enables automated publishing of our app on PyPi by adding a workflow file, "publish-pypi.yml". Maintainers can trigger the workflow by pushing a tag with a new version number ("vX.Y.Z").