### PR TITLE
Remove redundant basic services label from fic plot

### DIFF
--- a/src/workers_control/flask/plotter.py
+++ b/src/workers_control/flask/plotter.py
@@ -125,8 +125,7 @@ class PayoutFactorDetailsPlotter:
             label=bs_label,
             zorder=3,
         )
-        ax.set_yticks(plan_indices + [bs_row_y])
-        ax.set_yticklabels([str(i) for i in plan_indices] + [bs_label])
+        ax.set_yticks(plan_indices)
 
         title = self.translator.gettext("Payout Factor Calculation Window")
         ax.set_title(title)

--- a/tests/flask_integration/test_plotter.py
+++ b/tests/flask_integration/test_plotter.py
@@ -29,6 +29,9 @@ class PlotterTestCase(BaseTestCase):
     def get_tick_labels(self, axes: Axes) -> list[str]:
         return [tick.get_text() for tick in axes.get_xticklabels()]
 
+    def get_y_tick_labels(self, axes: Axes) -> list[str]:
+        return [tick.get_text() for tick in axes.get_yticklabels()]
+
     def get_ticks_in_user_timezone(self, axes: Axes) -> list[datetime]:
         tz = self.timezone_configuration.get_timezone_of_current_user()
         return [mdates.num2date(tick, tz=tz) for tick in axes.get_xticks()]
@@ -132,6 +135,18 @@ class PayoutFactorDetailsPlotterTests(PlotterTestCase):
         assert ticks
         for tick, label in zip(ticks, labels, strict=True):
             assert label == tick.strftime("%Y-%m")
+
+    def test_that_y_axis_is_labelled_with_plan_indices_only_and_ignores_basic_services(
+        self,
+    ) -> None:
+        figure = self.plotter._create_figure(
+            self.create_response(
+                plans=[self.create_plan(), self.create_plan()],
+                basic_service_consumptions=[self.create_basic_service_consumption()],
+            )
+        )
+        axes = self.render(figure)
+        assert self.get_y_tick_labels(axes) == ["0", "1"]
 
     def create_response(
         self,


### PR DESCRIPTION
The legend's star entry already identifies basic service consumptions, and  the tick reserved an empty labelled row whenever there were none.