### PR TITLE
Improve labels and ticks in plots

### DIFF
--- a/src/workers_control/core/interactors/show_payout_factor_details.py
+++ b/src/workers_control/core/interactors/show_payout_factor_details.py
@@ -21,6 +21,8 @@ class Response:
     window_size_in_days: int
     window_start: datetime
     window_end: datetime
+    display_start: datetime
+    display_end: datetime
     plans: list[PlanData]
     basic_service_consumptions: list[BasicServiceConsumptionData]
 
@@ -54,7 +56,9 @@ class ShowPayoutFactorDetailsInteractor:
         window_size_in_days = self.payout_factor_config.get_window_length_in_days()
         window_start = now - timedelta(days=window_size_in_days / 2)
         window_end = now + timedelta(days=window_size_in_days / 2)
-        plan_records = self._get_plans_sorted(now, window_size_in_days)
+        display_start = now - timedelta(days=window_size_in_days)
+        display_end = now + timedelta(days=window_size_in_days)
+        plan_records = self._get_plans_sorted(display_start)
 
         plans = [
             self._create_plan_data(
@@ -74,17 +78,17 @@ class ShowPayoutFactorDetailsInteractor:
             window_size_in_days=window_size_in_days,
             window_start=window_start,
             window_end=window_end,
+            display_start=display_start,
+            display_end=display_end,
             plans=plans,
             basic_service_consumptions=basic_service_consumptions,
         )
 
-    def _get_plans_sorted(
-        self, now: datetime, window_size_in_days: int
-    ) -> list[records.Plan]:
+    def _get_plans_sorted(self, display_start: datetime) -> list[records.Plan]:
         relevant_plans = list(
             self.database_gateway.get_plans()
             .that_are_approved()
-            .that_will_expire_after(now - timedelta(days=window_size_in_days))
+            .that_will_expire_after(display_start)
         )
         plans_sorted = sorted(
             relevant_plans,

--- a/src/workers_control/flask/plotter.py
+++ b/src/workers_control/flask/plotter.py
@@ -1,6 +1,6 @@
 import io
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime
 from decimal import Decimal
 from typing import List, Optional, Tuple, Union
 
@@ -58,6 +58,14 @@ class PayoutFactorDetailsPlotter:
     timezone_config: TimezoneConfiguration
 
     def plot(self, response: show_payout_factor_details.Response) -> bytes:
+        fig = self._create_figure(response)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0.5)
+        buf.seek(0)
+        return buf.getvalue()
+
+    def _create_figure(self, response: show_payout_factor_details.Response) -> Figure:
+        tz = self.timezone_config.get_timezone_of_current_user()
 
         plan_indices: list[int] = []
         start: list[datetime] = []
@@ -106,8 +114,7 @@ class PayoutFactorDetailsPlotter:
         ylabel = self.translator.gettext("Plans")
         ax.set_ylabel(ylabel)
 
-        tz = self.timezone_config.get_timezone_of_current_user()
-        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d", tz=tz))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m", tz=tz))
         ax.xaxis.set_major_locator(mdates.AutoDateLocator(tz=tz))
         fig.autofmt_xdate()
         ax.invert_yaxis()
@@ -129,13 +136,8 @@ class PayoutFactorDetailsPlotter:
         ax.legend()
         fig.set_size_inches(14, (len(plan_indices) + 1) * 0.3 + 2)
 
-        margin = timedelta(days=response.window_size_in_days / 2)
         ax.set_xlim(
-            mdates.date2num(response.window_start - margin),
-            mdates.date2num(response.window_end + margin),
+            mdates.date2num(response.display_start),
+            mdates.date2num(response.display_end),
         )
-
-        buf = io.BytesIO()
-        fig.savefig(buf, format="png", bbox_inches="tight", pad_inches=0.5)
-        buf.seek(0)
-        return buf.getvalue()
+        return fig

--- a/src/workers_control/flask/plotter.py
+++ b/src/workers_control/flask/plotter.py
@@ -13,19 +13,38 @@ from workers_control.web.colors import HexColors
 from workers_control.web.formatters.datetime_formatter import TimezoneConfiguration
 from workers_control.web.translator import Translator
 
+DEFAULT_LINE_PLOT_SIZE: Tuple[int, int] = (10, 5)
 
+
+@dataclass
 class GeneralPlotter:
+    timezone_config: TimezoneConfiguration
+
     def create_line_plot(
-        self, x: List[datetime], y: List[Decimal], fig_size: Tuple[int, int] = (10, 5)
+        self,
+        x: List[datetime],
+        y: List[Decimal],
+        fig_size: Tuple[int, int] = DEFAULT_LINE_PLOT_SIZE,
     ) -> bytes:
+        fig = self._create_line_plot_figure(x=x, y=y, fig_size=fig_size)
+        return self._figure_to_bytes(fig)
+
+    def _create_line_plot_figure(
+        self,
+        x: List[datetime],
+        y: List[Decimal],
+        fig_size: Tuple[int, int] = DEFAULT_LINE_PLOT_SIZE,
+    ) -> Figure:
+        tz = self.timezone_config.get_timezone_of_current_user()
         fig = Figure()
         ax = fig.subplots()
         ax.axhline(linestyle="--", color="black")
         ax.plot(x, y)  # type: ignore[arg-type]
-        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d"))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%Y-%m-%d", tz=tz))
+        ax.xaxis.set_major_locator(mdates.AutoDateLocator(tz=tz))
         fig.set_size_inches(fig_size[0], fig_size[1])
         fig.autofmt_xdate()
-        return self._figure_to_bytes(fig)
+        return fig
 
     def create_bar_plot(
         self,

--- a/tests/flask_integration/test_plotter.py
+++ b/tests/flask_integration/test_plotter.py
@@ -1,0 +1,174 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import matplotlib.dates as mdates
+from matplotlib.axes import Axes
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+from parameterized import parameterized
+
+from tests.base_test_case import BaseTestCase
+from tests.datetime_service import datetime_utc
+from workers_control.core.interactors.show_payout_factor_details import (
+    BasicServiceConsumptionData,
+    PlanData,
+    Response,
+)
+from workers_control.flask.plotter import GeneralPlotter, PayoutFactorDetailsPlotter
+
+PNG_MAGIC_BYTES = b"\x89PNG"
+
+
+class PlotterTestCase(BaseTestCase):
+    def render(self, figure: Figure) -> Axes:
+        # Ticks are only calculated and labelled once the figure is drawn.
+        FigureCanvasAgg(figure).draw()
+        return figure.axes[0]
+
+    def get_tick_labels(self, axes: Axes) -> list[str]:
+        return [tick.get_text() for tick in axes.get_xticklabels()]
+
+    def get_ticks_in_user_timezone(self, axes: Axes) -> list[datetime]:
+        tz = self.timezone_configuration.get_timezone_of_current_user()
+        return [mdates.num2date(tick, tz=tz) for tick in axes.get_xticks()]
+
+
+class GeneralPlotterTests(PlotterTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.plotter = self.injector.get(GeneralPlotter)
+
+    def test_that_line_plot_is_rendered_as_png(self) -> None:
+        png = self.plotter.create_line_plot(
+            x=[datetime_utc(2026, 8, 4), datetime_utc(2026, 8, 6)],
+            y=[Decimal(1), Decimal(5)],
+        )
+        assert png.startswith(PNG_MAGIC_BYTES)
+
+    def test_that_days_are_labelled_in_utc_for_a_user_in_utc(self) -> None:
+        self.timezone_configuration.set_timezone_of_current_user("UTC")
+        axes = self.render(self.create_two_day_figure())
+        assert set(self.get_tick_labels(axes)) == {
+            "2026-08-04",
+            "2026-08-05",
+            "2026-08-06",
+        }
+
+    def test_that_days_are_labelled_in_local_time_for_a_user_in_tokyo(self) -> None:
+        self.timezone_configuration.set_timezone_of_current_user("Asia/Tokyo")
+        axes = self.render(self.create_two_day_figure())
+        assert set(self.get_tick_labels(axes)) == {
+            "2026-08-05",
+            "2026-08-06",
+            "2026-08-07",
+        }
+
+    @parameterized.expand([("UTC",), ("Asia/Tokyo",), ("America/New_York",)])
+    def test_that_daily_ticks_fall_on_midnight_in_the_users_timezone(
+        self, timezone: str
+    ) -> None:
+        self.timezone_configuration.set_timezone_of_current_user(timezone)
+        figure = self.plotter._create_line_plot_figure(
+            x=[datetime_utc(2026, 8, 4, 20), datetime_utc(2026, 8, 14, 20)],
+            y=[Decimal(1), Decimal(5)],
+        )
+        axes = self.render(figure)
+        ticks = self.get_ticks_in_user_timezone(axes)
+        assert ticks
+        for tick in ticks:
+            assert (tick.hour, tick.minute) == (0, 0)
+
+    def create_two_day_figure(self) -> Figure:
+        # In Tokyo (UTC+9) both timestamps fall on the following day.
+        return self.plotter._create_line_plot_figure(
+            x=[datetime_utc(2026, 8, 4, 20), datetime_utc(2026, 8, 6, 20)],
+            y=[Decimal(1), Decimal(5)],
+        )
+
+
+class PayoutFactorDetailsPlotterTests(PlotterTestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.plotter = self.injector.get(PayoutFactorDetailsPlotter)
+
+    def test_that_plot_is_rendered_as_png(self) -> None:
+        png = self.plotter.plot(
+            self.create_response(
+                plans=[
+                    self.create_plan(),
+                    self.create_plan(is_public_service=True),
+                ],
+                basic_service_consumptions=[self.create_basic_service_consumption()],
+            )
+        )
+        assert png.startswith(PNG_MAGIC_BYTES)
+
+    def test_that_plot_without_plans_or_consumptions_is_rendered_as_png(self) -> None:
+        png = self.plotter.plot(self.create_response())
+        assert png.startswith(PNG_MAGIC_BYTES)
+
+    @parameterized.expand([("UTC",), ("Asia/Tokyo",), ("America/New_York",)])
+    def test_that_month_ticks_fall_on_the_first_of_the_month_in_the_users_timezone(
+        self, timezone: str
+    ) -> None:
+        self.timezone_configuration.set_timezone_of_current_user(timezone)
+        figure = self.plotter._create_figure(self.create_response())
+        axes = self.render(figure)
+        ticks = self.get_ticks_in_user_timezone(axes)
+        assert ticks
+        for tick in ticks:
+            assert (tick.day, tick.hour, tick.minute) == (1, 0, 0)
+
+    @parameterized.expand([("UTC",), ("Asia/Tokyo",), ("America/New_York",)])
+    def test_that_ticks_are_labelled_with_their_month_in_the_users_timezone(
+        self, timezone: str
+    ) -> None:
+        self.timezone_configuration.set_timezone_of_current_user(timezone)
+        figure = self.plotter._create_figure(self.create_response())
+        axes = self.render(figure)
+        ticks = self.get_ticks_in_user_timezone(axes)
+        labels = self.get_tick_labels(axes)
+        assert ticks
+        for tick, label in zip(ticks, labels, strict=True):
+            assert label == tick.strftime("%Y-%m")
+
+    def create_response(
+        self,
+        plans: list[PlanData] | None = None,
+        basic_service_consumptions: list[BasicServiceConsumptionData] | None = None,
+    ) -> Response:
+        window_size_in_days = 90
+        center = datetime_utc(2026, 8, 5, 12)
+        return Response(
+            payout_factor=Decimal("1.0"),
+            window_center=center,
+            window_size_in_days=window_size_in_days,
+            window_start=center - timedelta(days=window_size_in_days / 2),
+            window_end=center + timedelta(days=window_size_in_days / 2),
+            display_start=center - timedelta(days=window_size_in_days),
+            display_end=center + timedelta(days=window_size_in_days),
+            plans=plans if plans is not None else [],
+            basic_service_consumptions=(
+                basic_service_consumptions
+                if basic_service_consumptions is not None
+                else []
+            ),
+        )
+
+    def create_plan(self, is_public_service: bool = False) -> PlanData:
+        return PlanData(
+            id_=uuid4(),
+            name="test plan",
+            approval_date=datetime_utc(2026, 7, 5),
+            expiration_date=datetime_utc(2026, 9, 5),
+            is_public_service=is_public_service,
+            timeframe=62,
+            coverage=Decimal("1.0"),
+        )
+
+    def create_basic_service_consumption(self) -> BasicServiceConsumptionData:
+        return BasicServiceConsumptionData(
+            date=datetime_utc(2026, 8, 1),
+            value=Decimal(10),
+        )

--- a/tests/interactors/test_show_payout_factor_details.py
+++ b/tests/interactors/test_show_payout_factor_details.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from parameterized import parameterized
 
 from tests.base_test_case import BaseTestCase
+from tests.datetime_service import datetime_utc
 from tests.payout_factor import PayoutFactorConfigTestImpl
 from workers_control.core.interactors import show_payout_factor_details
 from workers_control.core.services.payout_factor import PayoutFactorService
@@ -62,6 +63,32 @@ class InteractorTests(BaseTestCase):
         expected_end = dt + timedelta(days=window_size / 2)
         assert response.window_end == expected_end
 
+    @parameterized.expand(
+        [(datetime_utc(2020, 5, 10), 4), (datetime_utc(2025, 1, 9), 20)]
+    )
+    def test_that_display_start_is_now_minus_window_size(
+        self,
+        dt: datetime,
+        window_size: int,
+    ) -> None:
+        self.datetime_service.freeze_time(dt)
+        self.payout_factor_config.set_window_length(window_size)
+        response = self.interactor.show_payout_factor_details()
+        assert response.display_start == dt - timedelta(days=window_size)
+
+    @parameterized.expand(
+        [(datetime_utc(2020, 5, 10), 4), (datetime_utc(2025, 1, 9), 20)]
+    )
+    def test_that_display_end_is_now_plus_window_size(
+        self,
+        dt: datetime,
+        window_size: int,
+    ) -> None:
+        self.datetime_service.freeze_time(dt)
+        self.payout_factor_config.set_window_length(window_size)
+        response = self.interactor.show_payout_factor_details()
+        assert response.display_end == dt + timedelta(days=window_size)
+
 
 class PlanDataTests(BaseTestCase):
     def setUp(self) -> None:
@@ -96,13 +123,13 @@ class PlanDataTests(BaseTestCase):
 
     @parameterized.expand(
         [
-            (datetime(2000, 1, 14), datetime(2000, 1, 15), 1, True),
-            (datetime(2000, 1, 14, 1), datetime(2000, 1, 15), 1, False),
-            (datetime(2000, 1, 13), datetime(2000, 1, 15), 2, True),
-            (datetime(2000, 1, 13, 1), datetime(2000, 1, 15), 2, False),
+            (datetime_utc(2000, 1, 14), datetime_utc(2000, 1, 15), 1, True),
+            (datetime_utc(2000, 1, 14, 1), datetime_utc(2000, 1, 15), 1, False),
+            (datetime_utc(2000, 1, 13), datetime_utc(2000, 1, 15), 2, True),
+            (datetime_utc(2000, 1, 13, 1), datetime_utc(2000, 1, 15), 2, False),
         ]
     )
-    def test_that_plans_that_have_expired_at_least_one_window_size_before_now_are_ignored(
+    def test_that_plans_that_have_expired_before_start_of_display_range_are_ignored(
         self,
         plan_expiration: datetime,
         now: datetime,
@@ -117,6 +144,18 @@ class PlanDataTests(BaseTestCase):
             assert len(self.interactor.show_payout_factor_details().plans) == 0
         else:
             assert len(self.interactor.show_payout_factor_details().plans) == 1
+
+    def test_that_plan_expiring_between_display_start_and_calculation_window_is_listed_with_zero_coverage(
+        self,
+    ) -> None:
+        # display range starts at 2000-02-05, calculation window at 2000-02-10
+        self.payout_factor_config.set_window_length(10)
+        self.datetime_service.freeze_time(datetime_utc(2000, 2, 7))
+        self.plan_generator.create_plan(timeframe=1)
+        self.datetime_service.freeze_time(datetime_utc(2000, 2, 15))
+        response = self.interactor.show_payout_factor_details()
+        assert len(response.plans) == 1
+        assert response.plans[0].coverage == Decimal(0)
 
     def test_that_plans_are_ordered_by_approval(self) -> None:
         approval_1 = datetime(1900, 1, 1)

--- a/tests/web/www/presenters/test_colors.py
+++ b/tests/web/www/presenters/test_colors.py
@@ -1,11 +1,11 @@
 class ColorsTestImpl:
     def __init__(self) -> None:
         self.all_colors = {
-            "primary": "primary_color",
-            "info": "info_color",
-            "warning": "warning_color",
-            "danger": "danger_color",
-            "success": "success_color",
+            "primary": "#1f77b4",
+            "info": "#17becf",
+            "warning": "#ff7f0e",
+            "danger": "#d62728",
+            "success": "#2ca02c",
         }
 
     @property

--- a/tests/web/www/presenters/test_show_payout_factor_details_presenter.py
+++ b/tests/web/www/presenters/test_show_payout_factor_details_presenter.py
@@ -28,6 +28,8 @@ class PresenterBaseTestCase(BaseTestCase):
         window_size_in_days: int = 30,
         window_start: datetime | None = None,
         window_end: datetime | None = None,
+        display_start: datetime | None = None,
+        display_end: datetime | None = None,
         plans: list[PlanData] | None = None,
         basic_service_consumptions: list[BasicServiceConsumptionData] | None = None,
     ) -> Response:
@@ -37,6 +39,10 @@ class PresenterBaseTestCase(BaseTestCase):
             window_start = datetime_min_utc()
         if window_end is None:
             window_end = datetime_min_utc() + timedelta(days=window_size_in_days)
+        if display_start is None:
+            display_start = datetime_min_utc()
+        if display_end is None:
+            display_end = datetime_min_utc() + timedelta(days=2 * window_size_in_days)
         if plans is None:
             plans = []
         if basic_service_consumptions is None:
@@ -47,6 +53,8 @@ class PresenterBaseTestCase(BaseTestCase):
             window_size_in_days=window_size_in_days,
             window_start=window_start,
             window_end=window_end,
+            display_start=display_start,
+            display_end=display_end,
             plans=plans,
             basic_service_consumptions=basic_service_consumptions,
         )


### PR DESCRIPTION
- Draw payout factor graph with monthly ticks 
  
  Label the x axis of the PayoutFactorDetailsPlotter by month instead of by day.
  
  Refactor: Calculate payout factor graph's display_start and display_end in the core logic (interactor) instead of the flask plotter. Extract the figure construction into _create_figure.

- Draw plot axis ticks in the user's timezone 
  
  Charts now label their time axis in the user's timezone instead of UTC. Previously a chart and the table next to it could show the same transfer on different days.
  
  Add integration tests for GeneralPlotter and PayoutFactorDetailsPlotterTests.