### PR TITLE
Move request-cooperation action from plan details to my cooperations

### DIFF
--- a/src/workers_control/flask/templates/company/my_cooperations.html
+++ b/src/workers_control/flask/templates/company/my_cooperations.html
@@ -21,6 +21,14 @@
                     <div class="subtitle"></div>
                 </div>
             </a>
+            <div class="pt-3"></div>
+            <a href="{{ url_for('main_company.request_cooperation') }}">
+                <div class="box has-background-primary-light">
+                    <h1 class="title is-5"><span class="icon">{{ "envelope"|icon }}</span>
+                        {{ gettext("Request cooperation") }}</h1>
+                    <div class="subtitle"></div>
+                </div>
+            </a>
     </div>
 </div>
 <div class="section has-text-centered">

--- a/src/workers_control/flask/templates/company/plan_details.html
+++ b/src/workers_control/flask/templates/company/plan_details.html
@@ -18,7 +18,6 @@
     <div class="column is-offset-2 is-8">
         <div class="box">
             <div class="box has-background-danger-light">
-                {% if view_model.own_plan_action.is_cooperating %}
                 <h1 class="title is-4">{{ gettext("End cooperation:") }}</h1>
                 <form method="post" action="{{ url_for('.end_cooperation') }}">
                     <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
@@ -28,12 +27,6 @@
                         <span>{{ gettext("End") }}</span>
                     </button>
                 </form>
-                {% else %}
-                <h1 class="title is-4">{{ gettext("Join a cooperation") }} </h1>
-                <a class="button is-primary" href="{{ view_model.own_plan_action.request_coop_url }}">
-                    <span>{{ gettext("Join") }}</span>
-                </a>
-                {% endif %}
             </div>
         </div>
     </div>

--- a/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
+++ b/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Optional
 
 from workers_control.core.interactors.get_plan_details import GetPlanDetailsInteractor
 from workers_control.core.services.plan_details import PlanDetails
@@ -11,15 +10,11 @@ from workers_control.web.session import Session
 from workers_control.web.translator import Translator
 from workers_control.web.www.navbar import NavbarItem
 
-from ...url_index import UrlIndex
-
 
 @dataclass
 class OwnPlanAction:
-    is_cooperating: bool
     plan_id: str
     cooperation_id: str | None
-    request_coop_url: Optional[str]
 
 
 @dataclass
@@ -32,7 +27,6 @@ class GetPlanDetailsCompanyViewModel:
 @dataclass
 class GetPlanDetailsCompanyPresenter:
     plan_details_service: PlanDetailsFormatter
-    url_index: UrlIndex
     session: Session
     translator: Translator
 
@@ -47,7 +41,9 @@ class GetPlanDetailsCompanyPresenter:
         assert current_user
         current_user_is_planner = response.plan_details.planner_id == current_user
         show_own_plan_action_section = (
-            current_user_is_planner and plan_details.is_active
+            current_user_is_planner
+            and plan_details.is_active
+            and plan_details.is_cooperating
         )
         view_model = GetPlanDetailsCompanyViewModel(
             details=self.plan_details_service.format_plan_details(plan_details),
@@ -58,13 +54,7 @@ class GetPlanDetailsCompanyPresenter:
 
     def _create_own_plan_action_section(self, plan: PlanDetails) -> OwnPlanAction:
         section = OwnPlanAction(
-            is_cooperating=plan.is_cooperating,
             plan_id=str(plan.plan_id),
             cooperation_id=str(plan.cooperation) if plan.cooperation else None,
-            request_coop_url=(
-                self.url_index.get_request_coop_url()
-                if not plan.is_cooperating
-                else None
-            ),
         )
         return section

--- a/tests/web/www/presenters/test_get_plan_details_company_presenter.py
+++ b/tests/web/www/presenters/test_get_plan_details_company_presenter.py
@@ -22,10 +22,12 @@ class TestPresenterForPlanner(BaseTestCase):
         self.expected_planner = uuid4()
         self.session.login_company(company=self.expected_planner)
 
-    def test_action_section_is_shown_when_current_user_is_planner(self):
+    def test_action_section_is_shown_when_current_user_is_planner_of_cooperating_plan(
+        self,
+    ):
         response = InteractorResponse(
             plan_details=self.plan_details_generator.create_plan_details(
-                planner_id=self.expected_planner
+                is_cooperating=True, planner_id=self.expected_planner
             ),
         )
         view_model = self.presenter.present(response)
@@ -37,6 +39,17 @@ class TestPresenterForPlanner(BaseTestCase):
         response = InteractorResponse(
             plan_details=self.plan_details_generator.create_plan_details(
                 is_active=False, planner_id=self.expected_planner
+            ),
+        )
+        view_model = self.presenter.present(response)
+        self.assertFalse(view_model.show_own_plan_action_section)
+
+    def test_action_section_is_not_shown_when_planner_plan_is_active_but_not_cooperating(
+        self,
+    ):
+        response = InteractorResponse(
+            plan_details=self.plan_details_generator.create_plan_details(
+                is_cooperating=False, planner_id=self.expected_planner
             ),
         )
         view_model = self.presenter.present(response)
@@ -76,32 +89,6 @@ class TestPresenterForPlanner(BaseTestCase):
         view_model = self.presenter.present(response)
         assert not view_model.own_plan_action.cooperation_id
 
-    def test_no_url_for_requesting_cooperation_is_displayed_when_plan_is_cooperating(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=True, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertIsNone(view_model.own_plan_action.request_coop_url)
-
-    def test_url_for_requesting_cooperation_is_displayed_correctly_when_plan_is_not_cooperating(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=False, cooperation=None, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertFalse(view_model.own_plan_action.is_cooperating)
-        self.assertEqual(
-            view_model.own_plan_action.request_coop_url,
-            self.url_index.get_request_coop_url(),
-        )
-
 
 class TestPresenterForNonPlanningCompany(BaseTestCase):
     def setUp(self) -> None:
@@ -116,17 +103,6 @@ class TestPresenterForNonPlanningCompany(BaseTestCase):
         )
         view_model = self.presenter.present(response)
         self.assertFalse(view_model.show_own_plan_action_section)
-
-    def test_view_model_shows_plan_as_cooperating_when_plan_is_cooperating(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=True
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertTrue(view_model.own_plan_action.is_cooperating)
 
 
 class NavbarItemsTests(BaseTestCase):


### PR DESCRIPTION
The request-cooperation button is removed from the company plan details page and added to the my-cooperations page, leaving only the end-cooperation action on plan details.

fixes #1513 