### PR TITLE
Remove private-consumption action from member plan-details page

### DIFF
--- a/src/workers_control/flask/templates/member/plan_details.html
+++ b/src/workers_control/flask/templates/member/plan_details.html
@@ -8,19 +8,4 @@
 {% block content %}
 {% from 'macros/plan_details.html' import plan_details %}
 {{ plan_details(view_model) }}
-
-<h1 class="title">
-    {{ gettext("Actions") }}
-</h1>
-<div class="column is-offset-2 is-8">
-    <div class="box">
-        <div class="box has-background-danger-light">
-            <h1 class="title is-4">{{ gettext("Register consumption") }}</h1>
-            <a class="button is-primary" href="{{ view_model.register_private_consumption_url }}">
-                <span>{{ gettext("Register consumption") }}</span>
-            </a>
-        </div>
-    </div>
-</div>
-
 {% endblock %}

--- a/src/workers_control/web/www/presenters/get_plan_details_member_presenter.py
+++ b/src/workers_control/web/www/presenters/get_plan_details_member_presenter.py
@@ -5,7 +5,6 @@ from workers_control.web.formatters.plan_details_formatter import (
     PlanDetailsFormatter,
     PlanDetailsWeb,
 )
-from workers_control.web.url_index import UrlIndex
 from workers_control.web.www.navbar import NavbarItem
 
 from ...translator import Translator
@@ -14,14 +13,12 @@ from ...translator import Translator
 @dataclass
 class GetPlanDetailsMemberViewModel:
     details: PlanDetailsWeb
-    register_private_consumption_url: str
 
 
 @dataclass
 class GetPlanDetailsMemberMemberPresenter:
     trans: Translator
     plan_details_service: PlanDetailsFormatter
-    url_index: UrlIndex
 
     def create_navbar_items(self) -> list[NavbarItem]:
         return [NavbarItem(text=self.trans.gettext("Plan information"), url=None)]
@@ -32,8 +29,5 @@ class GetPlanDetailsMemberMemberPresenter:
         return GetPlanDetailsMemberViewModel(
             details=self.plan_details_service.format_plan_details(
                 response.plan_details
-            ),
-            register_private_consumption_url=self.url_index.get_register_private_consumption_url(
-                amount=None, plan_id=response.plan_details.plan_id
             ),
         )

--- a/tests/web/www/presenters/test_get_plan_details_member_presenter.py
+++ b/tests/web/www/presenters/test_get_plan_details_member_presenter.py
@@ -1,37 +1,7 @@
-from uuid import uuid4
-
 from tests.web.base_test_case import BaseTestCase
-from tests.web.www.presenters.data_generators import PlanDetailsGenerator
-from workers_control.core.interactors.get_plan_details import GetPlanDetailsInteractor
 from workers_control.web.www.presenters.get_plan_details_member_presenter import (
     GetPlanDetailsMemberMemberPresenter,
 )
-
-
-class PresenterTests(BaseTestCase):
-    """
-    some functionality tested in tests/presenters/test_plan_details_formatter.py
-    """
-
-    def setUp(self) -> None:
-        super().setUp()
-        self.presenter = self.injector.get(GetPlanDetailsMemberMemberPresenter)
-        self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
-
-    def test_that_register_consumption_url_is_shown_correctly(self):
-        PLAN_ID = uuid4()
-        interactor_response = GetPlanDetailsInteractor.Response(
-            plan_details=self.plan_details_generator.create_plan_details(
-                plan_id=PLAN_ID
-            )
-        )
-        view_model = self.presenter.present(interactor_response)
-        self.assertEqual(
-            view_model.register_private_consumption_url,
-            self.url_index.get_register_private_consumption_url(
-                amount=None, plan_id=PLAN_ID
-            ),
-        )
 
 
 class NavbarItemsTests(BaseTestCase):


### PR DESCRIPTION
No functionality is lost — members can still register private consumptions via  /user/query_offers and the standalone register_private_consumption route.

fixes #1509
