### PR TITLE
Remove productive-consumption action from company plan-details page

### DIFF
--- a/src/workers_control/flask/templates/company/plan_details.html
+++ b/src/workers_control/flask/templates/company/plan_details.html
@@ -11,21 +11,6 @@
 {{ plan_details(view_model) }}
 
 <div class="section has-text-centered">
-    {% if view_model.show_productive_consumption_url %}
-    <h1 class="title">
-        {{ gettext("Actions") }}
-    </h1>
-    <div class="column is-offset-2 is-8">
-        <div class="box">
-            <div class="box has-background-danger-light">
-                <h1 class="title is-4">{{ gettext("Register consumption") }}</h1>
-                <a class="button is-primary" href="{{ view_model.productive_consumption_url }}">
-                    <span>{{ gettext("Register consumption") }}</span>
-                </a>
-            </div>
-        </div>
-    </div>
-    {% endif %}
     {% if view_model.show_own_plan_action_section %}
     <h1 class="title">
         {{ gettext("Actions") }}

--- a/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
+++ b/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
@@ -27,8 +27,6 @@ class GetPlanDetailsCompanyViewModel:
     details: PlanDetailsWeb
     show_own_plan_action_section: bool
     own_plan_action: OwnPlanAction
-    show_productive_consumption_url: bool
-    productive_consumption_url: str
 
 
 @dataclass
@@ -55,12 +53,6 @@ class GetPlanDetailsCompanyPresenter:
             details=self.plan_details_service.format_plan_details(plan_details),
             show_own_plan_action_section=show_own_plan_action_section,
             own_plan_action=self._create_own_plan_action_section(plan_details),
-            show_productive_consumption_url=(
-                True if not current_user_is_planner else False
-            ),
-            productive_consumption_url=self.url_index.get_register_productive_consumption_url(
-                plan_details.plan_id
-            ),
         )
         return view_model
 

--- a/tests/web/www/presenters/test_get_plan_details_company_presenter.py
+++ b/tests/web/www/presenters/test_get_plan_details_company_presenter.py
@@ -102,17 +102,6 @@ class TestPresenterForPlanner(BaseTestCase):
             self.url_index.get_request_coop_url(),
         )
 
-    def test_url_for_consuming_product_is_not_displayed_when_user_is_planner_of_plan(
-        self,
-    ):
-        response = InteractorResponse(
-            self.plan_details_generator.create_plan_details(
-                planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertFalse(view_model.show_productive_consumption_url)
-
 
 class TestPresenterForNonPlanningCompany(BaseTestCase):
     def setUp(self) -> None:
@@ -138,28 +127,6 @@ class TestPresenterForNonPlanningCompany(BaseTestCase):
         )
         view_model = self.presenter.present(response)
         self.assertTrue(view_model.own_plan_action.is_cooperating)
-
-    def test_url_for_consuming_product_is_displayed_when_user_is_not_planner_of_plan(
-        self,
-    ):
-        response = InteractorResponse(
-            self.plan_details_generator.create_plan_details(),
-        )
-        view_model = self.presenter.present(response)
-        self.assertTrue(view_model.show_productive_consumption_url)
-
-    def test_correct_url_for_consuming_product_is_displayed(
-        self,
-    ):
-        expected_plan_id = uuid4()
-        response = InteractorResponse(
-            self.plan_details_generator.create_plan_details(plan_id=expected_plan_id),
-        )
-        view_model = self.presenter.present(response)
-        self.assertEqual(
-            view_model.productive_consumption_url,
-            self.url_index.get_register_productive_consumption_url(expected_plan_id),
-        )
 
 
 class NavbarItemsTests(BaseTestCase):


### PR DESCRIPTION
No functionality is lost: companies can still register productive consumptions ia /user/query_offers and the standalone register_productive_consumption route.

fixes #1510 