### PR TITLE
Move end-cooperation to my cooperations

### DIFF
--- a/src/workers_control/flask/routes/company/routes.py
+++ b/src/workers_control/flask/routes/company/routes.py
@@ -19,6 +19,9 @@ from workers_control.flask.views.create_draft_view import CreateDraftView
 from workers_control.flask.views.delete_draft_view import DeleteDraftView
 from workers_control.flask.views.deny_cooperation_view import DenyCooperationView
 from workers_control.flask.views.draft_details_view import DraftDetailsView
+from workers_control.flask.views.end_plan_cooperation_view import (
+    EndPlanCooperationView,
+)
 from workers_control.flask.views.file_plan_with_accounting_view import (
     FilePlanWithAccountingView,
 )
@@ -216,6 +219,11 @@ class list_pending_work_invites(ListPendingWorkInvitesView): ...
 @CompanyRoute("/end_cooperation", methods=["POST"])
 @as_flask_view()
 class end_cooperation(EndCooperationView): ...
+
+
+@CompanyRoute("/end_plan_cooperation", methods=["POST"])
+@as_flask_view()
+class end_plan_cooperation(EndPlanCooperationView): ...
 
 
 @CompanyRoute("/review_registered_consumptions")

--- a/src/workers_control/flask/templates/company/my_cooperations.html
+++ b/src/workers_control/flask/templates/company/my_cooperations.html
@@ -183,6 +183,18 @@
                     </p>
                 </div>
             </div>
+            <div class="media-right">
+                <form action="{{ url_for('main_company.end_plan_cooperation') }}" method="post">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <input type="hidden" name="plan_id" value="{{ plan.plan_id }}">
+                    <input type="hidden" name="cooperation_id" value="{{ plan.coop_id }}">
+                    <button class="button large-button is-danger"
+                            type="submit"
+                            title="{{ gettext('End cooperation') }}">
+                        {{ "times"|icon }}
+                    </button>
+                </form>
+            </div>
         </article>
         {% endfor %}
         {% else %}

--- a/src/workers_control/flask/templates/company/plan_details.html
+++ b/src/workers_control/flask/templates/company/plan_details.html
@@ -9,27 +9,4 @@
 
 {% from 'macros/plan_details.html' import plan_details %}
 {{ plan_details(view_model) }}
-
-<div class="section has-text-centered">
-    {% if view_model.show_own_plan_action_section %}
-    <h1 class="title">
-        {{ gettext("Actions") }}
-    </h1>
-    <div class="column is-offset-2 is-8">
-        <div class="box">
-            <div class="box has-background-danger-light">
-                <h1 class="title is-4">{{ gettext("End cooperation:") }}</h1>
-                <form method="post" action="{{ url_for('.end_cooperation') }}">
-                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                    <input type="hidden" name="plan_id" value="{{ view_model.own_plan_action.plan_id }}">
-                    <input type="hidden" name="cooperation_id" value="{{ view_model.own_plan_action.cooperation_id }}">
-                    <button class="button is-danger" type="submit">
-                        <span>{{ gettext("End") }}</span>
-                    </button>
-                </form>
-            </div>
-        </div>
-    </div>
-    {% endif %}
-</div>
 {% endblock %}

--- a/src/workers_control/flask/views/end_plan_cooperation_view.py
+++ b/src/workers_control/flask/views/end_plan_cooperation_view.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+import flask
+
+from workers_control.core.interactors.end_cooperation import (
+    EndCooperationInteractor,
+    EndCooperationRequest,
+)
+from workers_control.db import commit_changes
+from workers_control.flask.flask_session import FlaskSession
+from workers_control.flask.types import Response
+from workers_control.web.www.presenters.end_plan_cooperation_presenter import (
+    EndPlanCooperationPresenter,
+)
+
+
+@dataclass
+class EndPlanCooperationView:
+    interactor: EndCooperationInteractor
+    presenter: EndPlanCooperationPresenter
+    flask_session: FlaskSession
+
+    @commit_changes
+    def POST(self) -> Response:
+        form = flask.request.form
+        current_user = self.flask_session.get_current_user()
+        assert current_user
+        cooperation_id = UUID(form["cooperation_id"].strip())
+        plan_id = UUID(form["plan_id"].strip())
+        response = self.interactor.execute(
+            EndCooperationRequest(
+                requester_id=current_user,
+                plan_id=plan_id,
+                cooperation_id=cooperation_id,
+            )
+        )
+        view_model = self.presenter.render_response(response)
+        return flask.redirect(view_model.redirection_url)

--- a/src/workers_control/web/www/presenters/end_cooperation_presenter.py
+++ b/src/workers_control/web/www/presenters/end_cooperation_presenter.py
@@ -1,11 +1,9 @@
 from dataclasses import dataclass
-from urllib.parse import urlparse
 from uuid import UUID
 
 from workers_control.core.interactors.end_cooperation import EndCooperationResponse
 from workers_control.web.notification import Notifier
 from workers_control.web.request import Request
-from workers_control.web.session import Session
 from workers_control.web.translator import Translator
 from workers_control.web.url_index import UrlIndex
 
@@ -20,7 +18,6 @@ class EndCooperationPresenter:
     notifier: Notifier
     url_index: UrlIndex
     translator: Translator
-    session: Session
 
     def present(
         self, response: EndCooperationResponse, *, web_request: Request
@@ -37,23 +34,9 @@ class EndCooperationPresenter:
         return self.ViewModel(show_404=False, redirect_url=redirect_url)
 
     def _get_redirect_url(self, request: Request) -> str:
-        referer = request.get_header("Referer")
         query_string = request.query_string()
-        plan_id = query_string.get_last_value("plan_id") or request.get_form("plan_id")
         cooperation_id = query_string.get_last_value(
             "cooperation_id"
         ) or request.get_form("cooperation_id")
-        assert plan_id
         assert cooperation_id
-        if referer:
-            if self._refers_from_plan_details(referer):
-                url = self.url_index.get_plan_details_url(
-                    user_role=self.session.get_user_role(), plan_id=UUID(plan_id)
-                )
-                return url
-        url = self.url_index.get_coop_summary_url(coop_id=UUID(cooperation_id))
-        return url
-
-    def _refers_from_plan_details(self, referer: str) -> bool:
-        referer_path = urlparse(referer).path
-        return True if referer_path.startswith("/company/plan_details") else False
+        return self.url_index.get_coop_summary_url(coop_id=UUID(cooperation_id))

--- a/src/workers_control/web/www/presenters/end_plan_cooperation_presenter.py
+++ b/src/workers_control/web/www/presenters/end_plan_cooperation_presenter.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass
+
+from workers_control.core.interactors.end_cooperation import EndCooperationResponse
+from workers_control.web.notification import Notifier
+from workers_control.web.translator import Translator
+from workers_control.web.url_index import UrlIndex
+
+
+@dataclass
+class ViewModel:
+    redirection_url: str
+
+
+@dataclass
+class EndPlanCooperationPresenter:
+    translator: Translator
+    notifier: Notifier
+    url_index: UrlIndex
+
+    def render_response(self, response: EndCooperationResponse) -> ViewModel:
+        if not response.is_rejected:
+            self.notifier.display_info(
+                self.translator.gettext("Cooperation has been terminated.")
+            )
+        else:
+            self.notifier.display_warning(
+                self.translator.gettext("Cooperation could not be terminated.")
+            )
+        return ViewModel(redirection_url=self.url_index.get_my_cooperations_url())

--- a/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
+++ b/src/workers_control/web/www/presenters/get_plan_details_company_presenter.py
@@ -1,33 +1,22 @@
 from dataclasses import dataclass
 
 from workers_control.core.interactors.get_plan_details import GetPlanDetailsInteractor
-from workers_control.core.services.plan_details import PlanDetails
 from workers_control.web.formatters.plan_details_formatter import (
     PlanDetailsFormatter,
     PlanDetailsWeb,
 )
-from workers_control.web.session import Session
 from workers_control.web.translator import Translator
 from workers_control.web.www.navbar import NavbarItem
 
 
 @dataclass
-class OwnPlanAction:
-    plan_id: str
-    cooperation_id: str | None
-
-
-@dataclass
 class GetPlanDetailsCompanyViewModel:
     details: PlanDetailsWeb
-    show_own_plan_action_section: bool
-    own_plan_action: OwnPlanAction
 
 
 @dataclass
 class GetPlanDetailsCompanyPresenter:
     plan_details_service: PlanDetailsFormatter
-    session: Session
     translator: Translator
 
     def create_navbar_items(self) -> list[NavbarItem]:
@@ -36,25 +25,8 @@ class GetPlanDetailsCompanyPresenter:
     def present(
         self, response: GetPlanDetailsInteractor.Response
     ) -> GetPlanDetailsCompanyViewModel:
-        plan_details = response.plan_details
-        current_user = self.session.get_current_user()
-        assert current_user
-        current_user_is_planner = response.plan_details.planner_id == current_user
-        show_own_plan_action_section = (
-            current_user_is_planner
-            and plan_details.is_active
-            and plan_details.is_cooperating
+        return GetPlanDetailsCompanyViewModel(
+            details=self.plan_details_service.format_plan_details(
+                response.plan_details
+            ),
         )
-        view_model = GetPlanDetailsCompanyViewModel(
-            details=self.plan_details_service.format_plan_details(plan_details),
-            show_own_plan_action_section=show_own_plan_action_section,
-            own_plan_action=self._create_own_plan_action_section(plan_details),
-        )
-        return view_model
-
-    def _create_own_plan_action_section(self, plan: PlanDetails) -> OwnPlanAction:
-        section = OwnPlanAction(
-            plan_id=str(plan.plan_id),
-            cooperation_id=str(plan.cooperation) if plan.cooperation else None,
-        )
-        return section

--- a/src/workers_control/web/www/presenters/show_my_cooperations_presenter.py
+++ b/src/workers_control/web/www/presenters/show_my_cooperations_presenter.py
@@ -51,8 +51,10 @@ class ListOfOutboundCooperationRequestsRow:
 
 @dataclass
 class CooperatingPlan:
+    plan_id: str
     plan_name: str
     plan_url: str
+    coop_id: str
     coop_name: str
     coop_url: str
 
@@ -181,10 +183,12 @@ class ShowMyCooperationsPresenter:
         self, plan: ListMyCooperatingPlansInteractor.CooperatingPlan
     ) -> CooperatingPlan:
         return CooperatingPlan(
+            plan_id=str(plan.plan_id),
             plan_name=plan.plan_name,
             plan_url=self.url_index.get_plan_details_url(
                 user_role=UserRole.company, plan_id=plan.plan_id
             ),
+            coop_id=str(plan.coop_id),
             coop_name=plan.coop_name,
             coop_url=self.url_index.get_coop_summary_url(coop_id=plan.coop_id),
         )

--- a/tests/flask_integration/test_end_plan_cooperation_view.py
+++ b/tests/flask_integration/test_end_plan_cooperation_view.py
@@ -1,0 +1,33 @@
+from uuid import uuid4
+
+from .base_test_case import ViewTestCase
+
+URL = "/company/end_plan_cooperation"
+
+
+class AuthenticatedCompanyTests(ViewTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.company = self.login_company()
+
+    def test_planner_ending_own_cooperation_is_redirected_to_my_cooperations(
+        self,
+    ) -> None:
+        plan = self.plan_generator.create_plan(planner=self.company)
+        cooperation = self.cooperation_generator.create_cooperation(plans=[plan])
+        response = self.client.post(
+            URL,
+            data={"plan_id": str(plan), "cooperation_id": str(cooperation)},
+        )
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/company/my_cooperations")
+
+    def test_rejected_request_is_still_redirected_to_my_cooperations(
+        self,
+    ) -> None:
+        response = self.client.post(
+            URL,
+            data={"plan_id": str(uuid4()), "cooperation_id": str(uuid4())},
+        )
+        self.assertEqual(response.status_code, 302)
+        assert response.location.endswith("/company/my_cooperations")

--- a/tests/web/www/presenters/test_end_cooperation_presenter.py
+++ b/tests/web/www/presenters/test_end_cooperation_presenter.py
@@ -4,7 +4,6 @@ from uuid import uuid4
 from tests.web.base_test_case import BaseTestCase
 from tests.web.www.request import FakeRequest
 from workers_control.core.interactors.end_cooperation import EndCooperationResponse
-from workers_control.web.session import UserRole
 from workers_control.web.www.presenters.end_cooperation_presenter import (
     EndCooperationPresenter,
 )
@@ -75,23 +74,6 @@ class PresenterTests(BaseTestCase):
         self.assertEqual(
             view_model.redirect_url,
             self.url_index.get_coop_summary_url(coop_id=coop_id),
-        )
-
-    def test_plan_details_url_gets_returned_when_plan_details_url_was_referer(
-        self,
-    ) -> None:
-        request = FakeRequest()
-        plan_id = uuid4()
-        request.set_header("Referer", f"/company/plan_details/{str(plan_id)}")
-        request.set_arg("plan_id", str(plan_id))
-        request.set_arg("cooperation_id", str(uuid4()))
-        view_model = self.presenter.present(SUCCESSFUL_RESPONSE, web_request=request)
-        self.assertFalse(view_model.show_404)
-        self.assertEqual(
-            view_model.redirect_url,
-            self.url_index.get_plan_details_url(
-                user_role=UserRole.company, plan_id=plan_id
-            ),
         )
 
     def test_correct_notification_is_returned_when_operation_was_successfull(

--- a/tests/web/www/presenters/test_end_plan_cooperation_presenter.py
+++ b/tests/web/www/presenters/test_end_plan_cooperation_presenter.py
@@ -1,0 +1,42 @@
+from parameterized import parameterized
+
+from tests.web.base_test_case import BaseTestCase
+from workers_control.core.interactors.end_cooperation import EndCooperationResponse
+from workers_control.web.www.presenters.end_plan_cooperation_presenter import (
+    EndPlanCooperationPresenter,
+)
+
+
+class EndPlanCooperationPresenterTests(BaseTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.presenter = self.injector.get(EndPlanCooperationPresenter)
+
+    def test_successful_response_shows_info_notification(self) -> None:
+        self.presenter.render_response(EndCooperationResponse(rejection_reason=None))
+        assert not self.notifier.warnings
+        assert self.notifier.infos == [
+            self.translator.gettext("Cooperation has been terminated.")
+        ]
+
+    def test_rejected_response_shows_warning_notification(self) -> None:
+        self.presenter.render_response(
+            EndCooperationResponse(
+                rejection_reason=EndCooperationResponse.RejectionReason.plan_not_found
+            )
+        )
+        assert not self.notifier.infos
+        assert self.notifier.warnings == [
+            self.translator.gettext("Cooperation could not be terminated.")
+        ]
+
+    @parameterized.expand(
+        [(reason,) for reason in EndCooperationResponse.RejectionReason] + [(None,)]
+    )
+    def test_user_gets_redirected_to_my_cooperations_view(
+        self, rejection_reason: EndCooperationResponse.RejectionReason | None
+    ) -> None:
+        response = self.presenter.render_response(
+            EndCooperationResponse(rejection_reason=rejection_reason)
+        )
+        assert response.redirection_url == self.url_index.get_my_cooperations_url()

--- a/tests/web/www/presenters/test_get_plan_details_company_presenter.py
+++ b/tests/web/www/presenters/test_get_plan_details_company_presenter.py
@@ -2,107 +2,10 @@
 some functionalities are tested in tests/presenters/test_plan_details_formatter.py
 """
 
-from uuid import uuid4
-
 from tests.web.base_test_case import BaseTestCase
-from tests.web.www.presenters.data_generators import PlanDetailsGenerator
-from workers_control.core.interactors.get_plan_details import GetPlanDetailsInteractor
 from workers_control.web.www.presenters.get_plan_details_company_presenter import (
     GetPlanDetailsCompanyPresenter,
 )
-
-InteractorResponse = GetPlanDetailsInteractor.Response
-
-
-class TestPresenterForPlanner(BaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.presenter = self.injector.get(GetPlanDetailsCompanyPresenter)
-        self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
-        self.expected_planner = uuid4()
-        self.session.login_company(company=self.expected_planner)
-
-    def test_action_section_is_shown_when_current_user_is_planner_of_cooperating_plan(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=True, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertTrue(view_model.show_own_plan_action_section)
-
-    def test_action_section_is_not_shown_when_current_user_is_planner_but_plan_is_expired(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_active=False, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertFalse(view_model.show_own_plan_action_section)
-
-    def test_action_section_is_not_shown_when_planner_plan_is_active_but_not_cooperating(
-        self,
-    ):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=False, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        self.assertFalse(view_model.show_own_plan_action_section)
-
-    def test_plan_id_is_displayed_correctly(self):
-        expected_plan_id = uuid4()
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                plan_id=expected_plan_id, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        assert view_model.own_plan_action.plan_id == str(expected_plan_id)
-
-    def test_cooperation_id_is_displayed_correctly_when_plan_is_cooperating(
-        self,
-    ):
-        expected_cooperation_id = uuid4()
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=True,
-                plan_id=uuid4(),
-                cooperation=expected_cooperation_id,
-                planner_id=self.expected_planner,
-            ),
-        )
-        view_model = self.presenter.present(response)
-        assert view_model.own_plan_action.cooperation_id == str(expected_cooperation_id)
-
-    def test_cooperation_id_is_none_when_plan_is_not_cooperating(self):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(
-                is_cooperating=False, planner_id=self.expected_planner
-            ),
-        )
-        view_model = self.presenter.present(response)
-        assert not view_model.own_plan_action.cooperation_id
-
-
-class TestPresenterForNonPlanningCompany(BaseTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.presenter = self.injector.get(GetPlanDetailsCompanyPresenter)
-        self.plan_details_generator = self.injector.get(PlanDetailsGenerator)
-        self.session.login_company(uuid4())
-
-    def test_action_section_is_not_shown_when_current_user_is_not_planner(self):
-        response = InteractorResponse(
-            plan_details=self.plan_details_generator.create_plan_details(),
-        )
-        view_model = self.presenter.present(response)
-        self.assertFalse(view_model.show_own_plan_action_section)
 
 
 class NavbarItemsTests(BaseTestCase):

--- a/tests/web/www/presenters/test_show_my_cooperations_presenter.py
+++ b/tests/web/www/presenters/test_show_my_cooperations_presenter.py
@@ -250,6 +250,18 @@ class CooperatingPlansTest(BaseTestCase):
     def test_show_one_plan_if_one_plan_exists(self) -> None:
         assert len(self.view_model.list_of_my_cooperating_plans.rows) == 1
 
+    def test_plan_id_is_shown_correctly(self) -> None:
+        self.assertEqual(
+            self.view_model.list_of_my_cooperating_plans.rows[0].plan_id,
+            str(self.PLAN_ID),
+        )
+
+    def test_coop_id_is_shown_correctly(self) -> None:
+        self.assertEqual(
+            self.view_model.list_of_my_cooperating_plans.rows[0].coop_id,
+            str(self.COOP_ID),
+        )
+
     def test_name_of_plan_is_shown(self) -> None:
         assert self.view_model.list_of_my_cooperating_plans.rows[0].plan_name
 


### PR DESCRIPTION
The end-cooperation button is removed from the company plan details page  and added per plan in the "My cooperating plans" section of my-cooperations,  via a new end_plan_cooperation route.

fixes #1515 