### PR TITLE
Replace PlanReview with PlanRejection model & Reset migration test db properly

### DIFF
--- a/src/workers_control/core/interactors/reject_plan.py
+++ b/src/workers_control/core/interactors/reject_plan.py
@@ -34,7 +34,7 @@ class RejectPlanInteractor:
         assert planner
         if plan.is_rejected:
             return self.Response(is_plan_rejected=False)
-        matching_plans.update().set_rejection_date(now).perform()
+        self.database_gateway.create_plan_rejection(plan_id=plan.id, date=now)
         email_address_from_planner = (
             self.database_gateway.get_email_addresses()
             .that_belong_to_company(planner.id)

--- a/src/workers_control/core/records.py
+++ b/src/workers_control/core/records.py
@@ -245,6 +245,13 @@ class PlanApproval:
     transfer_of_credit_a: UUID
 
 
+@dataclass
+class PlanRejection:
+    id: UUID
+    plan_id: UUID
+    date: datetime
+
+
 class ConsumptionType(Enum):
     means_of_prod = "means_of_prod"
     raw_materials = "raw_materials"

--- a/src/workers_control/core/repositories.py
+++ b/src/workers_control/core/repositories.py
@@ -146,11 +146,6 @@ class PlanUpdate(DatabaseUpdate, Protocol):
         updated through this method.
         """
 
-    def set_rejection_date(self, rejection_date: Optional[datetime]) -> Self:
-        """Set the rejection date on all matching plans. The return
-        value counts all the plans that were changed by this method.
-        """
-
     def hide(self) -> Self: ...
 
 
@@ -805,6 +800,12 @@ class DatabaseGateway(Protocol):
     ) -> records.PlanApproval: ...
 
     def get_plan_approvals(self) -> PlanApprovalResult: ...
+
+    def create_plan_rejection(
+        self,
+        plan_id: UUID,
+        date: datetime,
+    ) -> records.PlanRejection: ...
 
     def create_basic_service(
         self,

--- a/src/workers_control/db/migrations/versions/f4a9c2e1b6d3_replace_plan_review_with_plan_rejection.py
+++ b/src/workers_control/db/migrations/versions/f4a9c2e1b6d3_replace_plan_review_with_plan_rejection.py
@@ -1,0 +1,53 @@
+"""Replace plan_review with plan_rejection
+
+Revision ID: f4a9c2e1b6d3
+Revises: c9f2e1a4b8d7
+Create Date: 2026-05-31 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "f4a9c2e1b6d3"
+down_revision: Union[str, None] = "c9f2e1a4b8d7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "plan_rejection",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("plan_id", sa.Uuid(), nullable=False),
+        sa.Column("date", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["plan_id"], ["plan.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.execute(
+        "INSERT INTO plan_rejection (id, plan_id, date) "
+        "SELECT id, plan_id, rejection_date FROM plan_review "
+        "WHERE rejection_date IS NOT NULL"
+    )
+    op.drop_table("plan_review")
+
+
+def downgrade() -> None:
+    op.create_table(
+        "plan_review",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("rejection_date", sa.DateTime(), nullable=True),
+        sa.Column("plan_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(["plan_id"], ["plan.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.execute(
+        "INSERT INTO plan_review (id, plan_id, rejection_date) "
+        "SELECT plan.id, plan.id, plan_rejection.date "
+        "FROM plan LEFT JOIN plan_rejection ON plan_rejection.plan_id = plan.id"
+    )
+    op.drop_table("plan_rejection")

--- a/src/workers_control/db/models.py
+++ b/src/workers_control/db/models.py
@@ -191,8 +191,8 @@ class Plan(Base):
     )
     hidden_by_user: Mapped[bool] = mapped_column(default=False)
 
-    review: Mapped["PlanReview  | None"] = relationship(
-        "PlanReview", back_populates="plan"
+    rejection: Mapped["PlanRejection | None"] = relationship(
+        "PlanRejection", back_populates="plan"
     )
     approval: Mapped["PlanApproval | None"] = relationship(
         "PlanApproval", back_populates="plan"
@@ -206,19 +206,19 @@ class PlanCooperation(Base):
     cooperation: Mapped[UUID] = mapped_column(Uuid, ForeignKey("cooperation.id"))
 
 
-class PlanReview(Base):
-    __tablename__ = "plan_review"
+class PlanRejection(Base):
+    __tablename__ = "plan_rejection"
 
     id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
-    rejection_date: Mapped[datetime | None] = mapped_column(TZDateTime)
     plan_id: Mapped[UUID] = mapped_column(
         Uuid, ForeignKey("plan.id", ondelete="CASCADE")
     )
+    date: Mapped[datetime] = mapped_column(TZDateTime)
 
-    plan: Mapped["Plan"] = relationship("Plan", back_populates="review")
+    plan: Mapped["Plan"] = relationship("Plan", back_populates="rejection")
 
     def __repr__(self) -> str:
-        return f"PlanReview(id={self.id!r}, plan_id={self.plan_id!r}, rejection_date={self.rejection_date!r})"
+        return f"PlanRejection(id={self.id!r}, plan_id={self.plan_id!r}, date={self.date!r})"
 
 
 class PlanApproval(Base):

--- a/src/workers_control/db/repositories.py
+++ b/src/workers_control/db/repositories.py
@@ -114,16 +114,11 @@ class PlanQueryResult(SqlQueryResult[records.Plan]):
         )
 
     def ordered_by_rejection_date(self, ascending: bool = True) -> Self:
-        review = aliased(models.PlanReview)
-        ordering = (
-            review.rejection_date.asc() if ascending else review.rejection_date.desc()
+        rejection = aliased(models.PlanRejection)
+        ordering = rejection.date.asc() if ascending else rejection.date.desc()
+        return self._with_modified_query(
+            lambda query: query.outerjoin(rejection).order_by(ordering)
         )
-        query = self._with_modified_query(
-            lambda query: query.join(review, review.plan_id == models.Plan.id).order_by(
-                ordering
-            )
-        )
-        return query
 
     def with_id_containing(self, query: str) -> Self:
         return self._with_modified_query(
@@ -143,11 +138,8 @@ class PlanQueryResult(SqlQueryResult[records.Plan]):
         )
 
     def that_are_rejected(self) -> Self:
-        plan_review = aliased(models.PlanReview)
         return self._with_modified_query(
-            lambda query: query.join(plan_review).filter(
-                plan_review.rejection_date != None
-            )
+            lambda query: query.filter(models.Plan.rejection != None)
         )
 
     def that_were_approved_before(self, timestamp: datetime) -> Self:
@@ -207,14 +199,11 @@ class PlanQueryResult(SqlQueryResult[records.Plan]):
         )
 
     def without_completed_review(self) -> Self:
-        plan_review = aliased(models.PlanReview)
         return self._with_modified_query(
-            lambda query: query.join(
-                plan_review, plan_review.plan_id == models.Plan.id
-            ).filter(
+            lambda query: query.filter(
                 and_(
                     models.Plan.approval == None,
-                    plan_review.rejection_date == None,
+                    models.Plan.rejection == None,
                 )
             )
         )
@@ -436,7 +425,6 @@ class PlanUpdate:
     query: Query
     db: Database
     plan_update_values: Dict[str, Any] = field(default_factory=dict)
-    review_update_values: Dict[str, Any] = field(default_factory=dict)
     cooperation_update: SetCooperation | None = None
 
     @dataclass
@@ -459,19 +447,6 @@ class PlanUpdate:
             )
             result = self.db.session.execute(sql_statement)
             row_count = cast(CursorResult, result).rowcount
-        if self.review_update_values:
-            sql_statement = (
-                update(models.PlanReview)
-                .where(
-                    models.PlanReview.plan_id.in_(
-                        self.query.with_entities(models.Plan.id).scalar_subquery()
-                    )
-                )
-                .values(**self.review_update_values)
-                .execution_options(synchronize_session="fetch")
-            )
-            result = self.db.session.execute(sql_statement)
-            row_count = max(row_count, cast(CursorResult, result).rowcount)
         if self.cooperation_update:
             match self.cooperation_update:
                 case self.SetCooperation(cooperation=None):
@@ -524,14 +499,6 @@ class PlanUpdate:
             plan_update_values=dict(
                 self.plan_update_values,
                 requested_cooperation=cooperation,
-            ),
-        )
-
-    def set_rejection_date(self, rejection_date: Optional[datetime]) -> Self:
-        return replace(
-            self,
-            review_update_values=dict(
-                self.review_update_values, rejection_date=rejection_date
             ),
         )
 
@@ -2803,9 +2770,7 @@ class DatabaseGatewayImpl:
             timeframe=duration_in_days,
             is_public_service=is_public_service,
         )
-        review = models.PlanReview(plan=plan, rejection_date=None)
         self.db.session.add(plan)
-        self.db.session.add(review)
         self.db.session.flush()
         return self.plan_from_orm(plan)
 
@@ -2828,7 +2793,7 @@ class DatabaseGatewayImpl:
             timeframe=int(plan.timeframe),
             is_public_service=plan.is_public_service,
             approval_date=plan.approval.date if plan.approval else None,
-            rejection_date=plan.review.rejection_date if plan.review else None,
+            rejection_date=plan.rejection.date if plan.rejection else None,
             requested_cooperation=(
                 plan.requested_cooperation if plan.requested_cooperation else None
             ),
@@ -3359,6 +3324,33 @@ class DatabaseGatewayImpl:
             db=self.db,
             query=self.db.session.query(models.PlanApproval),
             mapper=self.plan_approval_from_orm,
+        )
+
+    def create_plan_rejection(
+        self,
+        plan_id: UUID,
+        date: datetime,
+    ) -> records.PlanRejection:
+        rejection_orm = models.PlanRejection(
+            id=uuid4(),
+            plan_id=plan_id,
+            date=date,
+        )
+        plan_orm = self.db.session.query(models.Plan).filter_by(id=plan_id).first()
+        assert plan_orm
+        plan_orm.rejection = rejection_orm
+        self.db.session.add(rejection_orm)
+        self.db.session.flush()
+        return self.plan_rejection_from_orm(rejection_orm)
+
+    @classmethod
+    def plan_rejection_from_orm(
+        cls, orm: models.PlanRejection
+    ) -> records.PlanRejection:
+        return records.PlanRejection(
+            id=orm.id,
+            plan_id=orm.plan_id,
+            date=orm.date,
         )
 
     @classmethod

--- a/tests/db/test_plan_results.py
+++ b/tests/db/test_plan_results.py
@@ -48,26 +48,29 @@ class PlanResultTests(DatabaseTestCase):
         assert plan.timeframe == expected_duration
         assert plan.is_public_service == expected_is_public_service
 
-    def test_that_created_plan_can_have_its_rejection_date_changed(self) -> None:
+    def test_that_created_plan_can_be_rejected(self) -> None:
         plan = self.create_plan()
         expected_rejection_date = datetime_utc(2020, 1, 1)
-        self.database_gateway.get_plans().with_id(plan.id).update().set_rejection_date(
-            expected_rejection_date
-        ).perform()
-        changed_plan = self.database_gateway.get_plans().with_id(plan.id).first()
-        assert changed_plan
-        assert changed_plan.rejection_date == expected_rejection_date
+        self.database_gateway.create_plan_rejection(
+            plan_id=plan.id, date=expected_rejection_date
+        )
+        rejected_plan = self.database_gateway.get_plans().with_id(plan.id).first()
+        assert rejected_plan
+        assert rejected_plan.rejection_date == expected_rejection_date
 
     def test_that_plan_gets_deleted(self) -> None:
         plan = self.create_plan()
         self.database_gateway.get_plans().with_id(plan.id).delete()
         assert not len(self.database_gateway.get_plans().with_id(plan.id))
 
-    def test_that_plan_review_gets_deleted_when_plan_gets_deleted(self) -> None:
+    def test_that_plan_rejection_gets_deleted_when_plan_gets_deleted(self) -> None:
         plan = self.create_plan()
-        assert self.database_gateway.db.session.query(models.PlanReview).all()
+        self.database_gateway.create_plan_rejection(
+            plan_id=plan.id, date=datetime_utc(2020, 1, 1)
+        )
+        assert self.database_gateway.db.session.query(models.PlanRejection).all()
         self.database_gateway.get_plans().with_id(plan.id).delete()
-        assert not self.database_gateway.db.session.query(models.PlanReview).all()
+        assert not self.database_gateway.db.session.query(models.PlanRejection).all()
 
     def create_plan(self) -> Plan:
         return self.database_gateway.create_plan(
@@ -449,11 +452,15 @@ class GetAllPlans(DatabaseTestCase):
         _, cooperation = result
         assert not cooperation
 
-    def test_can_set_rejection_date(self) -> None:
-        plan = self.plan_generator.create_plan(approved=False, rejected=True)
-        plans = self.database_gateway.get_plans().with_id(plan)
+    def test_that_create_plan_rejection_sets_the_rejection_date_on_the_plan(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(approved=False, rejected=False)
         expected_rejection_date = datetime_utc(2000, 3, 2)
-        assert plans.update().set_rejection_date(expected_rejection_date).perform()
+        self.database_gateway.create_plan_rejection(
+            plan_id=plan, date=expected_rejection_date
+        )
+        plans = self.database_gateway.get_plans().with_id(plan)
         assert all(plan.rejection_date == expected_rejection_date for plan in plans)
 
 

--- a/tests/flask_integration/test_db_migrations.py
+++ b/tests/flask_integration/test_db_migrations.py
@@ -1,10 +1,9 @@
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import Connection, inspect, text
+from sqlalchemy import Connection, MetaData, inspect, text
 
 from tests.db.base_test_case import TestCaseWithResettedDatabase
-from workers_control.db.db import Base
 from workers_control.flask import create_app
 
 from .dependency_injection import FlaskTestConfiguration
@@ -19,27 +18,22 @@ class MigrationsTestCase(TestCaseWithResettedDatabase):
 
     def setUp(self) -> None:
         super().setUp()
-        Base.metadata.drop_all(bind=self.db.engine)
         with self.db.engine.begin() as conn:
-            self._drop_non_model_tables(conn)
+            self._reset_database(conn)
 
         self.alembic_config = Config("tests/flask_integration/alembic.ini")
         self.flask_config = FlaskTestConfiguration.default()
 
     def tearDown(self) -> None:
         with self.db.engine.begin() as conn:
-            Base.metadata.drop_all(bind=conn)
-            self._drop_non_model_tables(conn)
+            self._reset_database(conn)
         super().tearDown()
 
     @staticmethod
-    def _drop_non_model_tables(conn: Connection) -> None:
-        # Tables that are not part of the current model metadata and therefore
-        # are not removed by ``Base.metadata.drop_all``. ``plan_review`` is
-        # recreated by the downgrade of the migration that replaced it with
-        # ``plan_rejection``, so it must be cleaned up explicitly.
-        conn.execute(text("DROP TABLE IF EXISTS alembic_version;"))
-        conn.execute(text("DROP TABLE IF EXISTS plan_review;"))
+    def _reset_database(conn: Connection) -> None:
+        metadata = MetaData()
+        metadata.reflect(bind=conn)
+        metadata.drop_all(bind=conn)
 
     def table_exists(self, table_name: str) -> bool:
         inspector = inspect(self.db.engine)

--- a/tests/flask_integration/test_db_migrations.py
+++ b/tests/flask_integration/test_db_migrations.py
@@ -1,7 +1,7 @@
 from alembic import command
 from alembic.config import Config
 from alembic.script import ScriptDirectory
-from sqlalchemy import inspect, text
+from sqlalchemy import Connection, inspect, text
 
 from tests.db.base_test_case import TestCaseWithResettedDatabase
 from workers_control.db.db import Base
@@ -21,7 +21,7 @@ class MigrationsTestCase(TestCaseWithResettedDatabase):
         super().setUp()
         Base.metadata.drop_all(bind=self.db.engine)
         with self.db.engine.begin() as conn:
-            conn.execute(text("DROP TABLE IF EXISTS alembic_version;"))
+            self._drop_non_model_tables(conn)
 
         self.alembic_config = Config("tests/flask_integration/alembic.ini")
         self.flask_config = FlaskTestConfiguration.default()
@@ -29,8 +29,17 @@ class MigrationsTestCase(TestCaseWithResettedDatabase):
     def tearDown(self) -> None:
         with self.db.engine.begin() as conn:
             Base.metadata.drop_all(bind=conn)
-            conn.execute(text("DROP TABLE IF EXISTS alembic_version;"))
+            self._drop_non_model_tables(conn)
         super().tearDown()
+
+    @staticmethod
+    def _drop_non_model_tables(conn: Connection) -> None:
+        # Tables that are not part of the current model metadata and therefore
+        # are not removed by ``Base.metadata.drop_all``. ``plan_review`` is
+        # recreated by the downgrade of the migration that replaced it with
+        # ``plan_rejection``, so it must be cleaned up explicitly.
+        conn.execute(text("DROP TABLE IF EXISTS alembic_version;"))
+        conn.execute(text("DROP TABLE IF EXISTS plan_review;"))
 
     def table_exists(self, table_name: str) -> bool:
         inspector = inspect(self.db.engine)

--- a/tests/interactors/repositories.py
+++ b/tests/interactors/repositories.py
@@ -410,12 +410,6 @@ class PlanUpdate:
 
         return self._add_update(update)
 
-    def set_rejection_date(self, rejection_date: Optional[datetime]) -> Self:
-        def update(plan: Plan) -> None:
-            plan.rejection_date = rejection_date
-
-        return self._add_update(update)
-
     def hide(self) -> Self:
         def update(plan: records.Plan) -> None:
             plan.hidden_by_user = True
@@ -2558,6 +2552,21 @@ class MockDatabase:
             database=self,
             items=lambda: self.plan_approvals,
         )
+
+    def create_plan_rejection(
+        self,
+        plan_id: UUID,
+        date: datetime,
+    ) -> records.PlanRejection:
+        record = records.PlanRejection(
+            id=uuid4(),
+            plan_id=plan_id,
+            date=date,
+        )
+        plan = self.get_plans().with_id(plan_id).first()
+        assert plan
+        plan.rejection_date = record.date
+        return record
 
     def create_basic_service(
         self,


### PR DESCRIPTION
- Replace PlanReview with PlanRejection model 

   PlanReview's only function was to mark a plan as rejected via a nullable rejection_date that was eagerly created for every plan. Replace it with a PlanRejection record mirroring PlanApproval: created lazily on rejection with a non-nullable date.

   fixes #1217 

- Reset migration test DB by reflecting the live schema 

   In migration tests on setup and tear down, drop every table that actually exists in the test database rather than only the tables in the current model metadata.