### PR TITLE
Update python version and nix pkgs

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -66,10 +66,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v5
-    - name: Set up Python 3.12
+    - name: Set up Python 3.13
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         cache: 'pip'
     - name: Install dependencies
       run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Verify tag matches pyproject version
         run: |
           tag="${GITHUB_REF_NAME#v}"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 sphinx:
    configuration: docs/conf.py

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -56,9 +56,9 @@ virtual environment by typing ``exit`` at the command prompt.
 Using Nix will give you the option to access a development environment with any of the supported
 python versions via ``nix develop``. Check `flake.nix` for the
 supported environments under the key ``devShells``. For example to
-enter a development shell with ``python3.12`` set as the default
-interpreter run ``nix develop .#python312``. This will drop you into a
-shell with python3.12 as the default python interpreter. This won't
+enter a development shell with ``python3.14`` set as the default
+interpreter run ``nix develop .#python314``. This will drop you into a
+shell with python3.14 as the default python interpreter. This won't
 change anything else on your machine and the respective python
 interpreter will be garbage collected the next time you run
 ``nix-collect-garbage``.

--- a/flake.lock
+++ b/flake.lock
@@ -55,18 +55,18 @@
         "type": "github"
       }
     },
-    "nixos-25-11": {
+    "nixos-26-05": {
       "locked": {
-        "lastModified": 1779467186,
-        "narHash": "sha256-nOesoDCiXcUftqbRBMz9tt4blI5PvljMWbm3kuCA+0s=",
+        "lastModified": 1780734595,
+        "narHash": "sha256-DmTfP92QFYRLOGXlMIE54MAgxSJjDWocl3gRNOu72Os=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b77b3de8775677f84492abe84635f87b0e153f0f",
+        "rev": "9b696460ac78b5ccfc17c854d8c976f20456e943",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -107,7 +107,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "flask-profiler": "flask-profiler",
-        "nixos-25-11": "nixos-25-11",
+        "nixos-26-05": "nixos-26-05",
         "nixpkgs": "nixpkgs_2"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -89,11 +89,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1779694939,
-        "narHash": "sha256-Ly4j75O8ICaSQx3uxPnwk2x7PMF0XQvn5r0c3yBA7FI=",
+        "lastModified": 1780747962,
+        "narHash": "sha256-IX7G1dlKrOqPOImfbo7ADDfV5yU1+j+MRChI3TL4tAA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f9d8b65950353691ab56561e7c73d2e1063d810b",
+        "rev": "cbb5cf358f50aa6acc9efd6113b7bcfbc352cd73",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,8 +41,12 @@
             nixos-unstable = pkgs.callPackage dev/nix/devShell.nix {
               includeGlibcLocales = !isMacOs;
             };
-            python312 = pkgs.callPackage dev/nix/devShell.nix {
-              python3 = pkgs.python312;
+            python313 = pkgs.callPackage dev/nix/devShell.nix {
+              python3 = pkgs.python313;
+              includeGlibcLocales = !isMacOs;
+            };
+            python314 = pkgs.callPackage dev/nix/devShell.nix {
+              python3 = pkgs.python314;
               includeGlibcLocales = !isMacOs;
             };
           };
@@ -57,11 +61,11 @@
             # python3 interpreter and also explicitly list all
             # versions we want to support.
             woco-python3-nixpkgs-unstable = pkgs.python3.pkgs.workers-control;
-            woco-python312-nixpkgs-unstable = pkgs.python312.pkgs.workers-control;
             woco-python313-nixpkgs-unstable = pkgs.python313.pkgs.workers-control;
+            woco-python314-nixpkgs-unstable = pkgs.python314.pkgs.workers-control;
             woco-python3-nixpkgs-stable = pkgs-26-05.python3.pkgs.workers-control;
-            woco-python312-nixpkgs-stable = pkgs-26-05.python312.pkgs.workers-control;
             woco-python313-nixpkgs-stable = pkgs-26-05.python313.pkgs.workers-control;
+            woco-python314-nixpkgs-stable = pkgs-26-05.python314.pkgs.workers-control;
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Workers control - a web app for labour time accounting.";
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nixos-25-11.url = "github:NixOS/nixpkgs/nixos-25.11";
+    nixos-26-05.url = "github:NixOS/nixpkgs/nixos-26.05";
     flake-utils.url = "github:numtide/flake-utils";
     flask-profiler.url = "github:seppeljordan/flask-profiler";
   };
@@ -13,7 +13,7 @@
       nixpkgs,
       flake-utils,
       flask-profiler,
-      nixos-25-11,
+      nixos-26-05,
     }:
     let
       supportedSystems = [
@@ -29,7 +29,7 @@
             inherit system;
             overlays = [ self.overlays.default ];
           };
-          pkgs-25-11 = import nixos-25-11 {
+          pkgs-26-05 = import nixos-26-05 {
             inherit system;
             overlays = [ self.overlays.default ];
           };
@@ -37,7 +37,7 @@
         {
           devShells = rec {
             default = nixos-unstable;
-            nixos-25-11 = pkgs-25-11.callPackage dev/nix/devShell.nix { includeGlibcLocales = !isMacOs; };
+            nixos-26-05 = pkgs-26-05.callPackage dev/nix/devShell.nix { includeGlibcLocales = !isMacOs; };
             nixos-unstable = pkgs.callPackage dev/nix/devShell.nix {
               includeGlibcLocales = !isMacOs;
             };
@@ -59,9 +59,9 @@
             woco-python3-nixpkgs-unstable = pkgs.python3.pkgs.workers-control;
             woco-python312-nixpkgs-unstable = pkgs.python312.pkgs.workers-control;
             woco-python313-nixpkgs-unstable = pkgs.python313.pkgs.workers-control;
-            woco-python3-nixpkgs-stable = pkgs-25-11.python3.pkgs.workers-control;
-            woco-python312-nixpkgs-stable = pkgs-25-11.python312.pkgs.workers-control;
-            woco-python313-nixpkgs-stable = pkgs-25-11.python313.pkgs.workers-control;
+            woco-python3-nixpkgs-stable = pkgs-26-05.python3.pkgs.workers-control;
+            woco-python312-nixpkgs-stable = pkgs-26-05.python312.pkgs.workers-control;
+            woco-python313-nixpkgs-stable = pkgs-26-05.python313.pkgs.workers-control;
           };
         }
       );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,12 @@ name = "workers-control"
 version = "0.2.2"
 description = "A flask app for labour time accounting."
 license = "AGPL-3.0-or-later"
-requires-python = ">=3.12"
+requires-python = ">=3.13"
 classifiers = [
     "Framework :: Flask",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 readme = "README.rst"
 
@@ -41,7 +41,7 @@ Changelog = "https://github.com/ida-arbeitszeit/workers-control/blob/master/CHAN
 where = [ "src" ]
 
 [tool.black]
-target-version = ['py312']
+target-version = ['py313']
 extend-exclude = '''
 (
   ^/src/workers_control/db/migrations/versions/


### PR DESCRIPTION
- Tests: Update nix pkgs from 25-11 to 26-05 

   Run nix tests with packages from nixos 26-05 instead of 25-11.

- Update python from 3.12/3.13 to 3.13/3.14 

   We drop python version 3.12 for development and production environment and add 3.14.