### PR TITLE
Fix bugs in cooperation presenters

### DIFF
--- a/src/workers_control/web/www/presenters/accept_cooperation_request_presenter.py
+++ b/src/workers_control/web/www/presenters/accept_cooperation_request_presenter.py
@@ -25,35 +25,33 @@ class AcceptCooperationRequestPresenter:
                 self.translator.gettext("Cooperation request has been accepted.")
             )
         else:
-            if (
-                response == AcceptCooperationResponse.RejectionReason.plan_not_found
-                or AcceptCooperationResponse.RejectionReason.cooperation_not_found
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Plan or cooperation not found.")
-                )
-            elif (
-                response == AcceptCooperationResponse.RejectionReason.plan_inactive
-                or AcceptCooperationResponse.RejectionReason.plan_has_cooperation
-                or AcceptCooperationResponse.RejectionReason.plan_is_public_service
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Something's wrong with that plan.")
-                )
-            elif (
-                response
-                == AcceptCooperationResponse.RejectionReason.cooperation_was_not_requested
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("This cooperation request does not exist.")
-                )
-            elif (
-                response
-                == AcceptCooperationResponse.RejectionReason.requester_is_not_coordinator
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext(
-                        "You are not coordinator of this cooperation."
+            rejection_reason = AcceptCooperationResponse.RejectionReason
+            match response.rejection_reason:
+                case (
+                    rejection_reason.plan_not_found
+                    | rejection_reason.cooperation_not_found
+                ):
+                    self.notifier.display_warning(
+                        self.translator.gettext("Plan or cooperation not found.")
                     )
-                )
+                case (
+                    rejection_reason.plan_inactive
+                    | rejection_reason.plan_has_cooperation
+                    | rejection_reason.plan_is_public_service
+                ):
+                    self.notifier.display_warning(
+                        self.translator.gettext("Something's wrong with that plan.")
+                    )
+                case rejection_reason.cooperation_was_not_requested:
+                    self.notifier.display_warning(
+                        self.translator.gettext(
+                            "This cooperation request does not exist."
+                        )
+                    )
+                case rejection_reason.requester_is_not_coordinator:
+                    self.notifier.display_warning(
+                        self.translator.gettext(
+                            "You are not coordinator of this cooperation."
+                        )
+                    )
         return ViewModel(redirection_url=self.url_index.get_my_cooperations_url())

--- a/src/workers_control/web/www/presenters/deny_cooperation_presenter.py
+++ b/src/workers_control/web/www/presenters/deny_cooperation_presenter.py
@@ -25,34 +25,31 @@ class DenyCooperationPresenter:
                 self.translator.gettext("Cooperation request has been denied.")
             )
         else:
-            if (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.plan_not_found
-                or DenyCooperationResponse.RejectionReason.cooperation_not_found
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("Plan or cooperation not found.")
-                )
-            elif (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.cooperation_was_not_requested
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext("This cooperation request does not exist.")
-                )
-            elif (
-                deny_cooperation_response
-                == DenyCooperationResponse.RejectionReason.requester_is_not_coordinator
-            ):
-                self.notifier.display_warning(
-                    self.translator.gettext(
-                        "You are not coordinator of this cooperation."
+            rejection_reason = DenyCooperationResponse.RejectionReason
+            match deny_cooperation_response.rejection_reason:
+                case (
+                    rejection_reason.plan_not_found
+                    | rejection_reason.cooperation_not_found
+                ):
+                    self.notifier.display_warning(
+                        self.translator.gettext("Plan or cooperation not found.")
                     )
-                )
-            else:
-                # catchall for rejected responses where rejection
-                # reason cannot be handled by presenter.
-                self.notifier.display_warning(
-                    self.translator.gettext("Could not deny cooperation")
-                )
+                case rejection_reason.cooperation_was_not_requested:
+                    self.notifier.display_warning(
+                        self.translator.gettext(
+                            "This cooperation request does not exist."
+                        )
+                    )
+                case rejection_reason.requester_is_not_coordinator:
+                    self.notifier.display_warning(
+                        self.translator.gettext(
+                            "You are not coordinator of this cooperation."
+                        )
+                    )
+                case _:
+                    # catchall for rejected responses where rejection
+                    # reason cannot be handled by presenter.
+                    self.notifier.display_warning(
+                        self.translator.gettext("Could not deny cooperation")
+                    )
         return ViewModel(redirection_url=self.url_index.get_my_cooperations_url())

--- a/tests/web/www/presenters/test_accept_cooperation_request_presenter.py
+++ b/tests/web/www/presenters/test_accept_cooperation_request_presenter.py
@@ -8,6 +8,8 @@ from workers_control.web.www.presenters.accept_cooperation_request_presenter imp
     AcceptCooperationRequestPresenter,
 )
 
+_reason = AcceptCooperationResponse.RejectionReason
+
 
 class ShowMyCooperationsPresenterTests(BaseTestCase):
     def setUp(self) -> None:
@@ -23,17 +25,40 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
         )
         assert not self.notifier.warnings
 
-    def test_failed_accept_request_response_is_presented_correctly(self) -> None:
-        self.presenter.render_response(
-            AcceptCooperationResponse(
-                rejection_reason=AcceptCooperationResponse.RejectionReason.plan_not_found
-            )
-        )
+    @parameterized.expand(
+        [
+            (_reason.plan_not_found, "Plan or cooperation not found."),
+            (_reason.cooperation_not_found, "Plan or cooperation not found."),
+            (_reason.plan_inactive, "Something's wrong with that plan."),
+            (_reason.plan_has_cooperation, "Something's wrong with that plan."),
+            (_reason.plan_is_public_service, "Something's wrong with that plan."),
+            (
+                _reason.cooperation_was_not_requested,
+                "This cooperation request does not exist.",
+            ),
+            (
+                _reason.requester_is_not_coordinator,
+                "You are not coordinator of this cooperation.",
+            ),
+        ]
+    )
+    def test_correct_warning_is_displayed_on_rejection(
+        self,
+        rejection_reason: AcceptCooperationResponse.RejectionReason,
+        message: str,
+    ) -> None:
+        self.presenter.render_response(self.create_response(rejection_reason))
         assert len(self.notifier.warnings) == 1
+        assert self.notifier.warnings[0] == self.translator.gettext(message)
+
+    @parameterized.expand(
+        [(reason,) for reason in AcceptCooperationResponse.RejectionReason]
+    )
+    def test_no_info_is_displayed_on_rejection(
+        self, rejection_reason: AcceptCooperationResponse.RejectionReason
+    ) -> None:
+        self.presenter.render_response(self.create_response(rejection_reason))
         assert not self.notifier.infos
-        assert self.notifier.warnings[0] == self.translator.gettext(
-            "Plan or cooperation not found."
-        )
 
     @parameterized.expand(
         [(reason,) for reason in AcceptCooperationResponse.RejectionReason] + [(None,)]
@@ -42,6 +67,11 @@ class ShowMyCooperationsPresenterTests(BaseTestCase):
         self, rejection_reason: AcceptCooperationResponse.RejectionReason | None
     ) -> None:
         response = self.presenter.render_response(
-            AcceptCooperationResponse(rejection_reason=rejection_reason)
+            self.create_response(rejection_reason)
         )
         assert response.redirection_url == self.url_index.get_my_cooperations_url()
+
+    def create_response(
+        self, rejection_reason: AcceptCooperationResponse.RejectionReason | None
+    ) -> AcceptCooperationResponse:
+        return AcceptCooperationResponse(rejection_reason=rejection_reason)

--- a/tests/web/www/presenters/test_deny_cooperation_presenter.py
+++ b/tests/web/www/presenters/test_deny_cooperation_presenter.py
@@ -6,6 +6,8 @@ from workers_control.web.www.presenters.deny_cooperation_presenter import (
     DenyCooperationPresenter,
 )
 
+_reason = DenyCooperationResponse.RejectionReason
+
 
 class DenyCooperationPresenterTests(BaseTestCase):
     def setUp(self) -> None:
@@ -20,17 +22,37 @@ class DenyCooperationPresenterTests(BaseTestCase):
             "Cooperation request has been denied."
         )
 
-    def test_failed_deny_request_response_is_presented_correctly(self) -> None:
-        self.presenter.render_response(
-            deny_cooperation_response=DenyCooperationResponse(
-                rejection_reason=DenyCooperationResponse.RejectionReason.plan_not_found
-            )
-        )
+    @parameterized.expand(
+        [
+            (_reason.plan_not_found, "Plan or cooperation not found."),
+            (_reason.cooperation_not_found, "Plan or cooperation not found."),
+            (
+                _reason.cooperation_was_not_requested,
+                "This cooperation request does not exist.",
+            ),
+            (
+                _reason.requester_is_not_coordinator,
+                "You are not coordinator of this cooperation.",
+            ),
+            # not handled explicitly by the presenter, falls back to the catchall
+            (_reason.plan_is_inactive, "Could not deny cooperation"),
+        ]
+    )
+    def test_correct_warning_is_displayed_on_rejection(
+        self, rejection_reason: DenyCooperationResponse.RejectionReason, message: str
+    ) -> None:
+        self.presenter.render_response(self.create_response(rejection_reason))
         assert len(self.notifier.warnings) == 1
+        assert self.notifier.warnings[0] == self.translator.gettext(message)
+
+    @parameterized.expand(
+        [(reason,) for reason in DenyCooperationResponse.RejectionReason]
+    )
+    def test_no_info_is_displayed_on_rejection(
+        self, rejection_reason: DenyCooperationResponse.RejectionReason
+    ) -> None:
+        self.presenter.render_response(self.create_response(rejection_reason))
         assert not self.notifier.infos
-        assert self.notifier.warnings[0] == self.translator.gettext(
-            "Plan or cooperation not found."
-        )
 
     @parameterized.expand(
         [(reason,) for reason in DenyCooperationResponse.RejectionReason] + [(None,)]
@@ -39,8 +61,11 @@ class DenyCooperationPresenterTests(BaseTestCase):
         self, rejection_reason: DenyCooperationResponse.RejectionReason | None
     ) -> None:
         response = self.presenter.render_response(
-            deny_cooperation_response=DenyCooperationResponse(
-                rejection_reason=rejection_reason
-            )
+            self.create_response(rejection_reason)
         )
         assert response.redirection_url == self.url_index.get_my_cooperations_url()
+
+    def create_response(
+        self, rejection_reason: DenyCooperationResponse.RejectionReason | None
+    ) -> DenyCooperationResponse:
+        return DenyCooperationResponse(rejection_reason=rejection_reason)


### PR DESCRIPTION
Both the AcceptCooperationRequestPresenter and the DenyCooperationPresenter had a bug which would always show the same warning message. The bugs have been fixed and missing tests have been added.