### PR TITLE
Fix issues related to timezones

### DIFF
--- a/src/workers_control/web/formatters/datetime_formatter.py
+++ b/src/workers_control/web/formatters/datetime_formatter.py
@@ -7,7 +7,9 @@ class DatetimeFormatter(Protocol):
         self,
         date: datetime,
         fmt: str | None = ...,
-    ) -> str: ...
+    ) -> str:
+        """Format a datetime and convert to current user's timezone."""
+        ...
 
 
 class TimezoneConfiguration(Protocol):

--- a/src/workers_control/web/www/presenters/show_my_plans_presenter.py
+++ b/src/workers_control/web/www/presenters/show_my_plans_presenter.py
@@ -5,6 +5,7 @@ from typing import Any, Dict, List, Optional
 
 from workers_control.core.datetime_service import DatetimeService
 from workers_control.core.interactors.show_my_plans import ShowMyPlansResponse
+from workers_control.web.formatters.datetime_formatter import DatetimeFormatter
 from workers_control.web.notification import Notifier
 from workers_control.web.translator import Translator
 from workers_control.web.url_index import UrlIndex
@@ -111,6 +112,7 @@ class ShowMyPlansPresenter:
     url_index: UrlIndex
     translator: Translator
     datetime_service: DatetimeService
+    datetime_formatter: DatetimeFormatter
     notifier: Notifier
 
     def present(self, response: ShowMyPlansResponse) -> ShowMyPlansViewModel:
@@ -248,7 +250,11 @@ class ShowMyPlansPresenter:
         )
 
     def __format_date(self, date: Optional[datetime]) -> str:
-        return date.strftime("%d.%m.%y") if date else "–"
+        return (
+            self.datetime_formatter.format_datetime(date=date, fmt="%d.%m.%y")
+            if date
+            else "–"
+        )
 
     def __format_price(self, price_per_unit: Decimal) -> str:
         return f"{round(price_per_unit, 2)}"

--- a/tests/web/www/datetime_formatter.py
+++ b/tests/web/www/datetime_formatter.py
@@ -15,9 +15,8 @@ class FakeDatetimeFormatter:
         date: datetime,
         fmt: str | None = None,
     ) -> str:
+        assert date.tzinfo is not None
         user_timezone = self.timezone_config.get_timezone_of_current_user()
-        if date.tzinfo is None:
-            date = date.replace(tzinfo=user_timezone)
         date = date.astimezone(user_timezone)
         if fmt is None:
             fmt = "%d.%m.%Y %H:%M"

--- a/tests/web/www/presenters/test_list_basic_services_of_worker_presenter.py
+++ b/tests/web/www/presenters/test_list_basic_services_of_worker_presenter.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from uuid import UUID, uuid4
 
 from tests.base_test_case import BaseTestCase
+from tests.datetime_service import datetime_utc
 from workers_control.core.interactors.list_basic_services_of_worker import (
     ListedBasicService,
     Response,
@@ -49,7 +50,7 @@ class PresenterTests(BaseTestCase):
         assert view_model.services[0].id == str(expected_id)
 
     def test_created_on_is_formatted_via_datetime_formatter(self) -> None:
-        created_on = datetime(2026, 3, 22, 12, 0)
+        created_on = datetime_utc(2026, 3, 22, 12, 0)
         response = self._create_response_with_one_service(created_on=created_on)
         view_model = self.presenter.present(response)
         expected_formatted = self.datetime_formatter.format_datetime(
@@ -76,13 +77,13 @@ class PresenterTests(BaseTestCase):
                     id=first_id,
                     name="A",
                     description="d",
-                    created_on=datetime(2026, 1, 1, 0, 0),
+                    created_on=datetime_utc(2026, 1, 1, 0, 0),
                 ),
                 ListedBasicService(
                     id=second_id,
                     name="B",
                     description="d",
-                    created_on=datetime(2026, 1, 1, 0, 0),
+                    created_on=datetime_utc(2026, 1, 1, 0, 0),
                 ),
             ]
         )
@@ -99,7 +100,7 @@ class PresenterTests(BaseTestCase):
         if service_id is None:
             service_id = uuid4()
         if created_on is None:
-            created_on = datetime(2026, 1, 1, 0, 0)
+            created_on = datetime_utc(2026, 1, 1, 0, 0)
         return Response(
             basic_services=[
                 ListedBasicService(

--- a/tests/web/www/presenters/test_show_basic_service_presenter.py
+++ b/tests/web/www/presenters/test_show_basic_service_presenter.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from tests.base_test_case import BaseTestCase
+from tests.datetime_service import datetime_utc
 from workers_control.core.interactors.show_basic_service import (
     ShowBasicServiceResponse,
 )
@@ -53,7 +54,7 @@ class ShowBasicServicePresenterTests(BaseTestCase):
         assert view_model.description == expected_description
 
     def test_view_model_contains_formatted_created_on(self) -> None:
-        created_on = datetime(2026, 3, 22, 12, 0)
+        created_on = datetime_utc(2026, 3, 22, 12, 0)
         response = self._create_response(created_on=created_on)
         view_model = self.presenter.present(response)
         assert view_model is not None
@@ -72,7 +73,7 @@ class ShowBasicServicePresenterTests(BaseTestCase):
         created_on: datetime | None = None,
     ) -> ShowBasicServiceResponse:
         if created_on is None:
-            created_on = datetime(2026, 1, 1, 0, 0)
+            created_on = datetime_utc(2026, 1, 1, 0, 0)
         return ShowBasicServiceResponse(
             details=ShowBasicServiceResponse.Details(
                 provider_name=provider_name,

--- a/tests/web/www/presenters/test_show_my_plans_presenter.py
+++ b/tests/web/www/presenters/test_show_my_plans_presenter.py
@@ -167,6 +167,33 @@ class ActivePlansTests(PresenterBase):
             else "–"
         )
 
+    @parameterized.expand(
+        [
+            ("UTC", datetime_utc(2020, 5, 1, 22, 30), "01.05.20"),
+            ("Asia/Tokyo", datetime_utc(2020, 5, 1, 22, 30), "02.05.20"),
+            ("Pacific/Honolulu", datetime_utc(2020, 5, 1, 0, 30), "30.04.20"),
+        ]
+    )
+    def test_that_dates_are_shown_in_the_timezone_of_the_current_user(
+        self,
+        configured_user_tz: str,
+        expiration_date: datetime,
+        expected_expiration_date: str,
+    ) -> None:
+        self.timezone_configuration.set_timezone_of_current_user(configured_user_tz)
+        response = self.create_interactor_response(
+            active_plans=[
+                self.create_plan_info(
+                    expiration_date=expiration_date,
+                )
+            ]
+        )
+        presentation = self.presenter.present(response)
+        assert (
+            presentation.active_plans.rows[0].expiration_date
+            == expected_expiration_date
+        )
+
     @parameterized.expand([(datetime_utc(2000, 1, 6),), (None,)])
     def test_that_relative_expiration_is_calculated_correctly_in_days_from_now(
         self, expiration_date: datetime | None


### PR DESCRIPTION
- Add a docstring to DatetimeFormatter.format_datetime
- Expect timezone aware dates in fake datetime formatter
- Show plan dates in the user's timezone